### PR TITLE
Remove purecomponent

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "15.1.0"
+  "version": "15.1.1"
 }

--- a/packages/es-components-via-theme/package.json
+++ b/packages/es-components-via-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components-via-theme",
-  "version": "15.1.0",
+  "version": "15.1.1",
   "main": "index.js",
   "author": "Willis Towers Watson - Individual Marketplace",
   "license": "MIT"

--- a/packages/es-components-wtw-theme/package.json
+++ b/packages/es-components-wtw-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components-wtw-theme",
-  "version": "15.1.0",
+  "version": "15.1.1",
   "main": "index.js",
   "author": "Willis Towers Watson - Individual Marketplace",
   "license": "MIT"

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components",
-  "version": "15.1.0",
+  "version": "15.1.1",
   "description": "React components built for Exchange Solutions products",
   "repository": "https://github.com/wtw-im/es-components",
   "main": "lib/index.js",

--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.js
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.js
@@ -9,7 +9,7 @@ import { injectGlobal, withTheme } from 'styled-components';
 import datepickerStyles from './datePickerStyles';
 import Textbox from '../../controls/textbox/Textbox';
 
-class DateTextbox extends React.PureComponent {
+class DateTextbox extends React.Component {
   static propTypes = Textbox.propTypes;
 
   componentDidMount() {


### PR DESCRIPTION
This library has a peerDependency of React >= 0.14. Because of this, PureComponent causes issues in any app using a version of React that does not support PureComponent. Until those applications can be updated, this library cannot use PureComponent.