### PR TITLE
Remove required prop from dropdownbutton

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "15.2.0"
+  "version": "15.2.1"
 }

--- a/packages/es-components-via-theme/package.json
+++ b/packages/es-components-via-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components-via-theme",
-  "version": "15.2.0",
+  "version": "15.2.1",
   "main": "index.js",
   "author": "Willis Towers Watson - Individual Marketplace",
   "license": "MIT"

--- a/packages/es-components-wtw-theme/package.json
+++ b/packages/es-components-wtw-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components-wtw-theme",
-  "version": "15.2.0",
+  "version": "15.2.1",
   "main": "index.js",
   "author": "Willis Towers Watson - Individual Marketplace",
   "license": "MIT"

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components",
-  "version": "15.2.0",
+  "version": "15.2.1",
   "description": "React components built for Exchange Solutions products",
   "repository": "https://github.com/wtw-im/es-components",
   "main": "lib/index.js",

--- a/packages/es-components/src/components/controls/buttons/DropdownButton.js
+++ b/packages/es-components/src/components/controls/buttons/DropdownButton.js
@@ -108,7 +108,7 @@ DropdownButton.Button = StyledButtonLink;
 
 DropdownButton.propTypes = {
   /** Content shown in the button */
-  buttonValue: PropTypes.any.isRequired,
+  buttonValue: PropTypes.any,
   /**
    * Defines what value should be displayed on the button.
    * Overrides the stored state value, and renders shouldUpdateButtonValue


### PR DESCRIPTION
There are two props for setting the value in a DropDownButton component. It no longer needs the buttonValue prop to be required.