### PR TITLE
Custom Mask support for Textbox

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "15.1.0"
+  "version": "15.2.0"
 }

--- a/packages/es-components-via-theme/package.json
+++ b/packages/es-components-via-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components-via-theme",
-  "version": "15.1.0",
+  "version": "15.2.0",
   "main": "index.js",
   "author": "Willis Towers Watson - Individual Marketplace",
   "license": "MIT"

--- a/packages/es-components-wtw-theme/package.json
+++ b/packages/es-components-wtw-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components-wtw-theme",
-  "version": "15.1.0",
+  "version": "15.2.0",
   "main": "index.js",
   "author": "Willis Towers Watson - Individual Marketplace",
   "license": "MIT"

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components",
-  "version": "15.1.0",
+  "version": "15.2.0",
   "description": "React components built for Exchange Solutions products",
   "repository": "https://github.com/wtw-im/es-components",
   "main": "lib/index.js",

--- a/packages/es-components/src/components/controls/textbox/Textbox.js
+++ b/packages/es-components/src/components/controls/textbox/Textbox.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css, withTheme } from 'styled-components';
-import { noop, omit } from 'lodash';
+import { omit } from 'lodash';
 import MaskedInput from 'react-text-mask';
 import classnames from 'classnames';
 
@@ -85,19 +85,17 @@ const Textbox = props => {
     labelText,
     name,
     id,
-    value,
     inline,
     inputRef,
     additionalHelpContent,
     validationState,
     prependIconName,
     appendIconName,
-    onChange,
-    onBlur,
     maskType,
+    customMask,
     theme,
     className,
-    ...otherProps
+    ...additionalTextProps
   } = props;
   const inputName = name || labelText.replace(/\s+/g, '');
   const textboxId = id !== undefined ? id : `for-${inputName}`;
@@ -119,7 +117,10 @@ const Textbox = props => {
   if (hasValidationIcon) numAppendIconNames++;
 
   const Input = maskType === 'none' ? StyledText : StyledMask;
-  const maskArgs = inputMaskType[maskType];
+  const maskArgs =
+    maskType === 'custom' && customMask !== undefined
+      ? customMask
+      : inputMaskType[maskType];
 
   return (
     <TextBoxLabel
@@ -141,12 +142,9 @@ const Textbox = props => {
           innerRef={inputRef}
           name={inputName}
           numAppendIconNames={numAppendIconNames}
-          onBlur={onBlur}
-          onChange={onChange}
           type="text"
-          value={value}
           {...maskArgs}
-          {...otherProps}
+          {...additionalTextProps}
           {...theme.validationInputColor[validationState]}
         />
         {(hasAppend || hasValidationIcon) && (
@@ -176,10 +174,6 @@ Textbox.propTypes = {
   inputRef: PropTypes.func,
   /** Display label inline with text box */
   inline: PropTypes.bool,
-  /** Function to execute when text box value changes */
-  onChange: PropTypes.func,
-  /** Function to execute when text box loses focus */
-  onBlur: PropTypes.func,
   /** Content to display underneath the text box */
   additionalHelpContent: PropTypes.node,
   /** Display label and text with contextual state colorings */
@@ -190,8 +184,6 @@ Textbox.propTypes = {
   appendIconName: PropTypes.string,
   /** Set the initial value, uncontrolled mode */
   defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  /** Value of the textbox */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** Sets a mask type on the input */
   maskType: PropTypes.oneOf([
     'none',
@@ -199,8 +191,17 @@ Textbox.propTypes = {
     'dollar',
     'phone',
     'ssnum',
-    'zip'
+    'zip',
+    'custom'
   ]),
+  customMask: PropTypes.shape({
+    mask: PropTypes.oneOfType([PropTypes.array, PropTypes.func]).isRequired,
+    guide: PropTypes.bool,
+    placeholderChar: PropTypes.string,
+    keepCharPositions: PropTypes.bool,
+    pipe: PropTypes.func,
+    showMask: PropTypes.bool
+  }),
   /**
    * Theme object used by the ThemeProvider,
    * automatically passed by any parent component using a ThemeProvider
@@ -212,8 +213,6 @@ Textbox.propTypes = {
 Textbox.defaultProps = {
   inline: false,
   maskType: 'none',
-  onChange: noop,
-  onBlur: noop,
   validationState: 'default'
 };
 

--- a/packages/es-components/src/components/controls/textbox/Textbox.md
+++ b/packages/es-components/src/components/controls/textbox/Textbox.md
@@ -1,3 +1,5 @@
+The Textbox component will accept typical input attributes as props such as onChange, onBlur, value, placeholder, etc.
+
 ```
 <div>
   <Textbox labelText="Stacked" id="foo" />
@@ -163,9 +165,25 @@ Provide an `appendText` or `prependText` prop for appending and prepending input
 </div>
 ```
 
+
+### Custom masks
+
+Create your own text mask using the structure documented [here](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#text-mask-documentation).
+```
+const mask = {
+    mask: [/[A-Za-z]/, /[A-Za-z]/, /[A-Za-z]/, '-', /[A-Za-z]/, /[A-Za-z]/, /[A-Za-z]/],
+    showMask: true,
+    keepCharPositions: false,
+    placeholderChar: '_'
+  };
+
+<Textbox name="maskExample" labelText="Enter 6 Letters (No Numbers)" maskType="custom" customMask={mask} />
+```
+
+
 ### Additional props
 
-Any unspecified props that get passed get added as a prop to the input in order to allow for additional HTML attributes to be provided. The react `autoFocus` property is also accepted.
+Other typical input attributes passed to `Textbox` are allowed. The react `autoFocus` property is also accepted.
 
 ```
 <div>
@@ -183,7 +201,7 @@ Any unspecified props that get passed get added as a prop to the input in order 
 
   <Textbox
     labelText="Placeholder"
-    placeholder="Placeholder is not a specified prop"
+    placeholder="Placeholder is one of many input attributes"
   />
 
 </div>

--- a/packages/es-components/src/components/controls/textbox/Textbox.specs.js
+++ b/packages/es-components/src/components/controls/textbox/Textbox.specs.js
@@ -149,4 +149,28 @@ describe('Textbox with Mask', () => {
     const textMask = mountWithTheme(buildTextbox(props)).find('input');
     expect(textMask.props().title).toBe('Test me');
   });
+
+  it('accepts and displays a custom mask', () => {
+    const props = {
+      maskType: 'custom',
+      title: 'custom mask',
+      customMask: {
+        mask: [
+          /[A-Za-z]/,
+          /[A-Za-z]/,
+          /[A-Za-z]/,
+          '-',
+          /[A-Za-z]/,
+          /[A-Za-z]/,
+          /[A-Za-z]/
+        ],
+        showMask: true,
+        keepCharPositions: false,
+        placeholderChar: '_'
+      }
+    };
+    const textMask = mountWithTheme(buildTextbox(props)).find('input');
+    expect(textMask.instance().value).toBe('___-___');
+    expect(textMask.props().title).toBe('custom mask');
+  });
 });


### PR DESCRIPTION
- Added a customMask prop and new "custom" type to maskType prop.
- Removed a few props that don't require explicit definition (shouldn't break any prior implementation).
- Updated docs with better explanations for additional props.
