### PR TITLE
Radio Accessibility Fix & Datepicker Color Update

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "15.4.2"
+  "version": "16.0.0"
 }

--- a/packages/es-components-via-theme/index.js
+++ b/packages/es-components-via-theme/index.js
@@ -51,12 +51,13 @@ const violetLighter = '#eac9f2';
 
 
 // Datepicker colors
-const navArrow = gray6;
-const navArrowHover = gray7;
+const dpBackground = '#006685';
+const navArrow = white;
+const navArrowHover = gray2;
 const selected = vbMagenta;
-const hover = '#4b063e';
-const keyboard = '#7a0a65';
-const inRange = 'rgba(193, 16, 160, 0.5)';
+const hover = '#7a0a65';
+const keyboard = primary;
+const inRange = 'rgba(251, 213, 244, 0.75)';
 const highlight = success;
 const highlightHover = '#007653';
 
@@ -108,6 +109,7 @@ const theme = {
     wtwGray: wtwGray
   },
   datepickerColors: {
+    dpBackground: dpBackground,
     navArrow: navArrow,
     navArrowHover: navArrowHover,
     selected: selected,

--- a/packages/es-components-via-theme/package.json
+++ b/packages/es-components-via-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components-via-theme",
-  "version": "15.4.2",
+  "version": "16.0.0",
   "main": "index.js",
   "author": "Willis Towers Watson - Individual Marketplace",
   "license": "MIT"

--- a/packages/es-components-wtw-theme/index.js
+++ b/packages/es-components-wtw-theme/index.js
@@ -51,8 +51,9 @@ const violetLighter = '#eac9f2';
 
 
 // Datepicker colors
-const navArrow = gray5;
-const navArrowHover = gray6;
+const dpBackground = '#006685';
+const navArrow = white;
+const navArrowHover = gray2;
 const selected = '#216ba5';
 const hover = '#1d5d90';
 const keyboard = '#2a87d0';

--- a/packages/es-components-wtw-theme/package.json
+++ b/packages/es-components-wtw-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components-wtw-theme",
-  "version": "15.4.2",
+  "version": "16.0.0",
   "main": "index.js",
   "author": "Willis Towers Watson - Individual Marketplace",
   "license": "MIT"

--- a/packages/es-components/package-lock.json
+++ b/packages/es-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components",
-  "version": "15.4.2",
+  "version": "16.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -77,7 +77,7 @@
     "lodash": "^4.17.5",
     "moment": "^2.21.0",
     "react-animate-height": "^0.10.10",
-    "react-datepicker": "^1.2.2",
+    "react-datepicker": "1.2.2",
     "react-overlays": "^0.8.3",
     "react-popper": "^0.10.4",
     "react-text-mask": "5.4.1",

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components",
-  "version": "15.4.2",
+  "version": "16.0.0",
   "description": "React components built for Exchange Solutions products",
   "repository": "https://github.com/wtw-im/es-components",
   "main": "lib/index.js",

--- a/packages/es-components/src/components/containers/fieldset/Fieldset.js
+++ b/packages/es-components/src/components/containers/fieldset/Fieldset.js
@@ -29,11 +29,10 @@ const StyledFieldset = styled.fieldset`
   padding: 0;
 `;
 
-function Fieldset({ legendClasses, legendContent, children, extraContent }) {
+function Fieldset({ legendClasses, legendContent, children }) {
   return (
     <StyledFieldset className="es-fieldset">
       {renderLegend(legendContent, legendClasses)}
-      {extraContent}
       {children}
     </StyledFieldset>
   );
@@ -44,11 +43,7 @@ Fieldset.propTypes = {
   legendContent: PropTypes.node,
   /** Additional classes to be applied to the legend element */
   legendClasses: PropTypes.string,
-  children: PropTypes.node,
-  /** Extra content that can be rendered after the Legend but before the radio buttons, allows
-   * content to be put in that will not affect the accessability of the Legend/input relationship.
-   */
-  extraContent: PropTypes.node
+  children: PropTypes.node
 };
 
 export default Fieldset;

--- a/packages/es-components/src/components/containers/fieldset/Fieldset.specs.js
+++ b/packages/es-components/src/components/containers/fieldset/Fieldset.specs.js
@@ -32,14 +32,4 @@ describe('Fieldset component', () => {
 
     expect(tree).toMatchSnapshot();
   });
-
-  it('renders as expected with extra content', () => {
-    const tree = renderWithTheme(
-      <Fieldset legendContent="I am legend" extraContent="Extra Content">
-        <div>Fieldset child</div>
-      </Fieldset>
-    );
-
-    expect(tree).toMatchSnapshot();
-  });
 });

--- a/packages/es-components/src/components/containers/fieldset/__snapshots__/Fieldset.specs.js.snap
+++ b/packages/es-components/src/components/containers/fieldset/__snapshots__/Fieldset.specs.js.snap
@@ -10,22 +10,6 @@ exports[`Fieldset component renders as expected 1`] = `
 </fieldset>
 `;
 
-exports[`Fieldset component renders as expected with extra content 1`] = `
-<fieldset
-  className="es-fieldset sc-bwzfXH kzYDuJ"
->
-  <legend
-    className="es-fieldset__legend sc-bdVaJa NnbOj"
-  >
-    I am legend
-  </legend>
-  Extra Content
-  <div>
-    Fieldset child
-  </div>
-</fieldset>
-`;
-
 exports[`Fieldset component renders as expected with legendText 1`] = `
 <fieldset
   className="es-fieldset sc-bwzfXH kzYDuJ"

--- a/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { withTheme } from 'styled-components';
-import { noop } from 'lodash';
 
 import Label from '../Label';
 import getRadioFillVariables from './radio-fill-variables';
@@ -9,12 +8,12 @@ import getRadioFillVariables from './radio-fill-variables';
 function radioFill(color) {
   return `
     background-color: ${color};
-    border-radius: 100%;
+    border-radius: 50%;
     content: '';
     display: block;
     height: 13px;
     left: 3px;
-    position: absolute;
+    position: relative;
     width: 13px;
     top: 3px;
     transition: background 0.25s linear;
@@ -23,11 +22,11 @@ function radioFill(color) {
 
 const RadioLabel = styled(Label)`
   color: ${props => (props.error ? props.theme.colors.danger : 'inherit')};
-  display: ${props => (props.inline ? 'inline-flex' : 'inherit')};
+  display: ${props => (props.inline ? 'inline-flex' : 'flex')};
   font-size: ${props => props.theme.sizes.baseFontSize};
   font-weight: normal;
+  margin-bottom: 18px;
   margin-right: ${props => (props.inline ? '20px' : 'initial')};
-  min-height: 25px;
   position: relative;
   padding: 5px 0;
   text-transform: none;
@@ -46,18 +45,12 @@ const RadioInput = styled.input`
   }
 `;
 
-const RadioText = styled.span`
-  align-self: center;
-  margin-left: 30px;
-`;
-
 const RadioDisplay = styled.span`
   border: 3px solid ${props => props.borderColor};
-  border-radius: 100%;
+  border-radius: 50%;
   box-sizing: border-box;
-  display: block;
   height: 25px;
-  position: absolute;
+  margin-right: 5px;
   width: 25px;
 
   &:before {
@@ -72,11 +65,8 @@ export function RadioButton({
   id,
   isDisabled = false,
   inline = true,
-  onClick = noop,
-  value,
   hasError = false,
   theme,
-  ariaHide,
   ...radioProps
 }) {
   const { hover, fill } = getRadioFillVariables(
@@ -102,8 +92,6 @@ export function RadioButton({
         type="radio"
         name={name}
         id={id}
-        onClick={onClick}
-        value={value}
         disabled={isDisabled}
         {...radioProps}
       />
@@ -112,9 +100,7 @@ export function RadioButton({
         borderColor={fill}
         fill={radioDisplayFill}
       />
-      <RadioText className="es-radio__text" aria-hidden={ariaHide}>
-        {optionText}
-      </RadioText>
+      {optionText}
     </RadioLabel>
   );
 }
@@ -126,9 +112,6 @@ RadioButton.propTypes = {
   id: PropTypes.string,
   isDisabled: PropTypes.bool,
   inline: PropTypes.bool,
-  onClick: PropTypes.func,
-  value: PropTypes.any,
-  ariaHide: PropTypes.bool,
   hasError: PropTypes.bool,
   /**
    * Theme object used by the ThemeProvider,

--- a/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
@@ -92,6 +92,7 @@ export function RadioButton({
         name={name}
         id={id}
         disabled={isDisabled}
+        checked={checked}
         {...radioProps}
       />
       <RadioDisplay

--- a/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
@@ -61,7 +61,7 @@ const RadioDisplay = styled.span`
 export function RadioButton({
   optionText,
   name,
-  checked = false,
+  isChecked = false,
   id,
   isDisabled = false,
   inline = true,
@@ -70,12 +70,12 @@ export function RadioButton({
   ...radioProps
 }) {
   const { hover, fill } = getRadioFillVariables(
-    checked,
+    isChecked,
     isDisabled,
     hasError,
     theme.colors
   );
-  const radioDisplayFill = checked ? fill : theme.colors.white;
+  const radioDisplayFill = isChecked ? fill : theme.colors.white;
 
   const labelProps = {
     inline,
@@ -92,6 +92,7 @@ export function RadioButton({
         name={name}
         id={id}
         disabled={isDisabled}
+        checked={isChecked}
         {...radioProps}
       />
       <RadioDisplay
@@ -107,7 +108,7 @@ export function RadioButton({
 RadioButton.propTypes = {
   optionText: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  checked: PropTypes.bool,
+  isChecked: PropTypes.bool,
   id: PropTypes.string,
   isDisabled: PropTypes.bool,
   inline: PropTypes.bool,

--- a/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
@@ -78,7 +78,6 @@ export function RadioButton({
   const radioDisplayFill = checked ? fill : theme.colors.white;
 
   const labelProps = {
-    checked,
     inline,
     disabled: isDisabled,
     htmlFor: id,

--- a/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
@@ -92,7 +92,6 @@ export function RadioButton({
         name={name}
         id={id}
         disabled={isDisabled}
-        checked={checked}
         {...radioProps}
       />
       <RadioDisplay

--- a/packages/es-components/src/components/controls/radio-buttons/RadioGroup.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioGroup.js
@@ -14,7 +14,7 @@ function RadioGroup({
   hasError = false,
   disableAllOptions = false,
   inline = true,
-  onClick = noop,
+  onChange = noop,
   extraContent
 }) {
   return (
@@ -22,15 +22,15 @@ function RadioGroup({
       {extraContent}
       {radioOptions.map((config, index) => {
         const radioId = `${name}-option-${index + 1}`;
-        const checked = config.optionValue === value;
+        const isChecked = config.optionValue === value;
         const isDisabled = disableAllOptions || config.isDisabled;
         const radioProps = {
           name,
-          checked,
+          isChecked,
           hasError,
           isDisabled,
           inline,
-          onClick,
+          onChange,
           id: radioId,
           optionText: config.optionText,
           value: config.optionValue
@@ -64,7 +64,7 @@ RadioGroup.propTypes = {
   /** Display the radio buttons inline */
   inline: PropTypes.bool,
   /** Function to execute when a radio button is selected */
-  onClick: PropTypes.func,
+  onChange: PropTypes.func,
   /** Extra content that can be rendered after the Legend but before the radio buttons, allows
    * content to be put in that will not affect the accessability of the Legend/Radio button relationship.
    */

--- a/packages/es-components/src/components/controls/radio-buttons/RadioGroup.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioGroup.js
@@ -33,8 +33,7 @@ function RadioGroup({
           onClick,
           id: radioId,
           optionText: config.optionText,
-          value: config.optionValue,
-          ariaHide: extraContent !== undefined
+          value: config.optionValue
         };
         return <RadioButton key={radioId} {...radioProps} />;
       })}

--- a/packages/es-components/src/components/controls/radio-buttons/RadioGroup.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioGroup.js
@@ -18,7 +18,8 @@ function RadioGroup({
   extraContent
 }) {
   return (
-    <Fieldset legendContent={legendContent} extraContent={extraContent}>
+    <Fieldset legendContent={legendContent}>
+      {extraContent}
       {radioOptions.map((config, index) => {
         const radioId = `${name}-option-${index + 1}`;
         const checked = config.optionValue === value;

--- a/packages/es-components/src/components/controls/radio-buttons/RadioGroup.md
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioGroup.md
@@ -39,7 +39,7 @@ class RadioGroupExample extends React.Component {
         name="recreational-activities"
         legendText="Recreational activities"
         radioOptions={options}
-        onClick={this.optionChanged}
+        onChange={this.optionChanged}
         value={this.state.value}
       />
     );
@@ -84,7 +84,7 @@ class RadioGroupExample extends React.Component {
         name="plates"
         radioOptions={options}
         inline={false}
-        onClick={this.optionChanged}
+        onChange={this.optionChanged}
         value={this.state.value}
       />
     );
@@ -128,7 +128,7 @@ class RadioGroupExample extends React.Component {
       <RadioGroup
         name="transports"
         radioOptions={options}
-        onClick={this.optionChanged}
+        onChange={this.optionChanged}
         value={this.state.value}
         hasError
       />

--- a/packages/es-components/src/components/controls/radio-buttons/RadioGroup.specs.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioGroup.specs.js
@@ -64,18 +64,19 @@ describe('RadioGroup component', () => {
 
   it('renders as expected', () => {
     const tree = renderWithTheme(
-      <RadioGroup name="test" radioOptions={defaultOptions} />
+      <RadioGroup name="test" radioOptions={defaultOptions} value={0} />
     );
 
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders as expected with legend text', () => {
+  it('renders as expected with legend text and extraContent', () => {
     const tree = renderWithTheme(
       <RadioGroup
         name="test"
         radioOptions={defaultOptions}
         legendContent="Test legend"
+        extraContent="Extra Content!"
       />
     );
 

--- a/packages/es-components/src/components/controls/radio-buttons/__snapshots__/RadioButton.specs.js.snap
+++ b/packages/es-components/src/components/controls/radio-buttons/__snapshots__/RadioButton.specs.js.snap
@@ -2,8 +2,7 @@
 
 exports[`RadioButton component renders as expected 1`] = `
 <label
-  checked={false}
-  className="es-radio sc-bwzfXH iRbUYb sc-bdVaJa jBoKPV"
+  className="es-radio sc-bwzfXH iWvndJ sc-bdVaJa jBoKPV"
   disabled={false}
   htmlFor="test"
 >
@@ -12,17 +11,12 @@ exports[`RadioButton component renders as expected 1`] = `
     disabled={false}
     id="test"
     name="rad"
-    onClick={[Function]}
     type="radio"
   />
   <span
-    className="es-radio__fill sc-ifAKCX fnveVG"
+    className="es-radio__fill sc-bxivhb jNoHRi"
     fill="#fff"
   />
-  <span
-    className="es-radio__text sc-bxivhb bRNnnP"
-  >
-    test
-  </span>
+  test
 </label>
 `;

--- a/packages/es-components/src/components/controls/radio-buttons/__snapshots__/RadioButton.specs.js.snap
+++ b/packages/es-components/src/components/controls/radio-buttons/__snapshots__/RadioButton.specs.js.snap
@@ -7,6 +7,7 @@ exports[`RadioButton component renders as expected 1`] = `
   htmlFor="test"
 >
   <input
+    checked={false}
     className="sc-htpNat kOMTgB"
     disabled={false}
     id="test"

--- a/packages/es-components/src/components/controls/radio-buttons/__snapshots__/RadioGroup.specs.js.snap
+++ b/packages/es-components/src/components/controls/radio-buttons/__snapshots__/RadioGroup.specs.js.snap
@@ -5,11 +5,12 @@ exports[`RadioGroup component renders as expected 1`] = `
   className="es-fieldset sc-EHOje gAPZeA"
 >
   <label
-    className="es-radio sc-bwzfXH iWvndJ sc-bdVaJa jBoKPV"
+    className="es-radio sc-bwzfXH fYkhsp sc-bdVaJa jBoKPV"
     disabled={false}
     htmlFor="test-option-1"
   >
     <input
+      checked={true}
       className="sc-htpNat kOMTgB"
       disabled={false}
       id="test-option-1"
@@ -19,8 +20,8 @@ exports[`RadioGroup component renders as expected 1`] = `
       value={0}
     />
     <span
-      className="es-radio__fill sc-bxivhb jNoHRi"
-      fill="#fff"
+      className="es-radio__fill sc-bxivhb bwNXgt"
+      fill="#069"
     />
     Option 0
   </label>
@@ -30,6 +31,7 @@ exports[`RadioGroup component renders as expected 1`] = `
     htmlFor="test-option-2"
   >
     <input
+      checked={false}
       className="sc-htpNat kOMTgB"
       disabled={false}
       id="test-option-2"
@@ -50,6 +52,7 @@ exports[`RadioGroup component renders as expected 1`] = `
     htmlFor="test-option-3"
   >
     <input
+      checked={false}
       className="sc-htpNat kOMTgB"
       disabled={false}
       id="test-option-3"
@@ -67,7 +70,7 @@ exports[`RadioGroup component renders as expected 1`] = `
 </fieldset>
 `;
 
-exports[`RadioGroup component renders as expected with legend text 1`] = `
+exports[`RadioGroup component renders as expected with legend text and extraContent 1`] = `
 <fieldset
   className="es-fieldset sc-EHOje gAPZeA"
 >
@@ -76,12 +79,14 @@ exports[`RadioGroup component renders as expected with legend text 1`] = `
   >
     Test legend
   </legend>
+  Extra Content!
   <label
     className="es-radio sc-bwzfXH iWvndJ sc-bdVaJa jBoKPV"
     disabled={false}
     htmlFor="test-option-1"
   >
     <input
+      checked={false}
       className="sc-htpNat kOMTgB"
       disabled={false}
       id="test-option-1"
@@ -102,6 +107,7 @@ exports[`RadioGroup component renders as expected with legend text 1`] = `
     htmlFor="test-option-2"
   >
     <input
+      checked={false}
       className="sc-htpNat kOMTgB"
       disabled={false}
       id="test-option-2"
@@ -122,6 +128,7 @@ exports[`RadioGroup component renders as expected with legend text 1`] = `
     htmlFor="test-option-3"
   >
     <input
+      checked={false}
       className="sc-htpNat kOMTgB"
       disabled={false}
       id="test-option-3"

--- a/packages/es-components/src/components/controls/radio-buttons/__snapshots__/RadioGroup.specs.js.snap
+++ b/packages/es-components/src/components/controls/radio-buttons/__snapshots__/RadioGroup.specs.js.snap
@@ -15,7 +15,7 @@ exports[`RadioGroup component renders as expected 1`] = `
       disabled={false}
       id="test-option-1"
       name="test"
-      onClick={[Function]}
+      onChange={[Function]}
       type="radio"
       value={0}
     />
@@ -36,7 +36,7 @@ exports[`RadioGroup component renders as expected 1`] = `
       disabled={false}
       id="test-option-2"
       name="test"
-      onClick={[Function]}
+      onChange={[Function]}
       type="radio"
       value={1}
     />
@@ -57,7 +57,7 @@ exports[`RadioGroup component renders as expected 1`] = `
       disabled={false}
       id="test-option-3"
       name="test"
-      onClick={[Function]}
+      onChange={[Function]}
       type="radio"
       value={2}
     />
@@ -91,7 +91,7 @@ exports[`RadioGroup component renders as expected with legend text and extraCont
       disabled={false}
       id="test-option-1"
       name="test"
-      onClick={[Function]}
+      onChange={[Function]}
       type="radio"
       value={0}
     />
@@ -112,7 +112,7 @@ exports[`RadioGroup component renders as expected with legend text and extraCont
       disabled={false}
       id="test-option-2"
       name="test"
-      onClick={[Function]}
+      onChange={[Function]}
       type="radio"
       value={1}
     />
@@ -133,7 +133,7 @@ exports[`RadioGroup component renders as expected with legend text and extraCont
       disabled={false}
       id="test-option-3"
       name="test"
-      onClick={[Function]}
+      onChange={[Function]}
       type="radio"
       value={2}
     />

--- a/packages/es-components/src/components/controls/radio-buttons/__snapshots__/RadioGroup.specs.js.snap
+++ b/packages/es-components/src/components/controls/radio-buttons/__snapshots__/RadioGroup.specs.js.snap
@@ -2,11 +2,10 @@
 
 exports[`RadioGroup component renders as expected 1`] = `
 <fieldset
-  className="es-fieldset sc-bZQynM dSZIHB"
+  className="es-fieldset sc-EHOje gAPZeA"
 >
   <label
-    checked={false}
-    className="es-radio sc-bwzfXH iRbUYb sc-bdVaJa jBoKPV"
+    className="es-radio sc-bwzfXH iWvndJ sc-bdVaJa jBoKPV"
     disabled={false}
     htmlFor="test-option-1"
   >
@@ -20,19 +19,13 @@ exports[`RadioGroup component renders as expected 1`] = `
       value={0}
     />
     <span
-      className="es-radio__fill sc-ifAKCX fnveVG"
+      className="es-radio__fill sc-bxivhb jNoHRi"
       fill="#fff"
     />
-    <span
-      aria-hidden={false}
-      className="es-radio__text sc-bxivhb bRNnnP"
-    >
-      Option 0
-    </span>
+    Option 0
   </label>
   <label
-    checked={false}
-    className="es-radio sc-bwzfXH iRbUYb sc-bdVaJa jBoKPV"
+    className="es-radio sc-bwzfXH iWvndJ sc-bdVaJa jBoKPV"
     disabled={false}
     htmlFor="test-option-2"
   >
@@ -46,19 +39,13 @@ exports[`RadioGroup component renders as expected 1`] = `
       value={1}
     />
     <span
-      className="es-radio__fill sc-ifAKCX fnveVG"
+      className="es-radio__fill sc-bxivhb jNoHRi"
       fill="#fff"
     />
-    <span
-      aria-hidden={false}
-      className="es-radio__text sc-bxivhb bRNnnP"
-    >
-      Option 1
-    </span>
+    Option 1
   </label>
   <label
-    checked={false}
-    className="es-radio sc-bwzfXH iRbUYb sc-bdVaJa jBoKPV"
+    className="es-radio sc-bwzfXH iWvndJ sc-bdVaJa jBoKPV"
     disabled={false}
     htmlFor="test-option-3"
   >
@@ -72,31 +59,25 @@ exports[`RadioGroup component renders as expected 1`] = `
       value={2}
     />
     <span
-      className="es-radio__fill sc-ifAKCX fnveVG"
+      className="es-radio__fill sc-bxivhb jNoHRi"
       fill="#fff"
     />
-    <span
-      aria-hidden={false}
-      className="es-radio__text sc-bxivhb bRNnnP"
-    >
-      Option 2
-    </span>
+    Option 2
   </label>
 </fieldset>
 `;
 
 exports[`RadioGroup component renders as expected with legend text 1`] = `
 <fieldset
-  className="es-fieldset sc-bZQynM dSZIHB"
+  className="es-fieldset sc-EHOje gAPZeA"
 >
   <legend
-    className="es-fieldset__legend sc-EHOje iSPUDq"
+    className="es-fieldset__legend sc-ifAKCX kkKCeA"
   >
     Test legend
   </legend>
   <label
-    checked={false}
-    className="es-radio sc-bwzfXH iRbUYb sc-bdVaJa jBoKPV"
+    className="es-radio sc-bwzfXH iWvndJ sc-bdVaJa jBoKPV"
     disabled={false}
     htmlFor="test-option-1"
   >
@@ -110,19 +91,13 @@ exports[`RadioGroup component renders as expected with legend text 1`] = `
       value={0}
     />
     <span
-      className="es-radio__fill sc-ifAKCX fnveVG"
+      className="es-radio__fill sc-bxivhb jNoHRi"
       fill="#fff"
     />
-    <span
-      aria-hidden={false}
-      className="es-radio__text sc-bxivhb bRNnnP"
-    >
-      Option 0
-    </span>
+    Option 0
   </label>
   <label
-    checked={false}
-    className="es-radio sc-bwzfXH iRbUYb sc-bdVaJa jBoKPV"
+    className="es-radio sc-bwzfXH iWvndJ sc-bdVaJa jBoKPV"
     disabled={false}
     htmlFor="test-option-2"
   >
@@ -136,19 +111,13 @@ exports[`RadioGroup component renders as expected with legend text 1`] = `
       value={1}
     />
     <span
-      className="es-radio__fill sc-ifAKCX fnveVG"
+      className="es-radio__fill sc-bxivhb jNoHRi"
       fill="#fff"
     />
-    <span
-      aria-hidden={false}
-      className="es-radio__text sc-bxivhb bRNnnP"
-    >
-      Option 1
-    </span>
+    Option 1
   </label>
   <label
-    checked={false}
-    className="es-radio sc-bwzfXH iRbUYb sc-bdVaJa jBoKPV"
+    className="es-radio sc-bwzfXH iWvndJ sc-bdVaJa jBoKPV"
     disabled={false}
     htmlFor="test-option-3"
   >
@@ -162,15 +131,10 @@ exports[`RadioGroup component renders as expected with legend text 1`] = `
       value={2}
     />
     <span
-      className="es-radio__fill sc-ifAKCX fnveVG"
+      className="es-radio__fill sc-bxivhb jNoHRi"
       fill="#fff"
     />
-    <span
-      aria-hidden={false}
-      className="es-radio__text sc-bxivhb bRNnnP"
-    >
-      Option 2
-    </span>
+    Option 2
   </label>
 </fieldset>
 `;

--- a/packages/es-components/src/components/patterns/datepicker/datePickerStyles.js
+++ b/packages/es-components/src/components/patterns/datepicker/datePickerStyles.js
@@ -38,7 +38,7 @@ export default function datepickerStyles(colors, dpColors) {
   .react-datepicker-popper[data-placement^="bottom"] .react-datepicker__triangle,
   .react-datepicker-popper[data-placement^="bottom"] .react-datepicker__triangle::before {
       border-top: none;
-      border-bottom-color: ${colors.gray1};
+      border-bottom-color: ${colors.white};
   }
   .react-datepicker-popper[data-placement^="bottom"] .react-datepicker__triangle::before {
       top: -1px;
@@ -71,8 +71,9 @@ export default function datepickerStyles(colors, dpColors) {
   .react-datepicker {
       font-size: 18px;
       background-color: ${colors.white};
+      border: solid 1px ${colors.gray5};
       border-radius: 4px;
-      color: ${colors.black};
+      color: ${colors.gray9};
       box-shadow: 0 5px 10px ${colors.boxShadowLight};
       display: inline-block;
       position: relative;
@@ -122,7 +123,7 @@ export default function datepickerStyles(colors, dpColors) {
   .react-datepicker__current-month,
   .react-datepicker-time__header {
       margin: 0 0 5px 0;
-      color: ${colors.black};
+      color: ${colors.gray9};
       font-weight: bold;
       font-size: 18px;
   }
@@ -256,7 +257,7 @@ export default function datepickerStyles(colors, dpColors) {
   .react-datepicker__day-name,
   .react-datepicker__day,
   .react-datepicker__time-name {
-      color: ${colors.black};
+      color: ${colors.gray9};
       display: inline-block;
       width: 1.9rem;
       line-height: 1.9rem;
@@ -280,7 +281,7 @@ export default function datepickerStyles(colors, dpColors) {
   }
   .react-datepicker__day--highlighted:hover {
       background-color: ${dpColors.highlightHover};
-      color: ${colors.black}
+      color: ${colors.gray9}
   }
   .react-datepicker__day--selected,
   .react-datepicker__day--in-selecting-range,
@@ -304,11 +305,11 @@ export default function datepickerStyles(colors, dpColors) {
   }
   .react-datepicker__day--in-selecting-range:not(.react-datepicker__day--in-range) {
       background-color: ${dpColors.inRange};
-      color: ${colors.black};
+      color: ${colors.gray9};
   }
   .react-datepicker__month--selecting-range .react-datepicker__day--in-range:not(.react-datepicker__day--in-selecting-range) {
       background-color: ${colors.gray3};
-      color: ${colors.black};
+      color: ${colors.gray9};
   }
   .react-datepicker__day--disabled {
       cursor: default;

--- a/packages/es-components/src/components/patterns/datepicker/datePickerStyles.js
+++ b/packages/es-components/src/components/patterns/datepicker/datePickerStyles.js
@@ -38,7 +38,7 @@ export default function datepickerStyles(colors, dpColors) {
   .react-datepicker-popper[data-placement^="bottom"] .react-datepicker__triangle,
   .react-datepicker-popper[data-placement^="bottom"] .react-datepicker__triangle::before {
       border-top: none;
-      border-bottom-color: ${colors.white};
+      border-bottom-color: ${dpColors.dpBackground};
   }
   .react-datepicker-popper[data-placement^="bottom"] .react-datepicker__triangle::before {
       top: -1px;
@@ -104,7 +104,7 @@ export default function datepickerStyles(colors, dpColors) {
   }
   .react-datepicker__header {
       text-align: center;
-      background-color: ${colors.white};
+      background-color: ${dpColors.dpBackground};
       border-top-left-radius: 4px;
       border-top-right-radius: 4px;
       padding-top: 10px;
@@ -123,7 +123,7 @@ export default function datepickerStyles(colors, dpColors) {
   .react-datepicker__current-month,
   .react-datepicker-time__header {
       margin: 0 0 5px 0;
-      color: ${colors.gray9};
+      color: ${colors.white};
       font-weight: bold;
       font-size: 18px;
   }
@@ -253,6 +253,9 @@ export default function datepickerStyles(colors, dpColors) {
   }
   .react-datepicker__day-names {
       font-weight: bold;
+  }
+  .react-datepicker__day-names .react-datepicker__day-name {
+      color: ${colors.white};
   }
   .react-datepicker__day-name,
   .react-datepicker__day,


### PR DESCRIPTION
Addresses TW-42794

1) Removed `ariaHide` prop from `RadioButton`. As far as I can tell its only purpose was to hide the reading of the radio labels if the `extraContent` prop was supplied. It didn't make sense to me that including some text above the radio buttons would disable reading the options for screen readers. If there was a specific reason for this please let me know. :)

2) Removed `extraContent` prop from `Fieldset` where it didn't really make sense to have since it was being rendered as a child anyway. It still works the same way when used in `RadioGroup` where it originated.

3) Removed `onClick` and `value` from `RadioButton` props, as they are passed along with any other props provided to the input.

4) Some minor radio CSS clean up

5) Added `checked` attribute to input, updated tests.

6) Renamed `onClick` to `onChange` due to some console warnings about not having `onChange` with a `checked` value. It's also the event typically associated with radio buttons.

7) Threw in some datepicker color changes