### PR TITLE
[WAIT] Float NPM Version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 node_js:
   - "lts/*"
   - "node"
-before_install:
-    - npm i -g npm@5.7.0
 script: npm run ci
 after_success: ./rebuild-docs.sh
 deploy:


### PR DESCRIPTION
Running `npm ci` using `npm@6.1.0` (the default version) against the latest node has been hanging in a couple of recent builds. The version has been temporarily dropped down to `5.7.0` to get builds going again.

Rerun the travis suite on this PR every now and then to check if the issue has been resolved. Once stable we can merge this and float the npm version again.