### PR TITLE
Remove react-dom as a peerDependency

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "17.0.3"
+  "version": "17.0.4"
 }

--- a/packages/es-components-via-theme/package.json
+++ b/packages/es-components-via-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components-via-theme",
-  "version": "17.0.3",
+  "version": "17.0.4",
   "main": "index.js",
   "author": "Willis Towers Watson - Individual Marketplace",
   "license": "MIT"

--- a/packages/es-components-wtw-theme/package.json
+++ b/packages/es-components-wtw-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components-wtw-theme",
-  "version": "17.0.3",
+  "version": "17.0.4",
   "main": "index.js",
   "author": "Willis Towers Watson - Individual Marketplace",
   "license": "MIT"

--- a/packages/es-components/README.md
+++ b/packages/es-components/README.md
@@ -1,7 +1,7 @@
 Exchange Solutions React components
 ==================
 
-[![Build Status](https://travis-ci.org/WTW-IM/es-components.svg?branch=master)](https://travis-ci.org/WTW-IM/es-components)
+[![Build Status](https://travis-ci.com/WTW-IM/es-components.svg?branch=master)](https://travis-ci.com/WTW-IM/es-components)
 [![npm version](https://badge.fury.io/js/es-components.svg)](https://badge.fury.io/js/es-components)
 
 ## Documentation and Demos

--- a/packages/es-components/package-lock.json
+++ b/packages/es-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components",
-  "version": "17.0.1",
+  "version": "17.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2126,10 +2126,13 @@
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
     },
     "asn1.js": {
       "version": "4.10.1",
@@ -2768,9 +2771,9 @@
       "dev": true
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4588,13 +4591,14 @@
       }
     },
     "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ee-first": {
@@ -5913,14 +5917,14 @@
       "dev": true
     },
     "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "dev": true,
       "requires": {
         "is-number": "^2.1.0",
         "isobject": "^2.0.0",
-        "randomatic": "^1.1.3",
+        "randomatic": "^3.0.0",
         "repeat-element": "^1.1.2",
         "repeat-string": "^1.5.2"
       },
@@ -9633,9 +9637,9 @@
       }
     },
     "macaddress": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
-      "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.9.tgz",
+      "integrity": "sha512-k4F1JUof6cQXxNFzx3thLby4oJzXTXQueAOOts944Vqizn+Rjc2QNFenT9FJSLU1CH3PmrHRSyZs2E+Cqw+P2w==",
       "dev": true
     },
     "magic-string": {
@@ -9726,6 +9730,12 @@
       "version": "1.2.17",
       "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
       "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
+      "dev": true
+    },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
       "dev": true
     },
     "md5.js": {
@@ -11726,43 +11736,27 @@
       }
     },
     "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
+      "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
       },
       "dependencies": {
         "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
         },
         "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
         }
       }
     },
@@ -13981,9 +13975,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -13993,6 +13987,7 @@
         "ecc-jsbn": "~0.1.1",
         "getpass": "^0.1.1",
         "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
     },

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components",
-  "version": "17.0.3",
+  "version": "17.0.4",
   "description": "React components built for Exchange Solutions products",
   "repository": "https://github.com/wtw-im/es-components",
   "main": "lib/index.js",

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -38,7 +38,6 @@
   },
   "peerDependencies": {
     "react": ">=0.14",
-    "react-dom": ">=0.14",
     "styled-components": "*"
   },
   "devDependencies": {

--- a/packages/es-components/src/components/controls/textbox/Textbox.js
+++ b/packages/es-components/src/components/controls/textbox/Textbox.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css, withTheme } from 'styled-components';
-import { omit } from 'lodash';
+import { noop, omit } from 'lodash';
 import MaskedInput from 'react-text-mask';
 import classnames from 'classnames';
 
@@ -150,6 +150,24 @@ const Textbox = props => {
   const maskArgs =
     maskType === 'custom' && customMask ? customMask : inputMaskType[maskType];
 
+  if (maskType !== 'none') {
+    maskArgs.render = (ref, maskedProps) => {
+      const setRef = inputElement => {
+        // Failing to call ref from the `react-text-mask` render prop will cause
+        // `react-text-mask` to break, as it needs the ref to function
+        ref(inputElement);
+        inputRef(inputElement);
+      };
+
+      // based on ReactTextMask.defaultProps.render since we don't normally use
+      // the render prop
+      // https://github.com/text-mask/text-mask/blob/72ed2c40ecd99817b946f15d3e75a4944b364f4e/react/src/reactTextMask.js#L89
+      return <input ref={setRef} {...maskedProps} />;
+    };
+  } else {
+    additionalTextProps.innerRef = inputRef;
+  }
+
   const addOnTextColor = hasValidationIcon
     ? theme.colors.white
     : theme.colors.gray8;
@@ -179,7 +197,6 @@ const Textbox = props => {
           hasAppend={hasAppend}
           hasPrepend={hasPrepend}
           id={textboxId}
-          innerRef={inputRef}
           name={inputName}
           hasValidationIcon={hasValidationIcon}
           type="text"
@@ -259,7 +276,7 @@ Textbox.defaultProps = {
   validationState: 'default',
   name: null,
   id: undefined,
-  inputRef: undefined,
+  inputRef: noop,
   additionalHelpContent: null,
   prependIconName: undefined,
   appendIconName: undefined,

--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.js
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
 import { noop, pick, omit } from 'lodash';
 import ReactDatePicker from 'react-datepicker';
@@ -12,16 +11,16 @@ import Textbox from '../../controls/textbox/Textbox';
 class DateTextbox extends React.Component {
   static propTypes = Textbox.propTypes; // eslint-disable-line react/forbid-foreign-prop-types
 
-  componentDidMount() {
-    this.inputElement = findDOMNode(this).querySelector('input');
-  }
+  setRef = ref => {
+    this.inputElement = ref;
+  };
 
   focus() {
     this.inputElement.focus();
   }
 
   render() {
-    return <Textbox {...this.props} />;
+    return <Textbox inputRef={this.setRef} {...this.props} />;
   }
 }
 


### PR DESCRIPTION
Closes #212

On one hand `Textbox` is growing into a mess. On the other, we can finally use `refs` with masked inputs again.