### PR TITLE
Datepicker pass through props

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "16.0.0"
+  "version": "16.0.1"
 }

--- a/packages/es-components-via-theme/package.json
+++ b/packages/es-components-via-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components-via-theme",
-  "version": "16.0.0",
+  "version": "16.0.1",
   "main": "index.js",
   "author": "Willis Towers Watson - Individual Marketplace",
   "license": "MIT"

--- a/packages/es-components-wtw-theme/package.json
+++ b/packages/es-components-wtw-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components-wtw-theme",
-  "version": "16.0.0",
+  "version": "16.0.1",
   "main": "index.js",
   "author": "Willis Towers Watson - Individual Marketplace",
   "license": "MIT"

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components",
-  "version": "16.0.0",
+  "version": "16.0.1",
   "description": "React components built for Exchange Solutions products",
   "repository": "https://github.com/wtw-im/es-components",
   "main": "lib/index.js",

--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.js
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.js
@@ -33,7 +33,6 @@ export const DatePicker = props => {
     placeholder,
     selectedDate,
     theme,
-    validationState,
     ...otherProps
   } = props;
 
@@ -50,7 +49,7 @@ export const DatePicker = props => {
       maskType="date"
       prependIconName="calendar"
       additionalHelpContent={additionalHelpContent}
-      validationState={validationState}
+      {...otherProps}
     />
   );
 
@@ -105,16 +104,13 @@ DatePicker.propTypes = {
    * Theme object used by the ThemeProvider,
    * automatically passed by any parent component using a ThemeProvider
    */
-  theme: PropTypes.object,
-  /** Display label and text with contextual state colorings */
-  validationState: PropTypes.oneOf(['default', 'success', 'warning', 'danger'])
+  theme: PropTypes.object
 };
 
 DatePicker.defaultProps = {
   onBlur: noop,
   onChangeRaw: noop,
-  placeholder: 'mm/dd/yyyy',
-  validationState: 'default'
+  placeholder: 'mm/dd/yyyy'
 };
 
 const UncontrolledDatePicker = uncontrollable(DatePicker, {

--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.md
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.md
@@ -1,5 +1,7 @@
 Supports many other props demoed <a href="https://hacker0x01.github.io/react-datepicker" target="blank">here</a>.
 
+Passes props through to the TextBox component for additional functionality (for example: validationState).
+
 **Keyboard support**
 
 * Left: Move to the previous day
@@ -129,32 +131,4 @@ const moment = require('moment');
 <DatePicker labelText="Child Content" onChange={()=>{}}>
   <div style={{textAlign: 'center', padding: '8px', clear: 'both', borderTop: '1px solid #aeaeae', backgroundColor: 'whitesmoke'}}><strong>Year: Home / End <br/> Month: PgUp / PgDn</strong></div>
 </DatePicker>
-```
-
-### Validation states
-
-```
-<div>
-  <DatePicker
-    labelText="Success"
-    validationState="success"
-    additionalHelpContent="When validationState is set to Success"
-    onChange={()=>{}} 
-  />
-
-  <DatePicker
-    labelText="Warning"
-    validationState="warning"
-    additionalHelpContent="When validationState is set to Warning"
-    onChange={()=>{}} 
-  />
-
-  <DatePicker
-    labelText="Danger"
-    validationState="danger"
-    additionalHelpContent="When validation state is set to Error"
-    onChange={()=>{}} 
-  />
-
-</div>
 ```


### PR DESCRIPTION
In needing to make the BirthDate component accessible I needed to pass the 'required' prop through to the TextBox.  In talking to Ken, it sounded like it would be best to remove the validationState work and pass through props to TextBox.