### PR TITLE
Updates to Tooltips and tweaks for popover performance

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "15.2.1"
+  "version": "15.3.0"
 }

--- a/packages/es-components-via-theme/package.json
+++ b/packages/es-components-via-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components-via-theme",
-  "version": "15.2.1",
+  "version": "15.3.0",
   "main": "index.js",
   "author": "Willis Towers Watson - Individual Marketplace",
   "license": "MIT"

--- a/packages/es-components-wtw-theme/package.json
+++ b/packages/es-components-wtw-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components-wtw-theme",
-  "version": "15.2.1",
+  "version": "15.3.0",
   "main": "index.js",
   "author": "Willis Towers Watson - Individual Marketplace",
   "license": "MIT"

--- a/packages/es-components/package-lock.json
+++ b/packages/es-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components",
-  "version": "15.0.0",
+  "version": "15.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components",
-  "version": "15.2.1",
+  "version": "15.3.0",
   "description": "React components built for Exchange Solutions products",
   "repository": "https://github.com/wtw-im/es-components",
   "main": "lib/index.js",

--- a/packages/es-components/src/components/containers/popover/Popover.js
+++ b/packages/es-components/src/components/containers/popover/Popover.js
@@ -3,7 +3,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { ThemeProvider } from 'styled-components';
-import { findDOMNode } from 'react-dom';
 import viaTheme from 'es-components-via-theme';
 
 import Icon from '../../base/icons/Icon';
@@ -29,60 +28,60 @@ const TriggerButton = styled(Button)`
 `;
 
 const TriggerButtonLabel = styled.span`
+  display: block;
   font-size: 0;
   height: 1px;
   overflow: hidden;
-  display: block;
 `;
 
 const PopoverContainer = styled.div`
-  min-width: 270px;
-  max-width: 400px;
   background: ${props => props.theme.colors.white};
   border: 1px solid rgba(0, 0, 0, 0.2);
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  max-width: 400px;
+  min-width: 270px;
 `;
 
 const PopoverHeader = styled.div`
-  display: flex;
-  justify-content: space-between;
-  color: ${props => props.theme.colors.white};
   background-color: ${props =>
     props.hasTitle ? props.theme.colors.popoverHeader : 'none'};
-  outline: none;
+  color: ${props => props.theme.colors.white};
+  display: flex;
+  justify-content: space-between;
   line-height: ${props => props.theme.sizes.baseLineHeight};
+  outline: none;
 `;
 
 const TitleBar = styled.h3`
   font-size: 18px;
-  padding: 8px 14px;
   margin: 0;
+  padding: 8px 14px;
 `;
 
 const PopoverBody = styled.div`
+  color: ${props => props.theme.colors.gray8};
+  font-size: 18px;
+  font-weight: normal;
+  line-height: ${props => props.theme.sizes.baseLineHeight};
   padding: ${props =>
     props.hasAltCloseWithNoTitle ? '0 14px 8px' : '8px 14px'};
   text-align: right;
-  color: ${props => props.theme.colors.gray8};
-  line-height: ${props => props.theme.sizes.baseLineHeight};
-  font-size: 18px;
-  font-weight: normal;
 `;
 
 const PopoverContent = styled.div`
-  text-align: left;
   margin-bottom: ${props => (props.showCloseButton ? '8px' : '0')};
+  text-align: left;
 `;
 
 const AlternateCloseButton = styled(Button)`
+  background: transparent;
+  border: none;
+  box-shadow: none;
   color: ${props =>
     props.hasTitle ? props.theme.colors.white : props.theme.colors.grayDark};
   margin: 0;
   margin-left: auto;
   padding: 0 8px;
-  background: transparent;
-  border: none;
-  box-shadow: none;
 
   &:hover {
     background: transparent;
@@ -90,9 +89,9 @@ const AlternateCloseButton = styled(Button)`
 `;
 
 const CloseHelpText = styled.span`
+  color: transparent;
   height: 1px;
   width: 1px;
-  color: transparent;
 `;
 
 class Popover extends React.Component {
@@ -100,13 +99,6 @@ class Popover extends React.Component {
     isOpen: false
   };
 
-  componentDidMount() {
-    this.header = findDOMNode(this.headerRef);
-    this.popoverContent = findDOMNode(this.contentRef);
-    this.closeBtn = findDOMNode(this.closeBtnRef);
-    this.triggerBtn = findDOMNode(this.triggerBtnRef);
-    this.popper = findDOMNode(this.popperRef);
-  }
   componentDidUpdate() {
     if (this.state.isOpen) {
       window.addEventListener('scroll', this.hidePopOnScroll);
@@ -117,16 +109,17 @@ class Popover extends React.Component {
 
   toggleShow = () => {
     setTimeout(() => {
-      const focusableContent = this.popoverContent.querySelector('a, button');
-      if (focusableContent) {
-        focusableContent.focus();
-      } else {
-        this.header.focus();
+      if (this.contentRef) {
+        const focusableContent = this.contentRef.querySelector('a, button');
+        if (focusableContent) {
+          focusableContent.focus();
+        } else {
+          this.headerRef.focus();
+        }
       }
     }, 200);
-
-    if (this.closeBtn) {
-      this.triggerBtn.focus();
+    if (this.closeBtnRef) {
+      this.triggerBtnRef.focus();
     }
 
     this.setState(({ isOpen }) => ({ isOpen: !isOpen }));
@@ -135,7 +128,7 @@ class Popover extends React.Component {
   hidePopover = event => {
     if (this.state.isOpen) {
       if (event.type !== 'click') {
-        this.triggerBtn.focus();
+        this.triggerBtnRef.focus();
       }
       this.setState({ isOpen: false });
     }
@@ -143,18 +136,20 @@ class Popover extends React.Component {
 
   hidePopOnScroll = () => {
     setInterval(() => {
-      const bounds = this.popper.getBoundingClientRect();
-      const inViewport =
-        bounds.top >= 90 &&
-        bounds.left >= 0 &&
-        bounds.right <=
-          (window.innerWidth || document.documentElement.clientWidth) &&
-        bounds.bottom <=
-          (window.innerHeight || document.documentElement.clientHeight);
+      if (this.popperRef) {
+        const bounds = this.popperRef.getBoundingClientRect();
+        const inViewport =
+          bounds.top >= 90 &&
+          bounds.left >= 0 &&
+          bounds.right <=
+            (window.innerWidth || document.documentElement.clientWidth) &&
+          bounds.bottom <=
+            (window.innerHeight || document.documentElement.clientHeight);
 
-      if (!inViewport && this.state.isOpen) {
-        this.triggerBtn.focus();
-        this.setState({ isOpen: false });
+        if (!inViewport && this.state.isOpen) {
+          this.triggerBtnRef.focus();
+          this.setState({ isOpen: false });
+        }
       }
     }, 100);
   };
@@ -187,7 +182,7 @@ class Popover extends React.Component {
     const closeButton = (
       <Button
         handleOnClick={this.toggleShow}
-        ref={btn => {
+        innerRef={btn => {
           this.closeBtnRef = btn;
         }}
       >
@@ -199,7 +194,7 @@ class Popover extends React.Component {
         aria-label="Close"
         hasTitle={hasTitle}
         handleOnClick={this.toggleShow}
-        ref={btn => {
+        innerRef={btn => {
           this.closeBtnRef = btn;
         }}
       >
@@ -215,7 +210,7 @@ class Popover extends React.Component {
         isLinkButton={isLinkButton}
         suppressUnderline={suppressUnderline}
         buttonBorderStyle={buttonBorderStyle}
-        ref={btn => {
+        innerRef={btn => {
           this.triggerBtnRef = btn;
         }}
         aria-expanded={this.state.isOpen}
@@ -246,7 +241,7 @@ class Popover extends React.Component {
             <PopoverContainer
               className="es-popover__container"
               role="dialog"
-              ref={elem => {
+              innerRef={elem => {
                 this.contentRef = elem;
               }}
             >
@@ -255,7 +250,7 @@ class Popover extends React.Component {
                 {hasAltCloseButton && altCloseButton}
                 <CloseHelpText
                   tabIndex={-1}
-                  ref={elem => {
+                  innerRef={elem => {
                     this.headerRef = elem;
                   }}
                   aria-label="Press escape to close the Popover"

--- a/packages/es-components/src/components/containers/popover/Popover.js
+++ b/packages/es-components/src/components/containers/popover/Popover.js
@@ -237,7 +237,7 @@ class Popover extends React.Component {
           <PopoverContainer
             className="es-popover__container"
             role="dialog"
-            ref={elem => {
+            innerRef={elem => {
               this.contentRef = elem;
             }}
           >
@@ -246,7 +246,7 @@ class Popover extends React.Component {
               {hasAltCloseButton && altCloseButton}
               <CloseHelpText
                 tabIndex={-1}
-                ref={elem => {
+                innerRef={elem => {
                   this.headerRef = elem;
                 }}
                 aria-label="Press escape to close the Popover"

--- a/packages/es-components/src/components/containers/popover/Popover.md
+++ b/packages/es-components/src/components/containers/popover/Popover.md
@@ -47,6 +47,7 @@ const styles = {
         Popover on Right
     </Popover>
     </div>
+    
 </div>
 ```
 

--- a/packages/es-components/src/components/containers/popover/Popover.specs.js
+++ b/packages/es-components/src/components/containers/popover/Popover.specs.js
@@ -36,6 +36,7 @@ describe('popover component', () => {
     expect(instance.find(Button).length).toBe(1);
 
     instance.setProps({ hasCloseButton: true });
+    instance.find(Button).simulate('click');
 
     expect(instance.find(Button).length).toBe(2);
   });
@@ -45,6 +46,7 @@ describe('popover component', () => {
     expect(instance.find(Icon).length).toBe(0);
 
     instance.setProps({ hasAltCloseButton: true });
+    instance.find(Button).simulate('click');
 
     expect(instance.find(Icon).length).toBe(1);
   });

--- a/packages/es-components/src/components/containers/popover/Popup.js
+++ b/packages/es-components/src/components/containers/popover/Popup.js
@@ -1,16 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled, { injectGlobal } from 'styled-components';
+import { injectGlobal } from 'styled-components';
 
 import popoverStyles from './popoverStyles';
 
 import { Manager, Target, Popper, Arrow } from 'react-popper';
 import Transition from 'react-transition-group/Transition';
 import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
-
-const PopperContainer = styled.div`
-  display: ${props => (props.transitionState === 'exited' ? 'none' : 'block')};
-`;
 
 const defaultStyle = {
   transition: 'opacity 0.2s ease-in-out',
@@ -63,27 +59,34 @@ function Popup({
   let popperObj = (
     <Manager>
       <Target>{trigger}</Target>
-      <Transition in={transitionIn} timeout={transitionTimeout}>
+      <Transition
+        in={transitionIn}
+        timeout={transitionTimeout}
+        mountOnEnter
+        unmountOnExit
+      >
         {state => (
-          <PopperContainer transitionState={state} name={name} ref={popperRef}>
-            <Popper
-              className={`${name}-popper`}
-              placement={placement}
-              eventsEnabled={transitionIn}
-              modifiers={{
-                preventOverflow: { boundariesElement: 'viewport' },
-                hide: { enabled: true },
-                flip: { enabled: !disableFlipping }
-              }}
-              style={{
-                ...defaultStyle,
-                ...transitionStyles[state]
-              }}
-            >
-              {children}
-              <Arrow className={`${name}-popper__arrow`} />
-            </Popper>
-          </PopperContainer>
+          <Popper
+            className={`${name}-popper`}
+            placement={placement}
+            eventsEnabled={transitionIn}
+            modifiers={{
+              preventOverflow: { boundariesElement: document.body },
+              hide: { enabled: true },
+              flip: {
+                enabled: !disableFlipping,
+                behavior: ['left', 'right', 'top', 'bottom']
+              }
+            }}
+            style={{
+              ...defaultStyle,
+              ...transitionStyles[state]
+            }}
+            innerRef={popperRef}
+          >
+            {children}
+            <Arrow className={`${name}-popper__arrow`} />
+          </Popper>
         )}
       </Transition>
     </Manager>

--- a/packages/es-components/src/components/containers/popover/__snapshots__/Popover.specs.js.snap
+++ b/packages/es-components/src/components/containers/popover/__snapshots__/Popover.specs.js.snap
@@ -2,13 +2,13 @@
 
 exports[`popover component renders as expected 1`] = `
 <div
-  className="es-popover sc-bZQynM dSsQJY"
+  className="es-popover sc-EHOje iOWvOn"
 >
   <div>
     <div>
       <button
         aria-expanded={false}
-        className="es-button es-button--default sc-gzVnrw iIXTKM sc-htpNat cJWpVN sc-bwzfXH jWFaYU"
+        className="es-button es-button--default sc-bZQynM cJNYqi sc-htpNat cJWpVN sc-bwzfXH jWFaYU"
         onClick={[Function]}
       >
         <span
@@ -17,61 +17,9 @@ exports[`popover component renders as expected 1`] = `
           Popover Text
         </span>
         <span
-          className="sc-htoDjs iqIjis"
+          className="sc-gzVnrw hEsVHA"
         />
       </button>
-    </div>
-    <div
-      className="sc-EHOje vChbq"
-      name="popTest"
-    >
-      <div
-        className="popTest-popper"
-        data-placement={undefined}
-        data-x-out-of-boundaries={undefined}
-        style={
-          Object {
-            "opacity": 0,
-            "pointerEvents": "none",
-            "position": "absolute",
-            "transition": "opacity 0.2s ease-in-out",
-            "zIndex": 5,
-          }
-        }
-      >
-        <div
-          className="es-popover__container sc-dnqmqq BnNnH"
-          role="dialog"
-        >
-          <div
-            className="es-popover__header sc-iwsKbI cirLJO"
-          >
-            <h3
-              className="sc-gZMcBi cPBpHt"
-            >
-              Popover Title
-            </h3>
-            <span
-              aria-label="Press escape to close the Popover"
-              className="sc-fjdhpX dYNDTL"
-              tabIndex={-1}
-            />
-          </div>
-          <div
-            className="es-popover__body sc-gqjmRU eiaKpk"
-          >
-            <div
-              className="es-popover__content sc-VigVT cztEQg"
-            >
-              This is the popover content.
-            </div>
-          </div>
-        </div>
-        <span
-          className="popTest-popper__arrow"
-          style={Object {}}
-        />
-      </div>
     </div>
   </div>
 </div>

--- a/packages/es-components/src/components/containers/popover/popoverStyles.js
+++ b/packages/es-components/src/components/containers/popover/popoverStyles.js
@@ -16,10 +16,6 @@ export default function arrowStyles(name, colors, arrowSize, hasTitle) {
             position: absolute;
         }
 
-        .${name}-popper[data-x-out-of-boundaries] {
-            display: none;
-          }
-
         .${name}-popper[data-placement^="top"] .${name}-popper__arrow {
             border-color: transparent;
             border-width: ${arrowSize}px;

--- a/packages/es-components/src/components/containers/tooltip/Tooltip.js
+++ b/packages/es-components/src/components/containers/tooltip/Tooltip.js
@@ -202,7 +202,12 @@ Tooltip.propTypes = {
   /** Set the position of the tooltip over the content */
   position: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
   /** Disables the default show onHover functionality */
-  disableHover: PropTypes.bool
+  disableHover: PropTypes.bool,
+  /**
+   * Theme object used by the ThemeProvider,
+   * automatically passed by any parent component using a ThemeProvider
+   */
+  theme: PropTypes.object
 };
 
 Tooltip.defaultProps = {

--- a/packages/es-components/src/components/containers/tooltip/Tooltip.js
+++ b/packages/es-components/src/components/containers/tooltip/Tooltip.js
@@ -6,19 +6,21 @@ import classnames from 'classnames';
 
 import Fade from '../../util/Fade';
 
+import Button from '../../controls/buttons/Button';
+
 const TooltipBase = styled.div`
   position: absolute;
 `;
 
 const TooltipInner = styled.div`
-  background-color: ${props => props.theme.colors.black};
+  background-color: ${props => props.theme.colors.info};
   border-radius: 2px;
   color: ${props => props.theme.colors.white};
   font-size: 15px;
   line-height: ${props => props.theme.sizes.baseLineHeight};
-  max-width: 200px;
+  max-width: 300px;
   padding: 3px 8px;
-  text-align: center;
+  text-align: left;
 `;
 
 const TooltipArrowBase = styled.div`
@@ -50,7 +52,7 @@ const TooltipLeft = styled(TooltipBase)`
 `;
 
 const TooltipArrowTop = styled(TooltipArrowBase)`
-  border-top-color: ${props => props.theme.colors.black};
+  border-top-color: ${props => props.theme.colors.info};
   border-width: 5px 5px 0;
   bottom: 0;
   left: 50%;
@@ -58,7 +60,7 @@ const TooltipArrowTop = styled(TooltipArrowBase)`
 `;
 
 const TooltipArrowRight = styled(TooltipArrowBase)`
-  border-right-color: ${props => props.theme.colors.black};
+  border-right-color: ${props => props.theme.colors.info};
   border-width: 5px 5px 5px 0;
   left: 0;
   margin-top: -5px;
@@ -66,7 +68,7 @@ const TooltipArrowRight = styled(TooltipArrowBase)`
 `;
 
 const TooltipArrowBottom = styled(TooltipArrowBase)`
-  border-bottom-color: ${props => props.theme.colors.black};
+  border-bottom-color: ${props => props.theme.colors.info};
   border-width: 0 5px 5px;
   left: 50%;
   margin-left: -5px;
@@ -74,19 +76,29 @@ const TooltipArrowBottom = styled(TooltipArrowBase)`
 `;
 
 const TooltipArrowLeft = styled(TooltipArrowBase)`
-  border-left-color: ${props => props.theme.colors.black};
+  border-left-color: ${props => props.theme.colors.info};
   border-width: 5px 0 5px 5px;
   margin-top: -5px;
   right: 0;
   top: 50%;
 `;
 
+const StyledButton = styled(Button)`
+  padding-bottom: 3px;
+  color: ${props => props.theme.colors.primary};
+
+  &:hover {
+    color: ${props => props.theme.colors.primary};
+    text-decoration: none;
+  }
+`;
+
 const FadeTransition = props => (
-  <Fade duration={200} opacity={0.9} withWrapper {...props} />
+  <Fade duration={200} opacity={1} withWrapper {...props} />
 );
 
 const Popup = props => {
-  const { className, children, position, style } = props;
+  const { name, className, children, position, style } = props;
   let TooltipStyled;
   let TooltipArrow;
 
@@ -113,6 +125,7 @@ const Popup = props => {
     <TooltipStyled
       role="tooltip"
       className={classnames('es-tooltip', className)}
+      id={`es-tooltip__${name}`}
       style={style}
     >
       <TooltipArrow />
@@ -122,6 +135,7 @@ const Popup = props => {
 };
 
 Popup.propTypes = {
+  name: PropTypes.string,
   children: PropTypes.any.isRequired,
   className: PropTypes.string,
   position: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
@@ -138,19 +152,31 @@ class Tooltip extends React.Component {
 
   hide = () => this.setState({ show: false });
 
+  closeOnEscape = event => {
+    if (event.keyCode === 27) {
+      this.setState({ show: false });
+    }
+  };
+
   render() {
     return (
       <span>
-        <span
+        <StyledButton
           className="es-tooltip__target"
           ref={span => {
             this.toolTipTarget = span;
           }}
-          onMouseEnter={this.show}
-          onMouseLeave={this.hide}
+          isLinkButton
+          onBlur={this.hide}
+          onFocus={this.show}
+          onMouseEnter={!this.props.disableHover ? this.show : undefined}
+          onMouseLeave={!this.props.disableHover ? this.hide : undefined}
+          handleOnClick={this.show}
+          onKeyDown={this.closeOnEscape}
+          aria-describedby={`es-tooltip__${this.props.name}`}
         >
           {this.props.children}
-        </span>
+        </StyledButton>
 
         <Overlay
           show={this.state.show}
@@ -159,7 +185,9 @@ class Tooltip extends React.Component {
           target={props => this.toolTipTarget}
           transition={FadeTransition}
         >
-          <Popup position={this.props.position}>{this.props.content}</Popup>
+          <Popup position={this.props.position} name={this.props.name}>
+            {this.props.content}
+          </Popup>
         </Overlay>
       </span>
     );
@@ -167,15 +195,19 @@ class Tooltip extends React.Component {
 }
 
 Tooltip.propTypes = {
+  name: PropTypes.string.isRequired,
   children: PropTypes.any.isRequired,
   /** The text the tooltip displays */
   content: PropTypes.node.isRequired,
   /** Set the position of the tooltip over the content */
-  position: PropTypes.oneOf(['top', 'right', 'bottom', 'left'])
+  position: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+  /** Disables the default show onHover functionality */
+  disableHover: PropTypes.bool
 };
 
 Tooltip.defaultProps = {
-  position: 'top'
+  position: 'top',
+  disableHover: false
 };
 
 export default Tooltip;

--- a/packages/es-components/src/components/containers/tooltip/Tooltip.md
+++ b/packages/es-components/src/components/containers/tooltip/Tooltip.md
@@ -2,10 +2,10 @@ Use a `Tooltip` component to display a small hover tip over content.
 
 ### Basic Tooltip:
 ```
-<div>Hover over <Tooltip content="This is the tooltip"><span style={{color: '#1727EE'}}>this text</span></Tooltip> to see the tooltip in action.</div>
+<div>Hover over <Tooltip name="tip1" content="This is the tooltip"><span>this text</span></Tooltip> to see the tooltip in action.</div>
 ```
 
 ### Tooltip with HTML:
 ```
-<div>Hover over <Tooltip content={<span>This contains <em>some</em> <strong>HTML</strong></span>} position="left"><span style={{color: '#1727EE'}}>this text</span></Tooltip> to see the tooltip in action.</div>
+<div>Hover over <Tooltip name="tip2" content={<span>This contains <em>some</em> <strong>HTML</strong></span>} position="left"><span>this text</span></Tooltip> to see the tooltip in action.</div>
 ```

--- a/packages/es-components/src/components/containers/tooltip/Tooltip.specs.js
+++ b/packages/es-components/src/components/containers/tooltip/Tooltip.specs.js
@@ -1,19 +1,18 @@
 /* eslint-env jest */
 
 import React from 'react';
-import renderer from 'react-test-renderer';
+// import renderer from 'react-test-renderer';
+import { renderWithTheme } from 'styled-enzyme';
 
 import Tooltip from './Tooltip';
 
 describe('tooltip component', () => {
   it('renders tooltip children', () => {
-    const tree = renderer
-      .create(
-        <Tooltip content="This is a tooltip">
-          This is the tooltip target.
-        </Tooltip>
-      )
-      .toJSON();
+    const tree = renderWithTheme(
+      <Tooltip name="test" content="This is a tooltip">
+        This is the tooltip target.
+      </Tooltip>
+    ).toJSON();
 
     expect(tree).toMatchSnapshot();
   });

--- a/packages/es-components/src/components/containers/tooltip/__snapshots__/Tooltip.specs.js.snap
+++ b/packages/es-components/src/components/containers/tooltip/__snapshots__/Tooltip.specs.js.snap
@@ -2,12 +2,17 @@
 
 exports[`tooltip component renders tooltip children 1`] = `
 <span>
-  <span
-    className="es-tooltip__target"
+  <button
+    aria-describedby="es-tooltip__test"
+    className="es-button es-button--link es-tooltip__target sc-fjdhpX fFtpZU sc-bxivhb iExzYH sc-bdVaJa kHkNOX"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
     This is the tooltip target.
-  </span>
+  </button>
 </span>
 `;


### PR DESCRIPTION
- Updates tooltips to be shown on click and makes the show on hover optional
- updates tooltip styling and accessibility

- changes popovers to use `react-transition-group`'s `mountOnEnter` and `unmountOnExit` because the amount of transitions occurring when there are a large number of popovers on a page causes a lot of slow down.
- minor fixes to popover positioning in mobile
- general cleanup