### PR TITLE
Remove PureComponent from DateTextbox

### DIFF
--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.js
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.js
@@ -9,7 +9,7 @@ import { injectGlobal, withTheme } from 'styled-components';
 import datepickerStyles from './datePickerStyles';
 import Textbox from '../../controls/textbox/Textbox';
 
-class DateTextbox extends React.PureComponent {
+class DateTextbox extends React.Component {
   static propTypes = Textbox.propTypes;
 
   componentDidMount() {


### PR DESCRIPTION
This library has a peerDependency of React >= 0.14. Because of this, PureComponent causes issues in any app using a version of React that does not support PureComponent. Until those applications can be updated, this library cannot use PureComponent.