### PR TITLE
Minor accessibility fixes for Checkbox and Popovers

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "13.0.0"
+  "version": "13.0.1"
 }

--- a/packages/es-components-via-theme/package.json
+++ b/packages/es-components-via-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components-via-theme",
-  "version": "13.0.0",
+  "version": "13.0.1",
   "main": "index.js",
   "author": "Willis Towers Watson - Individual Marketplace",
   "license": "MIT"

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components",
-  "version": "13.0.0",
+  "version": "13.0.1",
   "description": "React components built for Exchange Solutions products",
   "repository": "https://github.com/wtw-im/es-components",
   "main": "lib/index.js",

--- a/packages/es-components/src/components/containers/popover/Popover.js
+++ b/packages/es-components/src/components/containers/popover/Popover.js
@@ -87,6 +87,12 @@ const AlternateCloseButton = styled(Button)`
   }
 `;
 
+const CloseHelpText = styled.span`
+  height: 1px;
+  width: 1px;
+  color: transparent;
+`;
+
 class Popover extends React.Component {
   state = {
     isOpen: false
@@ -241,15 +247,16 @@ class Popover extends React.Component {
                 this.contentRef = elem;
               }}
             >
-              <PopoverHeader
-                hasTitle={hasTitle}
-                tabIndex={-1}
-                ref={elem => {
-                  this.headerRef = elem;
-                }}
-              >
+              <PopoverHeader hasTitle={hasTitle}>
                 {hasTitle && <TitleBar>{title}</TitleBar>}
                 {hasAltCloseButton && altCloseButton}
+                <CloseHelpText
+                  tabIndex={-1}
+                  ref={elem => {
+                    this.headerRef = elem;
+                  }}
+                  aria-label="Press escape to close the Popover"
+                />
               </PopoverHeader>
 
               <PopoverBody hasAltCloseWithNoTitle={hasAltCloseWithNoTitle}>

--- a/packages/es-components/src/components/containers/popover/__snapshots__/Popover.specs.js.snap
+++ b/packages/es-components/src/components/containers/popover/__snapshots__/Popover.specs.js.snap
@@ -45,13 +45,17 @@ exports[`popover component renders as expected 1`] = `
         >
           <div
             className="sc-iwsKbI jOGmdE"
-            tabIndex={-1}
           >
             <h3
               className="sc-gZMcBi cPBpHt"
             >
               Popover Title
             </h3>
+            <span
+              aria-label="Press escape to close the Popover"
+              className="sc-fjdhpX dYNDTL"
+              tabIndex={-1}
+            />
           </div>
           <div
             className="sc-gqjmRU hrhaoz"

--- a/packages/es-components/src/components/controls/checkbox/Checkbox.js
+++ b/packages/es-components/src/components/controls/checkbox/Checkbox.js
@@ -94,6 +94,7 @@ function Checkbox({
   isDisabled = false,
   onClick = noop,
   onChange = noop,
+  ariaLabel,
   theme
 }) {
   /* eslint-disable jsx-a11y/use-onblur-not-onchange */
@@ -107,10 +108,11 @@ function Checkbox({
           checked={isChecked}
           onClick={onClick}
           onChange={onChange}
+          aria-label={ariaLabel}
           focusBorderColor={theme.colors.inputFocus}
         />
         <CheckboxWrapper className="checkbox-fill" />
-        <CheckboxText>{labelText}</CheckboxText>
+        <CheckboxText aria-hidden={!!ariaLabel}>{labelText}</CheckboxText>
       </CheckboxLabel>
     </ThemeProvider>
   );
@@ -120,6 +122,8 @@ function Checkbox({
 Checkbox.propTypes = {
   labelText: PropTypes.string.isRequired,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Sets the aria-label attribute */
+  ariaLabel: PropTypes.string,
   isChecked: PropTypes.bool,
   /* Function to execute when a checkbox is clicked */
   onClick: PropTypes.func,

--- a/packages/es-components/src/components/controls/checkbox/__snapshots__/Checkbox.specs.js.snap
+++ b/packages/es-components/src/components/controls/checkbox/__snapshots__/Checkbox.specs.js.snap
@@ -6,6 +6,7 @@ exports[`Checkbox renders as expected 1`] = `
   disabled={true}
 >
   <input
+    aria-label={undefined}
     checked={true}
     className="sc-htpNat dVmsUC"
     disabled={true}
@@ -18,6 +19,7 @@ exports[`Checkbox renders as expected 1`] = `
     className="checkbox-fill sc-bxivhb kynQKu"
   />
   <span
+    aria-hidden={false}
     className="sc-ifAKCX kVENxO"
   >
     Render test


### PR DESCRIPTION
Adds an ariaLabel prop on Checkbox because screen readers were not picking up aria-labels when put on the Checkbox.

Adds more descriptive close instructions to Popover that will receive focus on popovers without close buttons. This still allows the popovers to be properly read without the title being read twice, and gives better instruction on how to close the popover.