### PR TITLE
Class Names

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "14.2.0"
+  "version": "14.2.1"
 }

--- a/packages/es-components-via-theme/package.json
+++ b/packages/es-components-via-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components-via-theme",
-  "version": "14.2.0",
+  "version": "14.2.1",
   "main": "index.js",
   "author": "Willis Towers Watson - Individual Marketplace",
   "license": "MIT"

--- a/packages/es-components/package-lock.json
+++ b/packages/es-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components",
-  "version": "13.0.0",
+  "version": "14.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2161,9 +2161,9 @@
       }
     },
     "classnames": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
-      "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "clean-webpack-plugin": {
       "version": "0.1.19",
@@ -4898,8 +4898,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
           }
         },
         "npmlog": {
@@ -4965,8 +4965,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -10069,7 +10069,7 @@
       "integrity": "sha512-p5YSnW2L2sT6EuEsFqwAnbHgNC9yAoAwej/tYFBfWw61MaaAP71msyT84Vy3iKPrncUuACYWoKhGQVoqRISCOg==",
       "requires": {
         "@types/react": "16.0.40",
-        "classnames": "2.2.5",
+        "classnames": "2.2.6",
         "prop-types": "15.6.1"
       }
     },
@@ -10084,7 +10084,7 @@
       "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-1.2.2.tgz",
       "integrity": "sha512-344I24JomyPXFmi9PIbKnPEOx1GqPFybLBxkafItxzcCjDAP10+nMqcttoCpBtwPJDbBn4Cg6kBnGlBuK7BK2g==",
       "requires": {
-        "classnames": "2.2.5",
+        "classnames": "2.2.6",
         "prop-types": "15.6.1",
         "react-onclickoutside": "6.7.1",
         "react-popper": "0.8.3"
@@ -10425,7 +10425,7 @@
       "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.8.3.tgz",
       "integrity": "sha512-h6GT3jgy90PgctleP39Yu3eK1v9vaJAW73GOA/UbN9dJ7aAN4BTZD6793eI1D5U+ukMk17qiqN/wl3diK1Z5LA==",
       "requires": {
-        "classnames": "2.2.5",
+        "classnames": "2.2.6",
         "dom-helpers": "3.3.1",
         "prop-types": "15.6.1",
         "prop-types-extra": "1.0.1",
@@ -10464,7 +10464,7 @@
         "ast-types": "0.11.3",
         "buble": "0.19.3",
         "chalk": "2.3.2",
-        "classnames": "2.2.5",
+        "classnames": "2.2.6",
         "clean-webpack-plugin": "0.1.19",
         "clipboard-copy": "2.0.0",
         "codemirror": "5.36.0",
@@ -10769,7 +10769,7 @@
       "integrity": "sha512-q54UBM22bs/CekG8r3+vi9TugSqh0t7qcEVycaRc9M0p0aCEu+h6rp/RFiW7fHfgd1IKpd9oILFTl5QK+FpiPA==",
       "requires": {
         "chain-function": "1.0.0",
-        "classnames": "2.2.5",
+        "classnames": "2.2.6",
         "dom-helpers": "3.3.1",
         "loose-envify": "1.3.1",
         "prop-types": "15.6.1",

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components",
-  "version": "14.2.0",
+  "version": "14.2.1",
   "description": "React components built for Exchange Solutions products",
   "repository": "https://github.com/wtw-im/es-components",
   "main": "lib/index.js",

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -63,6 +63,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.20.0",
+    "classnames": "^2.2.6",
     "enzyme-adapter-react-16": "^1.1.1",
     "lodash": "^4.17.5",
     "moment": "^2.21.0",

--- a/packages/es-components/src/components/base/icons/Icon.js
+++ b/packages/es-components/src/components/base/icons/Icon.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import classNames from 'classNames';
 
 import { regular } from './icon-definitions';
 
@@ -34,7 +35,7 @@ function Icon({ className, name, size, ...other }) {
   return (
     <StyledIcon
       aria-hidden
-      className={className}
+      className={classNames('es-icon', className)}
       {...styledIconProps}
       {...other}
     />

--- a/packages/es-components/src/components/base/icons/Icon.js
+++ b/packages/es-components/src/components/base/icons/Icon.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import classNames from 'classNames';
+import classnames from 'classnames';
 
 import { regular } from './icon-definitions';
 
@@ -35,7 +35,7 @@ function Icon({ className, name, size, ...other }) {
   return (
     <StyledIcon
       aria-hidden
-      className={classNames('es-icon', className)}
+      className={classnames('es-icon', className)}
       {...styledIconProps}
       {...other}
     />

--- a/packages/es-components/src/components/containers/drawer/Drawer.js
+++ b/packages/es-components/src/components/containers/drawer/Drawer.js
@@ -4,6 +4,7 @@ import styled, { ThemeProvider, withTheme } from 'styled-components';
 import { noop } from 'lodash';
 import uncontrollable from 'uncontrollable';
 import viaTheme from 'es-components-via-theme';
+import classNames from 'classNames';
 
 import DrawerPanel from './DrawerPanel';
 
@@ -89,7 +90,9 @@ export const Drawer = props => {
 
   return (
     <ThemeProvider theme={theme}>
-      <StyledDrawer className={className}>{getPanels()}</StyledDrawer>
+      <StyledDrawer className={classNames('es-drawer', className)}>
+        {getPanels()}
+      </StyledDrawer>
     </ThemeProvider>
   );
 };

--- a/packages/es-components/src/components/containers/drawer/Drawer.js
+++ b/packages/es-components/src/components/containers/drawer/Drawer.js
@@ -4,7 +4,7 @@ import styled, { ThemeProvider, withTheme } from 'styled-components';
 import { noop } from 'lodash';
 import uncontrollable from 'uncontrollable';
 import viaTheme from 'es-components-via-theme';
-import classNames from 'classNames';
+import classnames from 'classnames';
 
 import DrawerPanel from './DrawerPanel';
 
@@ -90,7 +90,7 @@ export const Drawer = props => {
 
   return (
     <ThemeProvider theme={theme}>
-      <StyledDrawer className={classNames('es-drawer', className)}>
+      <StyledDrawer className={classnames('es-drawer', className)}>
         {getPanels()}
       </StyledDrawer>
     </ThemeProvider>

--- a/packages/es-components/src/components/containers/drawer/Drawer.js
+++ b/packages/es-components/src/components/containers/drawer/Drawer.js
@@ -106,7 +106,7 @@ Drawer.propTypes = {
   /** Should only contain one or more Drawer.Panel elements */
   children: drawerPanelPropType,
   /** Add additional CSS classes to the root drawer element */
-  className: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  className: PropTypes.string,
   /** Override the default plus icon with another OE icon name */
   closedIconName: PropTypes.string,
   /** Used in uncontrolled mode to set initial drawer state */

--- a/packages/es-components/src/components/containers/drawer/DrawerPanel.js
+++ b/packages/es-components/src/components/containers/drawer/DrawerPanel.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Icon from '../../base/icons/Icon';
 import styled from 'styled-components';
 import AnimateHeight from 'react-animate-height';
-import classNames from 'classNames';
+import classnames from 'classnames';
 
 import genId from '../../util/generateAlphaName';
 
@@ -65,7 +65,7 @@ const DrawerPanel = props => {
   const aside = titleAside !== undefined && <aside>{titleAside}</aside>;
 
   return (
-    <PanelWrapper className={classNames('es-drawer__panel', className)}>
+    <PanelWrapper className={classnames('es-drawer__panel', className)}>
       <div className="es-drawer__heading" id={headingAriaId} role="heading">
         <PanelButton
           aria-expanded={isOpen}

--- a/packages/es-components/src/components/containers/drawer/DrawerPanel.js
+++ b/packages/es-components/src/components/containers/drawer/DrawerPanel.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Icon from '../../base/icons/Icon';
 import styled from 'styled-components';
 import AnimateHeight from 'react-animate-height';
+import classNames from 'classNames';
 
 import genId from '../../util/generateAlphaName';
 
@@ -64,8 +65,8 @@ const DrawerPanel = props => {
   const aside = titleAside !== undefined && <aside>{titleAside}</aside>;
 
   return (
-    <PanelWrapper className={className}>
-      <div id={headingAriaId} role="heading">
+    <PanelWrapper className={classNames('es-drawer__panel', className)}>
+      <div className="es-drawer__heading" id={headingAriaId} role="heading">
         <PanelButton
           aria-expanded={isOpen}
           aria-controls={regionAriaId}
@@ -80,6 +81,7 @@ const DrawerPanel = props => {
       </div>
       <PanelBody
         aria-labelledby={headingAriaId}
+        className="es-drawer__body"
         duration={300}
         height={isOpen ? 'auto' : 0}
         id={regionAriaId}

--- a/packages/es-components/src/components/containers/drawer/__snapshots__/Drawer.specs.js.snap
+++ b/packages/es-components/src/components/containers/drawer/__snapshots__/Drawer.specs.js.snap
@@ -2,12 +2,13 @@
 
 exports[`drawer component accordion renders as expected 1`] = `
 <div
-  className="important sc-EHOje ixLrxb"
+  className="es-drawer important sc-EHOje ixLrxb"
 >
   <div
-    className="first sc-bwzfXH bBIqkK"
+    className="es-drawer__panel first sc-bwzfXH bBIqkK"
   >
     <div
+      className="es-drawer__heading"
       id="abcdef"
       role="heading"
     >
@@ -35,7 +36,7 @@ exports[`drawer component accordion renders as expected 1`] = `
     <div
       aria-hidden={true}
       aria-labelledby="abcdef"
-      className="rah-static rah-static--height-zero sc-ifAKCX HqBXT"
+      className="rah-static rah-static--height-zero es-drawer__body sc-ifAKCX HqBXT"
       id="abcdef"
       role="region"
       style={
@@ -53,9 +54,10 @@ exports[`drawer component accordion renders as expected 1`] = `
     </div>
   </div>
   <div
-    className="second sc-bwzfXH bBIqkK"
+    className="es-drawer__panel second sc-bwzfXH bBIqkK"
   >
     <div
+      className="es-drawer__heading"
       id="abcdef"
       role="heading"
     >
@@ -80,7 +82,7 @@ exports[`drawer component accordion renders as expected 1`] = `
     <div
       aria-hidden={true}
       aria-labelledby="abcdef"
-      className="rah-static rah-static--height-zero sc-ifAKCX bUSXbP"
+      className="rah-static rah-static--height-zero es-drawer__body sc-ifAKCX bUSXbP"
       id="abcdef"
       role="region"
       style={
@@ -98,9 +100,10 @@ exports[`drawer component accordion renders as expected 1`] = `
     </div>
   </div>
   <div
-    className="third sc-bwzfXH bBIqkK"
+    className="es-drawer__panel third sc-bwzfXH bBIqkK"
   >
     <div
+      className="es-drawer__heading"
       id="abcdef"
       role="heading"
     >
@@ -125,7 +128,7 @@ exports[`drawer component accordion renders as expected 1`] = `
     <div
       aria-hidden={true}
       aria-labelledby="abcdef"
-      className="rah-static rah-static--height-zero sc-ifAKCX HqBXT"
+      className="rah-static rah-static--height-zero es-drawer__body sc-ifAKCX HqBXT"
       id="abcdef"
       role="region"
       style={
@@ -147,12 +150,13 @@ exports[`drawer component accordion renders as expected 1`] = `
 
 exports[`drawer component drawer renders as expected 1`] = `
 <div
-  className="important sc-EHOje ixLrxb"
+  className="es-drawer important sc-EHOje ixLrxb"
 >
   <div
-    className="first sc-bwzfXH bBIqkK"
+    className="es-drawer__panel first sc-bwzfXH bBIqkK"
   >
     <div
+      className="es-drawer__heading"
       id="abcdef"
       role="heading"
     >
@@ -180,7 +184,7 @@ exports[`drawer component drawer renders as expected 1`] = `
     <div
       aria-hidden={true}
       aria-labelledby="abcdef"
-      className="rah-static rah-static--height-zero sc-ifAKCX HqBXT"
+      className="rah-static rah-static--height-zero es-drawer__body sc-ifAKCX HqBXT"
       id="abcdef"
       role="region"
       style={
@@ -198,9 +202,10 @@ exports[`drawer component drawer renders as expected 1`] = `
     </div>
   </div>
   <div
-    className="second sc-bwzfXH bBIqkK"
+    className="es-drawer__panel second sc-bwzfXH bBIqkK"
   >
     <div
+      className="es-drawer__heading"
       id="abcdef"
       role="heading"
     >
@@ -225,7 +230,7 @@ exports[`drawer component drawer renders as expected 1`] = `
     <div
       aria-hidden={true}
       aria-labelledby="abcdef"
-      className="rah-static rah-static--height-zero sc-ifAKCX bUSXbP"
+      className="rah-static rah-static--height-zero es-drawer__body sc-ifAKCX bUSXbP"
       id="abcdef"
       role="region"
       style={
@@ -243,9 +248,10 @@ exports[`drawer component drawer renders as expected 1`] = `
     </div>
   </div>
   <div
-    className="third sc-bwzfXH bBIqkK"
+    className="es-drawer__panel third sc-bwzfXH bBIqkK"
   >
     <div
+      className="es-drawer__heading"
       id="abcdef"
       role="heading"
     >
@@ -270,7 +276,7 @@ exports[`drawer component drawer renders as expected 1`] = `
     <div
       aria-hidden={true}
       aria-labelledby="abcdef"
-      className="rah-static rah-static--height-zero sc-ifAKCX HqBXT"
+      className="rah-static rah-static--height-zero es-drawer__body sc-ifAKCX HqBXT"
       id="abcdef"
       role="region"
       style={

--- a/packages/es-components/src/components/containers/drawer/__snapshots__/Drawer.specs.js.snap
+++ b/packages/es-components/src/components/containers/drawer/__snapshots__/Drawer.specs.js.snap
@@ -20,7 +20,7 @@ exports[`drawer component accordion renders as expected 1`] = `
         <span>
           <i
             aria-hidden={true}
-            className="sc-bxivhb bCiBaT sc-bdVaJa eTkFwb"
+            className="es-icon sc-bxivhb bCiBaT sc-bdVaJa eTkFwb"
             content="601"
             fontFamily="indv-mkt-icons"
             fontSize="inherit"
@@ -68,7 +68,7 @@ exports[`drawer component accordion renders as expected 1`] = `
         <span>
           <i
             aria-hidden={true}
-            className="sc-bxivhb bCiBaT sc-bdVaJa eTkFwb"
+            className="es-icon sc-bxivhb bCiBaT sc-bdVaJa eTkFwb"
             content="601"
             fontFamily="indv-mkt-icons"
             fontSize="inherit"
@@ -113,7 +113,7 @@ exports[`drawer component accordion renders as expected 1`] = `
         <span>
           <i
             aria-hidden={true}
-            className="sc-bxivhb bCiBaT sc-bdVaJa eTkFwb"
+            className="es-icon sc-bxivhb bCiBaT sc-bdVaJa eTkFwb"
             content="601"
             fontFamily="indv-mkt-icons"
             fontSize="inherit"
@@ -165,7 +165,7 @@ exports[`drawer component drawer renders as expected 1`] = `
         <span>
           <i
             aria-hidden={true}
-            className="sc-bxivhb bCiBaT sc-bdVaJa eTkFwb"
+            className="es-icon sc-bxivhb bCiBaT sc-bdVaJa eTkFwb"
             content="601"
             fontFamily="indv-mkt-icons"
             fontSize="inherit"
@@ -213,7 +213,7 @@ exports[`drawer component drawer renders as expected 1`] = `
         <span>
           <i
             aria-hidden={true}
-            className="sc-bxivhb bCiBaT sc-bdVaJa eTkFwb"
+            className="es-icon sc-bxivhb bCiBaT sc-bdVaJa eTkFwb"
             content="601"
             fontFamily="indv-mkt-icons"
             fontSize="inherit"
@@ -258,7 +258,7 @@ exports[`drawer component drawer renders as expected 1`] = `
         <span>
           <i
             aria-hidden={true}
-            className="sc-bxivhb bCiBaT sc-bdVaJa eTkFwb"
+            className="es-icon sc-bxivhb bCiBaT sc-bdVaJa eTkFwb"
             content="601"
             fontFamily="indv-mkt-icons"
             fontSize="inherit"

--- a/packages/es-components/src/components/containers/fieldset/Fieldset.js
+++ b/packages/es-components/src/components/containers/fieldset/Fieldset.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { ThemeProvider, withTheme } from 'styled-components';
 import viaTheme from 'es-components-via-theme';
-import classNames from 'classNames';
+import classnames from 'classnames';
 
 const Legend = styled.legend`
   border: 0;
@@ -18,7 +18,7 @@ const Legend = styled.legend`
 
 function renderLegend(content, legendClasses) {
   return content ? (
-    <Legend className={classNames('es-fieldset__legend', legendClasses)}>
+    <Legend className={classnames('es-fieldset__legend', legendClasses)}>
       {content}
     </Legend>
   ) : null;

--- a/packages/es-components/src/components/containers/fieldset/Fieldset.js
+++ b/packages/es-components/src/components/containers/fieldset/Fieldset.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { ThemeProvider, withTheme } from 'styled-components';
 import viaTheme from 'es-components-via-theme';
+import classNames from 'classNames';
 
 const Legend = styled.legend`
   border: 0;
@@ -16,7 +17,11 @@ const Legend = styled.legend`
 `;
 
 function renderLegend(content, legendClasses) {
-  return content ? <Legend className={legendClasses}>{content}</Legend> : null;
+  return content ? (
+    <Legend className={classNames('es-fieldset__legend', legendClasses)}>
+      {content}
+    </Legend>
+  ) : null;
 }
 
 const StyledFieldset = styled.fieldset`
@@ -34,11 +39,9 @@ function Fieldset({
 }) {
   return (
     <ThemeProvider theme={theme}>
-      <StyledFieldset>
-        <div>
-          {renderLegend(legendContent, legendClasses)}
-          {extraContent}
-        </div>
+      <StyledFieldset className="es-fieldset">
+        {renderLegend(legendContent, legendClasses)}
+        {extraContent}
         {children}
       </StyledFieldset>
     </ThemeProvider>

--- a/packages/es-components/src/components/containers/fieldset/__snapshots__/Fieldset.specs.js.snap
+++ b/packages/es-components/src/components/containers/fieldset/__snapshots__/Fieldset.specs.js.snap
@@ -2,9 +2,8 @@
 
 exports[`Fieldset component renders as expected 1`] = `
 <fieldset
-  className="sc-bwzfXH kzYDuJ"
+  className="es-fieldset sc-bwzfXH kzYDuJ"
 >
-  <div />
   <div>
     Fieldset child
   </div>
@@ -13,16 +12,14 @@ exports[`Fieldset component renders as expected 1`] = `
 
 exports[`Fieldset component renders as expected with extra content 1`] = `
 <fieldset
-  className="sc-bwzfXH kzYDuJ"
+  className="es-fieldset sc-bwzfXH kzYDuJ"
 >
-  <div>
-    <legend
-      className="sc-bdVaJa NnbOj"
-    >
-      I am legend
-    </legend>
-    Extra Content
-  </div>
+  <legend
+    className="es-fieldset__legend sc-bdVaJa NnbOj"
+  >
+    I am legend
+  </legend>
+  Extra Content
   <div>
     Fieldset child
   </div>
@@ -31,15 +28,13 @@ exports[`Fieldset component renders as expected with extra content 1`] = `
 
 exports[`Fieldset component renders as expected with legendText 1`] = `
 <fieldset
-  className="sc-bwzfXH kzYDuJ"
+  className="es-fieldset sc-bwzfXH kzYDuJ"
 >
-  <div>
-    <legend
-      className="sc-bdVaJa NnbOj"
-    >
-      I am legend
-    </legend>
-  </div>
+  <legend
+    className="es-fieldset__legend sc-bdVaJa NnbOj"
+  >
+    I am legend
+  </legend>
   <div>
     Fieldset child
   </div>

--- a/packages/es-components/src/components/containers/menu/Menu.js
+++ b/packages/es-components/src/components/containers/menu/Menu.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ToggleButton from '../../controls/buttons/ToggleButton';
 import styled, { ThemeProvider, withTheme } from 'styled-components';
+import classnames from 'classnames';
+
+import ToggleButton from '../../controls/buttons/ToggleButton';
 import MenuPanel from './MenuPanel';
 import MenuSection from './MenuSection';
 import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
@@ -51,21 +53,23 @@ export class Menu extends React.Component {
       theme,
       openButtonType,
       rootClose,
-      hasBackdrop
+      hasBackdrop,
+      headerContent
     } = this.props;
 
     return (
       <ThemeProvider theme={theme}>
         <RootCloseWrapper onRootClose={this.closeMenu} disabled={!rootClose}>
-          <div className={className}>
+          <div className={classnames('es-menu', className)}>
             {hasBackdrop && (
               <Backdrop
+                className="es-menu__backdrop"
                 isMenuOpen={this.state.isMenuOpen}
                 onClick={this.closeMenu}
               />
             )}
             <ToggleButton
-              className="open-menu-button"
+              className="es-menu__toggle-button"
               handleOnClick={this.toggleMenu}
               isPressed={this.state.isMenuOpen}
               styleType={openButtonType}
@@ -73,7 +77,11 @@ export class Menu extends React.Component {
             >
               {buttonContent}
             </ToggleButton>
-            <MenuPanel isOpen={this.state.isMenuOpen} onClose={this.closeMenu}>
+            <MenuPanel
+              headerContent={headerContent}
+              isOpen={this.state.isMenuOpen}
+              onClose={this.closeMenu}
+            >
               {children}
             </MenuPanel>
           </div>
@@ -93,7 +101,8 @@ Menu.propTypes = {
   rootClose: PropTypes.bool,
   inline: PropTypes.bool,
   theme: PropTypes.object,
-  hasBackdrop: PropTypes.bool
+  hasBackdrop: PropTypes.bool,
+  headerContent: PropTypes.node
 };
 
 Menu.defaultProps = {

--- a/packages/es-components/src/components/containers/menu/Menu.js
+++ b/packages/es-components/src/components/containers/menu/Menu.js
@@ -69,7 +69,6 @@ export class Menu extends React.Component {
               />
             )}
             <ToggleButton
-              className="es-menu__toggle-button"
               handleOnClick={this.toggleMenu}
               isPressed={this.state.isMenuOpen}
               styleType={openButtonType}

--- a/packages/es-components/src/components/containers/menu/Menu.md
+++ b/packages/es-components/src/components/containers/menu/Menu.md
@@ -2,7 +2,7 @@ Use the `Menu` to expose an list of items overlayed over the screen when a butto
 
 ### Basic Example
 ```
-<Menu header="Small Menu" buttonContent="Open Menu" openButtonType="primary" rootClose hasBackdrop>
+<Menu headerContent="Small Menu" buttonContent="Open Menu" openButtonType="primary" rootClose hasBackdrop>
   <Menu.MenuSection title="Menu Section" isFirst rootClose>
     <a href="http://www.google.com">Go To Google</a>
   </Menu.MenuSection>
@@ -34,7 +34,7 @@ Use the `Menu` to expose an list of items overlayed over the screen when a butto
 By adding the `Inline` prop the menu will be displayed without bottom borders side by side.
 
 ```
-<Menu header="Small Menu" buttonContent="Open Menu" inline>
+<Menu headerContent="Small Menu" buttonContent="Open Menu" inline>
   <Menu.MenuSection title="Menu Section" isFirst>
     <a href="http://www.google.com">Go To Google</a>
   </Menu.MenuSection>

--- a/packages/es-components/src/components/containers/menu/Menu.specs.js
+++ b/packages/es-components/src/components/containers/menu/Menu.specs.js
@@ -11,7 +11,11 @@ describe('MenuTestSuite', () => {
 
   beforeEach(() => {
     instanceToRender = (
-      <Menu header="Small Menu" buttonContent="Open Menu">
+      <Menu
+        headerContent="Small Menu"
+        buttonContent="Open Menu"
+        className="test"
+      >
         <Menu.MenuSection title="Menu Section" isFirst>
           <a href="www.google.com">Go To Google</a>
         </Menu.MenuSection>

--- a/packages/es-components/src/components/containers/menu/MenuPanel.js
+++ b/packages/es-components/src/components/containers/menu/MenuPanel.js
@@ -11,11 +11,18 @@ const StyledPanel = styled.div`
 `;
 
 const StyledDismissButton = styled(DismissButton)`
-  float: right;
+  margin-left: auto;
 `;
 
-const Spacer = styled.div`
-  padding-bottom: 35px;
+const Header = styled.header`
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  padding-bottom: ${props => (props.hasHeaderContent ? '10px' : '0')}
+  padding-left: 11px;
+  padding-right: 5px;
+  padding-top: ${props => (props.hasHeaderContent ? '5px' : '0')}
 `;
 
 const StyledChildrenContainer = styled.div`
@@ -24,22 +31,42 @@ const StyledChildrenContainer = styled.div`
   flex-wrap: wrap;
 `;
 
-const MenuPanel = (props, context) => {
-  const { children, isOpen, onClose } = props;
-  return (
-    <StyledPanel isOpen={isOpen} className="menu-panel">
-      <Spacer>
-        <StyledDismissButton onClick={onClose} />
-      </Spacer>
-      <StyledChildrenContainer inline={context.inline}>
-        {children}
-      </StyledChildrenContainer>
-    </StyledPanel>
-  );
-};
+class MenuPanel extends React.Component {
+  componentDidMount = () => {
+    document.addEventListener('keydown', this.onEscape);
+  };
+
+  componentWillUnmount = () => {
+    document.removeEventListener('keydown', this.onEscape);
+  };
+
+  onEscape = ({ keyCode }) => {
+    if (keyCode === 27) {
+      this.props.onClose();
+    }
+  };
+
+  render() {
+    const { children, headerContent, isOpen, onClose } = this.props;
+    const hasHeaderContent = !!headerContent;
+
+    return (
+      <StyledPanel isOpen={isOpen} className="es-menu__panel">
+        <Header hasHeaderContent={hasHeaderContent}>
+          {hasHeaderContent && <span>{headerContent}</span>}
+          <StyledDismissButton onClick={onClose} />
+        </Header>
+        <StyledChildrenContainer inline={this.context.inline}>
+          {children}
+        </StyledChildrenContainer>
+      </StyledPanel>
+    );
+  }
+}
 
 MenuPanel.propTypes = {
   children: PropTypes.any.isRequired,
+  headerContent: PropTypes.node,
   isOpen: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
   theme: PropTypes.object

--- a/packages/es-components/src/components/containers/menu/MenuSection.js
+++ b/packages/es-components/src/components/containers/menu/MenuSection.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 /* eslint-disable no-confusing-arrow */
-const StyledMenuSection = styled.div`
+const StyledMenuSection = styled.section`
   padding-top: ${props =>
     !props.isFirst && !props.inline && !props.isOnlySection ? '20px' : '0px'};
   padding-bottom: ${props => (props.isLast ? '0px' : '20px')};
@@ -14,11 +14,11 @@ const StyledMenuSection = styled.div`
 `;
 /* eslint-enable */
 
-const StyledHeader = styled.div`
+const StyledHeader = styled.header`
   padding-left: 10px;
 `;
 
-const StyledChildrenContainer = styled.div`
+const StyledChildrenContainer = styled.section`
   padding: 15px 20px 0px 20px;
 `;
 
@@ -28,6 +28,7 @@ const MenuSection = (props, context) => {
 
   return (
     <StyledMenuSection
+      className="es-menu__section"
       isLast={isLast}
       isFirst={isFirst}
       inline={inline}

--- a/packages/es-components/src/components/containers/menu/__snapshots__/Menu.specs.js.snap
+++ b/packages/es-components/src/components/containers/menu/__snapshots__/Menu.specs.js.snap
@@ -6,7 +6,7 @@ exports[`MenuTestSuite renders as expected 1`] = `
 >
   <button
     aria-expanded={false}
-    className="es-menu__toggle-button sc-ifAKCX drovqE sc-bwzfXH hJmlCu sc-bdVaJa kHkNOX"
+    className="es-button es-button--default sc-ifAKCX drovqE sc-bwzfXH hJmlCu sc-bdVaJa kHkNOX"
     onClick={[Function]}
   >
     Open Menu

--- a/packages/es-components/src/components/containers/menu/__snapshots__/Menu.specs.js.snap
+++ b/packages/es-components/src/components/containers/menu/__snapshots__/Menu.specs.js.snap
@@ -2,24 +2,27 @@
 
 exports[`MenuTestSuite renders as expected 1`] = `
 <div
-  className={undefined}
+  className="es-menu test"
 >
   <button
     aria-expanded={false}
-    className="open-menu-button sc-ifAKCX drovqE sc-bwzfXH hJmlCu sc-bdVaJa kHkNOX"
+    className="es-menu__toggle-button sc-ifAKCX drovqE sc-bwzfXH hJmlCu sc-bdVaJa kHkNOX"
     onClick={[Function]}
   >
     Open Menu
   </button>
   <div
-    className="menu-panel sc-gzVnrw ZXtoB"
+    className="es-menu__panel sc-gzVnrw ZXtoB"
   >
-    <div
-      className="sc-dnqmqq djHNQY"
+    <header
+      className="sc-dnqmqq jBxXuW"
     >
+      <span>
+        Small Menu
+      </span>
       <button
         aria-label="Close"
-        className="sc-htoDjs hubgrr sc-EHOje cQHrKQ"
+        className="sc-htoDjs XrUxb sc-EHOje jHwaMP"
         onClick={[Function]}
       >
         <span
@@ -33,20 +36,20 @@ exports[`MenuTestSuite renders as expected 1`] = `
           Close
         </span>
       </button>
-    </div>
+    </header>
     <div
       className="sc-iwsKbI kyjaoD"
     >
-      <div
-        className="sc-gZMcBi ivZJCw"
+      <section
+        className="es-menu__section sc-gZMcBi ivZJCw"
       >
-        <div
+        <header
           aria-label="Menu Section"
           className="sc-gqjmRU fiUekS"
         >
           Menu Section
-        </div>
-        <div
+        </header>
+        <section
           className="sc-VigVT frPBLq"
         >
           <a
@@ -54,8 +57,8 @@ exports[`MenuTestSuite renders as expected 1`] = `
           >
             Go To Google
           </a>
-        </div>
-      </div>
+        </section>
+      </section>
     </div>
   </div>
 </div>

--- a/packages/es-components/src/components/containers/modal/Modal.js
+++ b/packages/es-components/src/components/containers/modal/Modal.js
@@ -129,13 +129,16 @@ class Modal extends React.Component {
           onHide={onHide}
           show={show}
           transition={animation ? Fade : undefined}
+          className="es-modal__dialog"
         >
           <ModalDialog
             size={size}
             aria-labelledby={this.state.ariaId}
-            className="modal-dialog"
+            className="es-modal__wrapper"
           >
-            <ModalContent>{children}</ModalContent>
+            <ModalContent className="es-modal__content">
+              {children}
+            </ModalContent>
           </ModalDialog>
         </DialogWrapper>
       </ThemeProvider>

--- a/packages/es-components/src/components/containers/modal/Modal.js
+++ b/packages/es-components/src/components/containers/modal/Modal.js
@@ -129,12 +129,12 @@ class Modal extends React.Component {
           onHide={onHide}
           show={show}
           transition={animation ? Fade : undefined}
-          className="es-modal__dialog"
+          className="es-modal"
         >
           <ModalDialog
             size={size}
             aria-labelledby={this.state.ariaId}
-            className="es-modal__wrapper"
+            className="es-modal__dialog"
           >
             <ModalContent className="es-modal__content">
               {children}

--- a/packages/es-components/src/components/containers/modal/__snapshots__/ModalHeader.specs.js.snap
+++ b/packages/es-components/src/components/containers/modal/__snapshots__/ModalHeader.specs.js.snap
@@ -12,7 +12,7 @@ exports[`modal header component renders with close button 1`] = `
   </h4>
   <button
     aria-label="Close"
-    className="sc-ifAKCX lfpfxN sc-bdVaJa ijDihB"
+    className="sc-ifAKCX lfpfxN sc-bdVaJa eLdFuS"
     onClick={[Function]}
   >
     <span

--- a/packages/es-components/src/components/containers/notification/Notification.js
+++ b/packages/es-components/src/components/containers/notification/Notification.js
@@ -128,7 +128,7 @@ const ButtonWrapper = styled.div`
 
 function renderCallsToAction(callsToAction, theme) {
   return (
-    <CallsToAction>
+    <CallsToAction className="es-notification__actions">
       {callsToAction.map((callToAction, index) => {
         const buttonStyleType = index === 0 ? 'primary' : 'default';
 
@@ -212,13 +212,12 @@ export function Notification({
 
   return (
     <ThemeProvider theme={theme}>
-      <NotificationWrapper>
+      <NotificationWrapper className="es-notification__wrapper" role={roleType}>
         <NotificationBgWrapper
           {...otherProps}
           color={theme.notificationStyles[type][bgType]}
-          role={roleType}
         >
-          <NotificationHeader>
+          <NotificationHeader className="es-notification__header">
             {renderLeadingHeader(type, includeIcon, header, additionalText)}
             {hasExtraAlert && renderExtraAlert(extraAlert)}
             {dismissable && (
@@ -230,7 +229,10 @@ export function Notification({
           </NotificationHeader>
 
           {hasChildren && (
-            <NotificationContent hasIcon={includeIcon}>
+            <NotificationContent
+              className="es-notification__content"
+              hasIcon={includeIcon}
+            >
               {children}
             </NotificationContent>
           )}

--- a/packages/es-components/src/components/containers/popover/Popover.js
+++ b/packages/es-components/src/components/containers/popover/Popover.js
@@ -207,6 +207,7 @@ class Popover extends React.Component {
 
     const triggerButton = (
       <TriggerButton
+        className="es-popover__trigger"
         handleOnClick={this.toggleShow}
         styleType={buttonStyle}
         isOutline={isOutline}
@@ -225,7 +226,7 @@ class Popover extends React.Component {
 
     return (
       <ThemeProvider theme={theme}>
-        <Container>
+        <Container className="es-popover">
           <Popup
             name={name}
             trigger={triggerButton}
@@ -242,12 +243,13 @@ class Popover extends React.Component {
             }}
           >
             <PopoverContainer
+              className="es-popover__container"
               role="dialog"
               ref={elem => {
                 this.contentRef = elem;
               }}
             >
-              <PopoverHeader hasTitle={hasTitle}>
+              <PopoverHeader className="es-popover__header" hasTitle={hasTitle}>
                 {hasTitle && <TitleBar>{title}</TitleBar>}
                 {hasAltCloseButton && altCloseButton}
                 <CloseHelpText
@@ -259,8 +261,14 @@ class Popover extends React.Component {
                 />
               </PopoverHeader>
 
-              <PopoverBody hasAltCloseWithNoTitle={hasAltCloseWithNoTitle}>
-                <PopoverContent showCloseButton={showCloseButton}>
+              <PopoverBody
+                className="es-popover__body"
+                hasAltCloseWithNoTitle={hasAltCloseWithNoTitle}
+              >
+                <PopoverContent
+                  className="es-popover__content"
+                  showCloseButton={showCloseButton}
+                >
                   {content}
                 </PopoverContent>
                 {showCloseButton && closeButton}

--- a/packages/es-components/src/components/containers/popover/Popover.js
+++ b/packages/es-components/src/components/containers/popover/Popover.js
@@ -207,7 +207,6 @@ class Popover extends React.Component {
 
     const triggerButton = (
       <TriggerButton
-        className="es-popover__trigger"
         handleOnClick={this.toggleShow}
         styleType={buttonStyle}
         isOutline={isOutline}

--- a/packages/es-components/src/components/containers/popover/__snapshots__/Popover.specs.js.snap
+++ b/packages/es-components/src/components/containers/popover/__snapshots__/Popover.specs.js.snap
@@ -8,7 +8,7 @@ exports[`popover component renders as expected 1`] = `
     <div>
       <button
         aria-expanded={false}
-        className="es-popover__trigger sc-gzVnrw jgosdJ sc-htpNat cJWpVN sc-bwzfXH jWFaYU"
+        className="es-button es-button--default sc-gzVnrw jgosdJ sc-htpNat cJWpVN sc-bwzfXH jWFaYU"
         onClick={[Function]}
       >
         <span

--- a/packages/es-components/src/components/containers/popover/__snapshots__/Popover.specs.js.snap
+++ b/packages/es-components/src/components/containers/popover/__snapshots__/Popover.specs.js.snap
@@ -2,13 +2,13 @@
 
 exports[`popover component renders as expected 1`] = `
 <div
-  className="sc-bZQynM dSsQJY"
+  className="es-popover sc-bZQynM dSsQJY"
 >
   <div>
     <div>
       <button
         aria-expanded={false}
-        className="sc-gzVnrw jgosdJ sc-htpNat cJWpVN sc-bwzfXH jWFaYU"
+        className="es-popover__trigger sc-gzVnrw jgosdJ sc-htpNat cJWpVN sc-bwzfXH jWFaYU"
         onClick={[Function]}
       >
         <span
@@ -40,11 +40,11 @@ exports[`popover component renders as expected 1`] = `
         }
       >
         <div
-          className="sc-dnqmqq BnNnH"
+          className="es-popover__container sc-dnqmqq BnNnH"
           role="dialog"
         >
           <div
-            className="sc-iwsKbI cirLJO"
+            className="es-popover__header sc-iwsKbI cirLJO"
           >
             <h3
               className="sc-gZMcBi cPBpHt"
@@ -58,10 +58,10 @@ exports[`popover component renders as expected 1`] = `
             />
           </div>
           <div
-            className="sc-gqjmRU eiaKpk"
+            className="es-popover__body sc-gqjmRU eiaKpk"
           >
             <div
-              className="sc-VigVT cztEQg"
+              className="es-popover__content sc-VigVT cztEQg"
             >
               This is the popover content.
             </div>

--- a/packages/es-components/src/components/containers/tabPanels/TabPanel.js
+++ b/packages/es-components/src/components/containers/tabPanels/TabPanel.js
@@ -78,7 +78,7 @@ class TabPanel extends React.Component {
             this.state.simpleName
           } Sub text is now showing`}</AriaAnnouncer>
           <TabWrapper className="es-tab-panel__wrapper">
-            <TabFormatter className="es-tab-panel__formatter">
+            <TabFormatter className="es-tab-panel__tabs">
               {elements}
             </TabFormatter>
           </TabWrapper>

--- a/packages/es-components/src/components/containers/tooltip/Tooltip.js
+++ b/packages/es-components/src/components/containers/tooltip/Tooltip.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Overlay from 'react-overlays/lib/Overlay';
 import styled, { ThemeProvider, withTheme } from 'styled-components';
 import viaTheme from 'es-components-via-theme';
+import classnames from 'classnames';
 
 import Fade from '../../util/Fade';
 
@@ -110,7 +111,11 @@ const Popup = props => {
   }
 
   return (
-    <TooltipStyled role="tooltip" className={className} style={style}>
+    <TooltipStyled
+      role="tooltip"
+      className={classnames('es-tooltip', className)}
+      style={style}
+    >
       <TooltipArrow />
       <TooltipInner>{children}</TooltipInner>
     </TooltipStyled>
@@ -139,6 +144,7 @@ class Tooltip extends React.Component {
       <ThemeProvider theme={this.props.theme}>
         <span>
           <span
+            className="es-tooltip__target"
             ref={span => {
               this.toolTipTarget = span;
             }}

--- a/packages/es-components/src/components/containers/tooltip/__snapshots__/Tooltip.specs.js.snap
+++ b/packages/es-components/src/components/containers/tooltip/__snapshots__/Tooltip.specs.js.snap
@@ -3,6 +3,7 @@
 exports[`tooltip component renders tooltip children 1`] = `
 <span>
   <span
+    className="es-tooltip__target"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >

--- a/packages/es-components/src/components/controls/DismissButton.js
+++ b/packages/es-components/src/components/controls/DismissButton.js
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 
 const DismissButtonBase = styled.button`
-  align-self: flex-start;
   background: transparent;
   border: 0;
   cursor: pointer;

--- a/packages/es-components/src/components/controls/buttons/Button.js
+++ b/packages/es-components/src/components/controls/buttons/Button.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { ThemeProvider, withTheme } from 'styled-components';
 import viaTheme from 'es-components-via-theme';
+import classnames from 'classnames';
 
 function getBlockPropertyValues(isBlock) {
   if (isBlock) {
@@ -133,12 +134,12 @@ export function Button({
   ...buttonProps
 }) {
   const buttonSize = theme.buttonSizes[size];
+  const { className, ...otherProps } = buttonProps;
   const sharedProps = {
     block,
     buttonSize,
     onClick: handleOnClick,
-    className: buttonClasses,
-    ...buttonProps
+    ...otherProps
   };
 
   const defaultNormal = {
@@ -162,7 +163,15 @@ export function Button({
 
   let variant = theme.buttonStyles.buttonsNormal[styleType] || defaultNormal;
   let button = (
-    <DefaultButton variant={variant} {...sharedProps}>
+    <DefaultButton
+      variant={variant}
+      {...sharedProps}
+      className={classnames(
+        'es-button es-button--default',
+        buttonClasses,
+        className
+      )}
+    >
       {children}
     </DefaultButton>
   );
@@ -170,14 +179,30 @@ export function Button({
   if (isOutline) {
     variant = theme.buttonStyles.buttonsOutline[styleType] || defaultOutline;
     button = (
-      <OutlineButton variant={variant} {...sharedProps}>
+      <OutlineButton
+        variant={variant}
+        {...sharedProps}
+        className={classnames(
+          'es-button es-button--outline',
+          buttonClasses,
+          className
+        )}
+      >
         {children}
       </OutlineButton>
     );
   } else if (isLinkButton) {
     variant = theme.buttonStyles.buttonsNormal[styleType] || defaultNormal;
     button = (
-      <LinkButton variant={variant} {...sharedProps}>
+      <LinkButton
+        variant={variant}
+        {...sharedProps}
+        className={classnames(
+          'es-button es-button--link',
+          buttonClasses,
+          className
+        )}
+      >
         {children}
       </LinkButton>
     );
@@ -192,7 +217,7 @@ Button.propTypes = {
   /** Function to execute when button is clicked */
   handleOnClick: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,
-  /** Any additional classes to apply to the button */
+  /** @deprecated Button will accept standard className prop */
   buttonClasses: PropTypes.string,
   /** Select the color style of the button, types come from theme */
   styleType: PropTypes.string,

--- a/packages/es-components/src/components/controls/buttons/ToggleButton.js
+++ b/packages/es-components/src/components/controls/buttons/ToggleButton.js
@@ -94,6 +94,7 @@ const buttonSizes = ['lg', 'default', 'sm', 'xs'];
 ToggleButton.propTypes = {
   handleOnClick: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,
+  /** @deprecated ToggleButton will accept standard className prop */
   buttonClasses: PropTypes.string,
   styleType: PropTypes.string,
   isLinkButton: PropTypes.bool,

--- a/packages/es-components/src/components/controls/checkbox/Checkbox.js
+++ b/packages/es-components/src/components/controls/checkbox/Checkbox.js
@@ -116,7 +116,7 @@ function Checkbox({
           focusBorderColor={theme.colors.inputFocus}
         />
         <CheckboxWrapper className="es-checkbox__fill" />
-        <CheckboxText className="es-checkbox__label" aria-hidden={!!ariaLabel}>
+        <CheckboxText className="es-checkbox__text" aria-hidden={!!ariaLabel}>
           {labelText}
         </CheckboxText>
       </CheckboxLabel>

--- a/packages/es-components/src/components/controls/checkbox/Checkbox.js
+++ b/packages/es-components/src/components/controls/checkbox/Checkbox.js
@@ -101,12 +101,11 @@ function Checkbox({
   return (
     <ThemeProvider theme={theme}>
       <CheckboxLabel
-        className="es-checkbox__label"
+        className="es-checkbox"
         disabled={isDisabled}
         isChecked={isChecked}
       >
         <CheckboxInput
-          className="es-checkbox"
           type="checkbox"
           disabled={isDisabled}
           value={value}
@@ -117,7 +116,7 @@ function Checkbox({
           focusBorderColor={theme.colors.inputFocus}
         />
         <CheckboxWrapper className="es-checkbox__fill" />
-        <CheckboxText className="es-checkbox__text" aria-hidden={!!ariaLabel}>
+        <CheckboxText className="es-checkbox__label" aria-hidden={!!ariaLabel}>
           {labelText}
         </CheckboxText>
       </CheckboxLabel>

--- a/packages/es-components/src/components/controls/checkbox/Checkbox.js
+++ b/packages/es-components/src/components/controls/checkbox/Checkbox.js
@@ -13,7 +13,7 @@ const CheckboxLabel = Label.extend`
   text-transform: none;
   display: flex;
 
-  > .checkbox-fill {
+  > .es-checkbox__fill {
     background-color: ${({ isChecked, theme }) =>
       isChecked ? theme.colors.info : theme.colors.white};
     border-color: ${({ isChecked, theme }) =>
@@ -24,12 +24,12 @@ const CheckboxLabel = Label.extend`
     }
   }
 
-  &:hover > .checkbox-fill:after {
+  &:hover > .es-checkbox__fill:after {
     border-color: ${({ isChecked, theme }) =>
       isChecked ? theme.colors.white : theme.colors.gray3};
   }
 
-  &[disabled] > .checkbox-fill {
+  &[disabled] > .es-checkbox__fill {
     background-color: ${({ isChecked, theme }) =>
       isChecked ? theme.colors.gray5 : theme.colors.white};
     border-color: ${props => props.theme.colors.gray5};
@@ -46,7 +46,7 @@ const CheckboxInput = styled.input`
   clip: rect(0, 0, 0, 0);
   position: absolute;
 
-  &:focus ~ .checkbox-fill {
+  &:focus ~ .es-checkbox__fill {
     box-shadow: 0 0 3px 3px ${props => props.theme.colors.inputFocus};
     &:after {
       border-color: ${({ checked, theme }) =>
@@ -100,8 +100,13 @@ function Checkbox({
   /* eslint-disable jsx-a11y/use-onblur-not-onchange */
   return (
     <ThemeProvider theme={theme}>
-      <CheckboxLabel disabled={isDisabled} isChecked={isChecked}>
+      <CheckboxLabel
+        className="es-checkbox__label"
+        disabled={isDisabled}
+        isChecked={isChecked}
+      >
         <CheckboxInput
+          className="es-checkbox"
           type="checkbox"
           disabled={isDisabled}
           value={value}
@@ -111,8 +116,10 @@ function Checkbox({
           aria-label={ariaLabel}
           focusBorderColor={theme.colors.inputFocus}
         />
-        <CheckboxWrapper className="checkbox-fill" />
-        <CheckboxText aria-hidden={!!ariaLabel}>{labelText}</CheckboxText>
+        <CheckboxWrapper className="es-checkbox__fill" />
+        <CheckboxText className="es-checkbox__text" aria-hidden={!!ariaLabel}>
+          {labelText}
+        </CheckboxText>
       </CheckboxLabel>
     </ThemeProvider>
   );

--- a/packages/es-components/src/components/controls/checkbox/__snapshots__/Checkbox.specs.js.snap
+++ b/packages/es-components/src/components/controls/checkbox/__snapshots__/Checkbox.specs.js.snap
@@ -20,7 +20,7 @@ exports[`Checkbox renders as expected 1`] = `
   />
   <span
     aria-hidden={false}
-    className="es-checkbox__label sc-ifAKCX kWaOTi"
+    className="es-checkbox__text sc-ifAKCX kWaOTi"
   >
     Render test
   </span>

--- a/packages/es-components/src/components/controls/checkbox/__snapshots__/Checkbox.specs.js.snap
+++ b/packages/es-components/src/components/controls/checkbox/__snapshots__/Checkbox.specs.js.snap
@@ -2,13 +2,13 @@
 
 exports[`Checkbox renders as expected 1`] = `
 <label
-  className="sc-bwzfXH lpnuLf"
+  className="es-checkbox__label sc-bwzfXH blPwYw"
   disabled={true}
 >
   <input
     aria-label={undefined}
     checked={true}
-    className="sc-htpNat dVmsUC"
+    className="es-checkbox sc-htpNat llDmUy"
     disabled={true}
     onChange={[Function]}
     onClick={[Function]}
@@ -16,11 +16,11 @@ exports[`Checkbox renders as expected 1`] = `
     value={undefined}
   />
   <span
-    className="checkbox-fill sc-bxivhb kynQKu"
+    className="es-checkbox__fill sc-bxivhb kynQKu"
   />
   <span
     aria-hidden={false}
-    className="sc-ifAKCX kWaOTi"
+    className="es-checkbox__text sc-ifAKCX kWaOTi"
   >
     Render test
   </span>

--- a/packages/es-components/src/components/controls/checkbox/__snapshots__/Checkbox.specs.js.snap
+++ b/packages/es-components/src/components/controls/checkbox/__snapshots__/Checkbox.specs.js.snap
@@ -2,13 +2,13 @@
 
 exports[`Checkbox renders as expected 1`] = `
 <label
-  className="es-checkbox__label sc-bwzfXH blPwYw"
+  className="es-checkbox sc-bwzfXH blPwYw"
   disabled={true}
 >
   <input
     aria-label={undefined}
     checked={true}
-    className="es-checkbox sc-htpNat llDmUy"
+    className="sc-htpNat llDmUy"
     disabled={true}
     onChange={[Function]}
     onClick={[Function]}
@@ -20,7 +20,7 @@ exports[`Checkbox renders as expected 1`] = `
   />
   <span
     aria-hidden={false}
-    className="es-checkbox__text sc-ifAKCX kWaOTi"
+    className="es-checkbox__label sc-ifAKCX kWaOTi"
   >
     Render test
   </span>

--- a/packages/es-components/src/components/controls/dropdown/Dropdown.js
+++ b/packages/es-components/src/components/controls/dropdown/Dropdown.js
@@ -45,6 +45,8 @@ function Dropdown({
     );
   });
 
+  const classNameState = `es-dropdown--${validationState}`;
+
   return (
     <ThemeProvider theme={theme}>
       <Label inline={inline} className={classnames('es-dropdown', className)}>
@@ -62,6 +64,7 @@ function Dropdown({
           value={value}
           onChange={onChange}
           onBlur={onBlur}
+          className={classNameState}
           {...theme.validationInputColor[validationState]}
           {...rest}
         >

--- a/packages/es-components/src/components/controls/dropdown/Dropdown.js
+++ b/packages/es-components/src/components/controls/dropdown/Dropdown.js
@@ -45,7 +45,7 @@ function Dropdown({
     );
   });
 
-  const classNameState = `es-dropdown--${validationState}`;
+  const classNameState = `es-dropdown__select--${validationState}`;
 
   return (
     <ThemeProvider theme={theme}>

--- a/packages/es-components/src/components/controls/dropdown/Dropdown.js
+++ b/packages/es-components/src/components/controls/dropdown/Dropdown.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { noop } from 'lodash';
 import { ThemeProvider, withTheme } from 'styled-components';
 import viaTheme from 'es-components-via-theme';
+import classnames from 'classnames';
 
 import Label from '../Label';
 import { LabelText, SelectBase } from '../BaseControls';
@@ -46,9 +47,10 @@ function Dropdown({
 
   return (
     <ThemeProvider theme={theme}>
-      <Label inline={inline} className={className}>
+      <Label inline={inline} className={classnames('es-dropdown', className)}>
         {labelText && (
           <LabelText
+            className="es-dropdown__label"
             foregroundColor={theme.validationTextColor[validationState]}
             inline={inline}
           >

--- a/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
@@ -33,7 +33,7 @@ const RadioLabel = styled(Label)`
   padding: 5px 0;
   text-transform: none;
 
-  &:hover .radio-fill:before {
+  &:hover .es-radio__fill:before {
     ${props => radioFill(props.hoverFillColor)};
   }
 `;
@@ -42,7 +42,7 @@ const RadioInput = styled.input`
   opacity: 0;
   position: absolute;
 
-  &:focus ~ .radio-fill {
+  &:focus ~ .es-radio__fill {
     box-shadow: 0 0 3px 3px ${props => props.theme.colors.inputFocus};
   }
 `;
@@ -99,7 +99,7 @@ export function RadioButton({
 
   return (
     <ThemeProvider theme={theme}>
-      <RadioLabel {...labelProps}>
+      <RadioLabel className="es-radio" {...labelProps}>
         <RadioInput
           type="radio"
           name={name}
@@ -110,11 +110,13 @@ export function RadioButton({
           {...radioProps}
         />
         <RadioDisplay
-          className="radio-fill"
+          className="es-radio__fill"
           borderColor={fill}
           fill={radioDisplayFill}
         />
-        <RadioText aria-hidden={ariaHide}>{optionText}</RadioText>
+        <RadioText className="es-radio__text" aria-hidden={ariaHide}>
+          {optionText}
+        </RadioText>
       </RadioLabel>
     </ThemeProvider>
   );

--- a/packages/es-components/src/components/controls/radio-buttons/__snapshots__/RadioButton.specs.js.snap
+++ b/packages/es-components/src/components/controls/radio-buttons/__snapshots__/RadioButton.specs.js.snap
@@ -3,12 +3,12 @@
 exports[`RadioButton component renders as expected 1`] = `
 <label
   checked={false}
-  className="sc-bwzfXH kVIXAD sc-bdVaJa jBoKPV"
+  className="es-radio sc-bwzfXH iRbUYb sc-bdVaJa jBoKPV"
   disabled={false}
   htmlFor="test"
 >
   <input
-    className="sc-htpNat jeuMMj"
+    className="sc-htpNat kOMTgB"
     disabled={false}
     id="test"
     name="rad"
@@ -17,12 +17,12 @@ exports[`RadioButton component renders as expected 1`] = `
     value={undefined}
   />
   <span
-    className="radio-fill sc-ifAKCX fnveVG"
+    className="es-radio__fill sc-ifAKCX fnveVG"
     fill="#fff"
   />
   <span
     aria-hidden={undefined}
-    className="sc-bxivhb bRNnnP"
+    className="es-radio__text sc-bxivhb bRNnnP"
   >
     test
   </span>

--- a/packages/es-components/src/components/controls/radio-buttons/__snapshots__/RadioGroup.specs.js.snap
+++ b/packages/es-components/src/components/controls/radio-buttons/__snapshots__/RadioGroup.specs.js.snap
@@ -2,9 +2,8 @@
 
 exports[`RadioGroup component renders as expected 1`] = `
 <fieldset
-  className="sc-bZQynM dSZIHB"
+  className="es-fieldset sc-bZQynM dSZIHB"
 >
-  <div />
   <label
     checked={false}
     className="sc-bwzfXH kVIXAD sc-bdVaJa jBoKPV"
@@ -88,15 +87,13 @@ exports[`RadioGroup component renders as expected 1`] = `
 
 exports[`RadioGroup component renders as expected with legend text 1`] = `
 <fieldset
-  className="sc-bZQynM dSZIHB"
+  className="es-fieldset sc-bZQynM dSZIHB"
 >
-  <div>
-    <legend
-      className="sc-EHOje iSPUDq"
-    >
-      Test legend
-    </legend>
-  </div>
+  <legend
+    className="es-fieldset__legend sc-EHOje iSPUDq"
+  >
+    Test legend
+  </legend>
   <label
     checked={false}
     className="sc-bwzfXH kVIXAD sc-bdVaJa jBoKPV"

--- a/packages/es-components/src/components/controls/radio-buttons/__snapshots__/RadioGroup.specs.js.snap
+++ b/packages/es-components/src/components/controls/radio-buttons/__snapshots__/RadioGroup.specs.js.snap
@@ -6,12 +6,12 @@ exports[`RadioGroup component renders as expected 1`] = `
 >
   <label
     checked={false}
-    className="sc-bwzfXH kVIXAD sc-bdVaJa jBoKPV"
+    className="es-radio sc-bwzfXH iRbUYb sc-bdVaJa jBoKPV"
     disabled={false}
     htmlFor="test-option-1"
   >
     <input
-      className="sc-htpNat jeuMMj"
+      className="sc-htpNat kOMTgB"
       disabled={false}
       id="test-option-1"
       name="test"
@@ -20,24 +20,24 @@ exports[`RadioGroup component renders as expected 1`] = `
       value={0}
     />
     <span
-      className="radio-fill sc-ifAKCX fnveVG"
+      className="es-radio__fill sc-ifAKCX fnveVG"
       fill="#fff"
     />
     <span
       aria-hidden={false}
-      className="sc-bxivhb bRNnnP"
+      className="es-radio__text sc-bxivhb bRNnnP"
     >
       Option 0
     </span>
   </label>
   <label
     checked={false}
-    className="sc-bwzfXH kVIXAD sc-bdVaJa jBoKPV"
+    className="es-radio sc-bwzfXH iRbUYb sc-bdVaJa jBoKPV"
     disabled={false}
     htmlFor="test-option-2"
   >
     <input
-      className="sc-htpNat jeuMMj"
+      className="sc-htpNat kOMTgB"
       disabled={false}
       id="test-option-2"
       name="test"
@@ -46,24 +46,24 @@ exports[`RadioGroup component renders as expected 1`] = `
       value={1}
     />
     <span
-      className="radio-fill sc-ifAKCX fnveVG"
+      className="es-radio__fill sc-ifAKCX fnveVG"
       fill="#fff"
     />
     <span
       aria-hidden={false}
-      className="sc-bxivhb bRNnnP"
+      className="es-radio__text sc-bxivhb bRNnnP"
     >
       Option 1
     </span>
   </label>
   <label
     checked={false}
-    className="sc-bwzfXH kVIXAD sc-bdVaJa jBoKPV"
+    className="es-radio sc-bwzfXH iRbUYb sc-bdVaJa jBoKPV"
     disabled={false}
     htmlFor="test-option-3"
   >
     <input
-      className="sc-htpNat jeuMMj"
+      className="sc-htpNat kOMTgB"
       disabled={false}
       id="test-option-3"
       name="test"
@@ -72,12 +72,12 @@ exports[`RadioGroup component renders as expected 1`] = `
       value={2}
     />
     <span
-      className="radio-fill sc-ifAKCX fnveVG"
+      className="es-radio__fill sc-ifAKCX fnveVG"
       fill="#fff"
     />
     <span
       aria-hidden={false}
-      className="sc-bxivhb bRNnnP"
+      className="es-radio__text sc-bxivhb bRNnnP"
     >
       Option 2
     </span>
@@ -96,12 +96,12 @@ exports[`RadioGroup component renders as expected with legend text 1`] = `
   </legend>
   <label
     checked={false}
-    className="sc-bwzfXH kVIXAD sc-bdVaJa jBoKPV"
+    className="es-radio sc-bwzfXH iRbUYb sc-bdVaJa jBoKPV"
     disabled={false}
     htmlFor="test-option-1"
   >
     <input
-      className="sc-htpNat jeuMMj"
+      className="sc-htpNat kOMTgB"
       disabled={false}
       id="test-option-1"
       name="test"
@@ -110,24 +110,24 @@ exports[`RadioGroup component renders as expected with legend text 1`] = `
       value={0}
     />
     <span
-      className="radio-fill sc-ifAKCX fnveVG"
+      className="es-radio__fill sc-ifAKCX fnveVG"
       fill="#fff"
     />
     <span
       aria-hidden={false}
-      className="sc-bxivhb bRNnnP"
+      className="es-radio__text sc-bxivhb bRNnnP"
     >
       Option 0
     </span>
   </label>
   <label
     checked={false}
-    className="sc-bwzfXH kVIXAD sc-bdVaJa jBoKPV"
+    className="es-radio sc-bwzfXH iRbUYb sc-bdVaJa jBoKPV"
     disabled={false}
     htmlFor="test-option-2"
   >
     <input
-      className="sc-htpNat jeuMMj"
+      className="sc-htpNat kOMTgB"
       disabled={false}
       id="test-option-2"
       name="test"
@@ -136,24 +136,24 @@ exports[`RadioGroup component renders as expected with legend text 1`] = `
       value={1}
     />
     <span
-      className="radio-fill sc-ifAKCX fnveVG"
+      className="es-radio__fill sc-ifAKCX fnveVG"
       fill="#fff"
     />
     <span
       aria-hidden={false}
-      className="sc-bxivhb bRNnnP"
+      className="es-radio__text sc-bxivhb bRNnnP"
     >
       Option 1
     </span>
   </label>
   <label
     checked={false}
-    className="sc-bwzfXH kVIXAD sc-bdVaJa jBoKPV"
+    className="es-radio sc-bwzfXH iRbUYb sc-bdVaJa jBoKPV"
     disabled={false}
     htmlFor="test-option-3"
   >
     <input
-      className="sc-htpNat jeuMMj"
+      className="sc-htpNat kOMTgB"
       disabled={false}
       id="test-option-3"
       name="test"
@@ -162,12 +162,12 @@ exports[`RadioGroup component renders as expected with legend text 1`] = `
       value={2}
     />
     <span
-      className="radio-fill sc-ifAKCX fnveVG"
+      className="es-radio__fill sc-ifAKCX fnveVG"
       fill="#fff"
     />
     <span
       aria-hidden={false}
-      className="sc-bxivhb bRNnnP"
+      className="es-radio__text sc-bxivhb bRNnnP"
     >
       Option 2
     </span>

--- a/packages/es-components/src/components/controls/textbox/Textbox.js
+++ b/packages/es-components/src/components/controls/textbox/Textbox.js
@@ -4,6 +4,7 @@ import styled, { css, ThemeProvider, withTheme } from 'styled-components';
 import { noop, omit } from 'lodash';
 import viaTheme from 'es-components-via-theme';
 import MaskedInput from 'react-text-mask';
+import classnames from 'classnames';
 
 import Icon from '../../base/icons/Icon';
 import { LabelText, InputBase } from '../BaseControls';
@@ -99,6 +100,7 @@ const Textbox = props => {
     theme,
     ...additionalTextProps
   } = props;
+  const { className, ...otherProps } = additionalTextProps;
   const inputName = name || labelText.replace(/\s+/g, '');
   const textboxId = id !== undefined ? id : `for-${inputName}`;
   const hasHelpContent = additionalHelpContent !== undefined;
@@ -108,6 +110,7 @@ const Textbox = props => {
       {additionalHelpContent}
     </AdditionalHelpContent>
   );
+  const classNameState = `es-textbox__input--${validationState}`;
 
   const hasPrepend = prependIconName !== undefined;
   const hasAppend = appendIconName !== undefined;
@@ -123,15 +126,19 @@ const Textbox = props => {
   return (
     <ThemeProvider theme={theme}>
       <TextBoxLabel
+        className={classnames('es-textbox', className)}
         htmlFor={textboxId}
         color={theme.validationTextColor[validationState]}
         inline={inline}
       >
-        <LabelText inline={inline}>{labelText}</LabelText>
-        <InputWrapper>
+        <LabelText className="es-textbox__label" inline={inline}>
+          {labelText}
+        </LabelText>
+        <InputWrapper className="es-textbox__wrapper">
           {hasPrepend && <Prepend name={prependIconName} size={20} />}
           <Input
             aria-describedby={helpId}
+            className={classNameState}
             hasPrepend={hasPrepend}
             id={textboxId}
             innerRef={inputRef}
@@ -142,7 +149,7 @@ const Textbox = props => {
             type="text"
             value={value}
             {...maskArgs}
-            {...additionalTextProps}
+            {...otherProps}
             {...theme.validationInputColor[validationState]}
           />
           {(hasAppend || hasValidationIcon) && (

--- a/packages/es-components/src/components/navigation/breadcrumb/Breadcrumb.js
+++ b/packages/es-components/src/components/navigation/breadcrumb/Breadcrumb.js
@@ -61,7 +61,7 @@ const Crumb = styled.li`
 function Breadcrumb({ children, ...props }) {
   return (
     <ThemeProvider theme={props.theme}>
-      <OrderedList {...props}>
+      <OrderedList {...props} className="es-breadcrumb">
         {React.Children.map(children, child => (
           <Crumb key={genId()}>{child}</Crumb>
         ))}

--- a/packages/es-components/src/components/navigation/breadcrumb/__snapshots__/Breadcrumb.specs.js.snap
+++ b/packages/es-components/src/components/navigation/breadcrumb/__snapshots__/Breadcrumb.specs.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BreadcrumbTestSuite renders as expected 1`] = `
 <ol
-  className="test sc-bdVaJa doUOMs"
+  className="es-breadcrumb sc-bdVaJa doUOMs"
 >
   <li
     className="sc-bwzfXH jyqTmE"

--- a/packages/es-components/src/components/navigation/sidenav/NavItem.js
+++ b/packages/es-components/src/components/navigation/sidenav/NavItem.js
@@ -17,7 +17,6 @@ const AnchorBase = styled.a`
 
   > i {
     color: ${props => props.theme.colors.white};
-    line-height: ${props => props.theme.sizes.baseLineHeight};
   }
 
   &:hover {
@@ -143,7 +142,7 @@ const NavItem = props => {
   };
 
   return (
-    <li>
+    <li className="es-sidenav__navitem">
       <AnchorStyled {...itemProps}>
         <FlexSpan>{children}</FlexSpan>
         <Icon name="chevron-right" />

--- a/packages/es-components/src/components/navigation/sidenav/SideNav.js
+++ b/packages/es-components/src/components/navigation/sidenav/SideNav.js
@@ -27,7 +27,7 @@ export const SideNav = props => {
 
   return (
     <ThemeProvider theme={theme}>
-      <NavStyled>
+      <NavStyled className="es-sidenav">
         <ul>
           {Children.toArray(children).map(child => {
             if (child !== null && child.type === NavItem) {

--- a/packages/es-components/src/components/navigation/sidenav/SideNav.md
+++ b/packages/es-components/src/components/navigation/sidenav/SideNav.md
@@ -44,7 +44,7 @@ class NavExample extends React.Component {
         <SideNav selected={ this.state.selected } onItemSelected={ this.onItemSelected }>
           <SideNav.Item id="home"><Icon name="home" /> Home</SideNav.Item>
           <SideNav.Item id="cart"><Icon name="shopping-cart" /> Cart</SideNav.Item>
-          <SideNav.Item id="disabled" isDisabled><Icon name="ban-circle" /> Disabled</SideNav.Item>
+          <SideNav.Item id="disabled" isDisabled><Icon name="no-symbol" /> Disabled</SideNav.Item>
         </SideNav>
       </div>
     )

--- a/packages/es-components/src/components/navigation/sidenav/__snapshots__/SideNav.specs.js.snap
+++ b/packages/es-components/src/components/navigation/sidenav/__snapshots__/SideNav.specs.js.snap
@@ -18,7 +18,7 @@ exports[`drawer renders as expected 1`] = `
         </span>
         <i
           aria-hidden={true}
-          className="sc-bdVaJa clAcVq"
+          className="es-icon sc-bdVaJa clAcVq"
           content="61f"
           fontFamily="indv-mkt-icons"
           fontSize="inherit"
@@ -38,7 +38,7 @@ exports[`drawer renders as expected 1`] = `
         </span>
         <i
           aria-hidden={true}
-          className="sc-bdVaJa clAcVq"
+          className="es-icon sc-bdVaJa clAcVq"
           content="61f"
           fontFamily="indv-mkt-icons"
           fontSize="inherit"
@@ -59,7 +59,7 @@ exports[`drawer renders as expected 1`] = `
         </span>
         <i
           aria-hidden={true}
-          className="sc-bdVaJa clAcVq"
+          className="es-icon sc-bdVaJa clAcVq"
           content="61f"
           fontFamily="indv-mkt-icons"
           fontSize="inherit"
@@ -79,7 +79,7 @@ exports[`drawer renders as expected 1`] = `
         </span>
         <i
           aria-hidden={true}
-          className="sc-bdVaJa clAcVq"
+          className="es-icon sc-bdVaJa clAcVq"
           content="61f"
           fontFamily="indv-mkt-icons"
           fontSize="inherit"

--- a/packages/es-components/src/components/navigation/sidenav/__snapshots__/SideNav.specs.js.snap
+++ b/packages/es-components/src/components/navigation/sidenav/__snapshots__/SideNav.specs.js.snap
@@ -2,12 +2,14 @@
 
 exports[`drawer renders as expected 1`] = `
 <nav
-  className="sc-ifAKCX kXLRTf"
+  className="es-sidenav sc-ifAKCX kXLRTf"
 >
   <ul>
-    <li>
+    <li
+      className="es-sidenav__navitem"
+    >
       <a
-        className="home sc-bwzfXH gWurLg"
+        className="home sc-bwzfXH igXrdK"
         href="/home"
         onClick={[Function]}
       >
@@ -25,9 +27,11 @@ exports[`drawer renders as expected 1`] = `
         />
       </a>
     </li>
-    <li>
+    <li
+      className="es-sidenav__navitem"
+    >
       <a
-        className="cart sc-bwzfXH gWurLg"
+        className="cart sc-bwzfXH igXrdK"
         href="#/"
         onClick={[Function]}
       >
@@ -45,9 +49,11 @@ exports[`drawer renders as expected 1`] = `
         />
       </a>
     </li>
-    <li>
+    <li
+      className="es-sidenav__navitem"
+    >
       <a
-        className="external sc-bwzfXH gWurLg"
+        className="external sc-bwzfXH igXrdK"
         href="http://www.google.com"
         onClick={[Function]}
         target="_blank"
@@ -66,9 +72,11 @@ exports[`drawer renders as expected 1`] = `
         />
       </a>
     </li>
-    <li>
+    <li
+      className="es-sidenav__navitem"
+    >
       <a
-        className="info sc-bwzfXH jFlIWF"
+        className="info sc-bwzfXH hJluX"
         href="#/"
         onClick={[Function]}
       >


### PR DESCRIPTION
These changes primarily consist of adding "es-[component]" class names to most components. These should help with some testing tools and just getting some consistent identifiers on some elements as handles. This PR should be backward compatibile.

Some extra things were done:
1) classnames (npm package) added to some components that were accepting either `className` as a prop or some other prop that passed in classes. In some cases these were pulled out of "packed" props into their own var and combined using classnames() so they didn't override other classes inadvertently. 

2) Menu seemed to be missing the `header` prop, which was used in both the docs and the tests. `headerContent` prop was added and will display at the top of the menu.

3) Added close on Esc key to menu for when a backdrop is not used.

4) Fixed a broken icon in the Sidenav docs example.