### PR TITLE
Datepicker Prop Fix

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "17.0.2"
+  "version": "17.0.3"
 }

--- a/packages/es-components-via-theme/package.json
+++ b/packages/es-components-via-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components-via-theme",
-  "version": "17.0.2",
+  "version": "17.0.3",
   "main": "index.js",
   "author": "Willis Towers Watson - Individual Marketplace",
   "license": "MIT"

--- a/packages/es-components-wtw-theme/package.json
+++ b/packages/es-components-wtw-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components-wtw-theme",
-  "version": "17.0.2",
+  "version": "17.0.3",
   "main": "index.js",
   "author": "Willis Towers Watson - Individual Marketplace",
   "license": "MIT"

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components",
-  "version": "17.0.2",
+  "version": "17.0.3",
   "description": "React components built for Exchange Solutions products",
   "repository": "https://github.com/wtw-im/es-components",
   "main": "lib/index.js",

--- a/packages/es-components/src/components/containers/popover/Popup.js
+++ b/packages/es-components/src/components/containers/popover/Popup.js
@@ -52,9 +52,8 @@ function Popup({
     getArrowSize(arrowSize),
     hasTitle
   );
-  /* eslint-disable no-unused-expressions */
-  injectGlobal`${arrowStyles}`;
-  /* eslint-enable no-unused-expressions */
+
+  injectGlobal`${arrowStyles}`; // eslint-disable-line no-unused-expressions
 
   let popperObj = (
     <Manager>

--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.js
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
+import { noop, pick, omit } from 'lodash';
 import ReactDatePicker from 'react-datepicker';
 import uncontrollable from 'uncontrollable';
 import { injectGlobal, withTheme } from 'styled-components';
@@ -10,7 +10,7 @@ import datepickerStyles from './datePickerStyles';
 import Textbox from '../../controls/textbox/Textbox';
 
 class DateTextbox extends React.Component {
-  static propTypes = Textbox.propTypes;
+  static propTypes = Textbox.propTypes; // eslint-disable-line react/forbid-foreign-prop-types
 
   componentDidMount() {
     this.inputElement = findDOMNode(this).querySelector('input');
@@ -29,36 +29,65 @@ export const DatePicker = props => {
   const {
     additionalHelpContent,
     children,
+    excludeDates,
+    filterDate,
+    highlightDates,
+    includeDates,
     labelText,
+    name,
+    onChange,
+    onChangeRaw,
+    onBlur,
     placeholder,
     selectedDate,
+    selectsEnd,
+    selectsStart,
+    startDate,
+    endDate,
     theme,
     ...otherProps
   } = props;
+
+  /* eslint-disable react/forbid-foreign-prop-types */
+  const textboxProps = omit(otherProps, ReactDatePicker.propTypes);
+  const datepickerProps = pick(otherProps, ReactDatePicker.propTypes);
+  /* eslint-enable */
 
   const dpStyles = datepickerStyles(theme.colors, theme.datepickerColors);
   /* eslint-disable no-unused-expressions */
   injectGlobal`
     ${dpStyles}
   `;
-  /* eslint-enable no-unused-expressions */
+  /* eslint-enable */
 
   const textbox = (
     <DateTextbox
+      additionalHelpContent={additionalHelpContent}
       labelText={labelText}
       maskType="date"
+      name={name}
       prependIconName="calendar"
-      additionalHelpContent={additionalHelpContent}
-      {...otherProps}
+      {...textboxProps}
     />
   );
 
   return (
     <ReactDatePicker
-      selected={selectedDate}
       customInput={textbox}
+      endDate={endDate}
+      excludeDates={excludeDates}
+      filterDate={filterDate}
+      highlightDates={highlightDates}
+      includeDates={includeDates}
+      onChange={onChange}
+      onChangeRaw={onChangeRaw}
+      onBlur={onBlur}
       placeholderText={placeholder}
-      {...otherProps}
+      selected={selectedDate}
+      selectsEnd={selectsEnd}
+      selectsStart={selectsStart}
+      startDate={startDate}
+      {...datepickerProps}
     >
       {children}
     </ReactDatePicker>

--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.js
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.js
@@ -27,30 +27,23 @@ class DateTextbox extends React.Component {
 
 export const DatePicker = props => {
   const {
-    additionalHelpContent,
     children,
-    excludeDates,
-    filterDate,
-    highlightDates,
-    includeDates,
-    labelText,
     name,
     onChange,
-    onChangeRaw,
     onBlur,
     placeholder,
     selectedDate,
-    selectsEnd,
-    selectsStart,
-    startDate,
-    endDate,
     theme,
     ...otherProps
   } = props;
 
   /* eslint-disable react/forbid-foreign-prop-types */
-  const textboxProps = omit(otherProps, ReactDatePicker.propTypes);
-  const datepickerProps = pick(otherProps, ReactDatePicker.propTypes);
+  const datepickerProps = pick(
+    otherProps,
+    Object.keys(ReactDatePicker.propTypes)
+  );
+  const textboxProps = omit(otherProps, Object.keys(ReactDatePicker.propTypes));
+
   /* eslint-enable */
 
   const dpStyles = datepickerStyles(theme.colors, theme.datepickerColors);
@@ -62,8 +55,6 @@ export const DatePicker = props => {
 
   const textbox = (
     <DateTextbox
-      additionalHelpContent={additionalHelpContent}
-      labelText={labelText}
       maskType="date"
       name={name}
       prependIconName="calendar"
@@ -74,19 +65,10 @@ export const DatePicker = props => {
   return (
     <ReactDatePicker
       customInput={textbox}
-      endDate={endDate}
-      excludeDates={excludeDates}
-      filterDate={filterDate}
-      highlightDates={highlightDates}
-      includeDates={includeDates}
       onChange={onChange}
-      onChangeRaw={onChangeRaw}
       onBlur={onBlur}
       placeholderText={placeholder}
       selected={selectedDate}
-      selectsEnd={selectsEnd}
-      selectsStart={selectsStart}
-      startDate={startDate}
       {...datepickerProps}
     >
       {children}

--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.md
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.md
@@ -1,4 +1,4 @@
-Supports many other props demoed <a href="https://hacker0x01.github.io/react-datepicker" target="blank">here</a>.
+Based on <a href="https://hacker0x01.github.io/react-datepicker" target="blank">React-Datepicker</a> and supports most of the props documented there.
 
 Passes props through to the TextBox component for additional functionality (for example: validationState).
 


### PR DESCRIPTION
Splits up the `otherProps` into distinct sets to pass along to react-datepicker and Textbox. The datepicker will only receive props that belong to its propTypes, and Textbox will get all the rest.