### PR TITLE
Radio & Checkbox Style Updates

### DIFF
--- a/packages/es-components/src/components/base/icons/Icon.md
+++ b/packages/es-components/src/components/base/icons/Icon.md
@@ -4,7 +4,7 @@ Icons will inherit their size unless otherwise specified. <a href="https://wtw-b
 const containerStyle = {
   backgroundColor: '#ddd',
   padding: '10px',
-  width: '400px',
+  width: '150px',
 };
 
 <div>

--- a/packages/es-components/src/components/controls/checkbox/Checkbox.js
+++ b/packages/es-components/src/components/controls/checkbox/Checkbox.js
@@ -4,20 +4,38 @@ import styled, { withTheme } from 'styled-components';
 
 import { Label } from '../BaseControls';
 
-/* eslint-disable no-confusing-arrow */
+const backgroundColorSelect = (checked, theme, validationState) => {
+  if (checked) {
+    return validationState === 'default'
+      ? theme.colors.primary
+      : theme.colors[validationState];
+  }
+  return theme.colors.white;
+};
+
 const CheckboxLabel = styled(Label)`
+  color: ${props => props.theme.colors[props.validationState]};
   font-size: ${props => props.theme.sizes.baseFontSize};
   font-weight: bold;
-  text-transform: none;
-  display: flex;
-  flex-flow: wrap;
-  color: ${props => props.theme.colors[props.validationState]};
+  line-height: ${props => props.theme.sizes.baseLineHeight};
+  margin-bottom: 10px;
+  margin-left: -10px;
+  min-height: 25px;
+  padding: 10px 0 10px 42px;
+  position: relative;
+
+  @media (min-width: ${props => props.theme.screenSize.tablet}) {
+    margin-left: 0;
+    padding: 5px 0 5px 32px;
+  }
 
   > .es-checkbox__fill {
-    background-color: ${({ checked, theme }) =>
-      checked ? theme.colors.info : theme.colors.white};
+    background-color: ${({ checked, theme, validationState }) =>
+      backgroundColorSelect(checked, theme, validationState)};
     border-color: ${({ checked, theme, validationState }) =>
-      checked ? theme.colors.info : theme.colors[validationState]};
+      checked && validationState === 'default'
+        ? theme.colors.primary
+        : theme.colors[validationState]};
 
     &:after {
       border-color: ${props => props.theme.colors.white};
@@ -44,6 +62,7 @@ const CheckboxLabel = styled(Label)`
 
 const CheckboxInput = styled.input`
   clip: rect(0, 0, 0, 0);
+  pointer-events: none;
   position: absolute;
 
   &:focus ~ .es-checkbox__fill {
@@ -54,17 +73,24 @@ const CheckboxInput = styled.input`
     }
   }
 `;
-/* eslint-enable */
 
-const CheckboxWrapper = styled.span`
+const CheckboxDisplay = styled.span`
   background: ${props => props.theme.colors.white};
   border: 3px solid ${props => props.theme.colors.gray8};
   border-radius: 4px;
   box-sizing: border-box;
   cursor: pointer;
   height: 25px;
+  left: 10px;
+  position: absolute;
+  top: 0.55em;
   transition: all 0.25s linear;
   width: 25px;
+
+  @media (min-width: ${props => props.theme.screenSize.tablet}) {
+    left: 0;
+    top: 0.35em;
+  }
 
   &:after {
     background: transparent;
@@ -73,26 +99,21 @@ const CheckboxWrapper = styled.span`
     border-top: none;
     box-sizing: border-box;
     content: '';
-    height: 9px;
     display: block;
+    height: 9px;
+    margin: 3px 0 0 2px;
     transform: rotate(-45deg);
     transition: border 0.25s linear;
     width: 15px;
-    margin: 3px 0 0 2px;
   }
-`;
-
-const CheckboxText = styled.span`
-  line-height: ${props => props.theme.sizes.baseLineHeight};
-  margin-left: 5px;
 `;
 
 const AdditionalHelpContent = styled.div`
   font-size: ${props => props.theme.sizes.baseFontSize};
   font-weight: 400;
   margin: 10px 0 10px 0;
-  text-transform: none;
-  flex-basis: 100%;
+  position: relative;
+  right: 32px;
 `;
 
 function Checkbox({
@@ -113,7 +134,7 @@ function Checkbox({
       {additionalHelpContent}
     </AdditionalHelpContent>
   );
-  /* eslint-disable jsx-a11y/use-onblur-not-onchange */
+
   return (
     <CheckboxLabel
       className="es-checkbox"
@@ -127,12 +148,11 @@ function Checkbox({
         focusBorderColor={theme.colors.inputFocus}
         {...checkboxProps}
       />
-      <CheckboxWrapper className="es-checkbox__fill" />
-      <CheckboxText className="es-checkbox__text">{labelText}</CheckboxText>
+      <CheckboxDisplay className="es-checkbox__fill" />
+      {labelText}
       {additionalHelp}
     </CheckboxLabel>
   );
-  /* eslint-enable */
 }
 
 Checkbox.propTypes = {

--- a/packages/es-components/src/components/controls/checkbox/Checkbox.md
+++ b/packages/es-components/src/components/controls/checkbox/Checkbox.md
@@ -1,9 +1,9 @@
 ```
 <div>
   <Checkbox name="uncheckedByDefault" labelText="I am unchecked by default" />
-  <Checkbox name="checkedByDefault" labelText="I am checked by default" checked />
+  <Checkbox name="checkedByDefault" labelText="I am checked by default" checked onChange={()=>{}} />
   <Checkbox name="disabled" labelText="I am disabled" disabled />
-  <Checkbox name="uncheckedByDefault" labelText="I am checked and disabled" checked disabled />
+  <Checkbox name="uncheckedByDefault" labelText="I am checked and disabled" checked onChange={()=>{}} disabled />
 </div>
 ```
 
@@ -12,7 +12,7 @@ Passing a function will execute with the current selection status of the Checkbo
 ```
 class CheckboxExample extends React.Component {
   constructor() {
-    this.state = { 
+    this.state = {
       isAppleChecked: false,
       isBananaChecked: false,
       isStrawberryChecked: true
@@ -28,28 +28,36 @@ class CheckboxExample extends React.Component {
   }
 
   render() {
+    const wrapperStyle = {
+      display: 'flex',
+      flexWrap: 'wrap',
+      justifyContent: 'space-between',
+      maxWidth: '40%',
+      width: '350px'
+    };
+
     return (
-      <div>
-        <Checkbox 
+      <div style={wrapperStyle}>
+        <Checkbox
           name="Apple"
           labelText="Apple"
           value="Apple"
           checked={this.state.isAppleChecked}
-          onClick={this.toggleCheckbox('isAppleChecked')}
+          onChange={this.toggleCheckbox('isAppleChecked')}
         />
-        <Checkbox 
+        <Checkbox
           name="Banana"
           labelText="Banana"
           value="Banana"
           checked={this.state.isBananaChecked}
-          onClick={this.toggleCheckbox('isBananaChecked')}
+          onChange={this.toggleCheckbox('isBananaChecked')}
         />
-        <Checkbox 
+        <Checkbox
           name="Strawberry"
           labelText="Strawberry"
           value="Strawberry"
           checked={this.state.isStrawberryChecked}
-          onClick={this.toggleCheckbox('isStrawberryChecked')}
+          onChange={this.toggleCheckbox('isStrawberryChecked')}
           disabled
         />
       </div>
@@ -59,11 +67,13 @@ class CheckboxExample extends React.Component {
 
 <CheckboxExample />
 ```
+
 ### Validation States
+
 ```
 class CheckboxExample extends React.Component {
   constructor() {
-    this.state = { 
+    this.state = {
       isAppleChecked: false,
       isBananaChecked: false,
       isStrawberryChecked: false
@@ -81,30 +91,30 @@ class CheckboxExample extends React.Component {
   render() {
     return (
       <div>
-        <Checkbox 
+        <Checkbox
           name="Apple_Success"
           labelText="Apple"
           value="Apple"
           checked={this.state.isAppleChecked}
-          onClick={this.toggleCheckbox('isAppleChecked')}
+          onChange={this.toggleCheckbox('isAppleChecked')}
           validationState="success"
           additionalHelpContent="When validationState is set to success."
         />
-        <Checkbox 
+        <Checkbox
           name="Banana_Success"
           labelText="Banana"
           value="Banana"
           checked={this.state.isBananaChecked}
-          onClick={this.toggleCheckbox('isBananaChecked')}
+          onChange={this.toggleCheckbox('isBananaChecked')}
           validationState="warning"
           additionalHelpContent="When validationState is set to warning."
         />
-        <Checkbox 
+        <Checkbox
           name="Strawberry_danger"
           labelText="Strawberry"
           value="Strawberry"
           checked={this.state.isStrawberryChecked}
-          onClick={this.toggleCheckbox('isStrawberryChecked')}
+          onChange={this.toggleCheckbox('isStrawberryChecked')}
           validationState="danger"
           additionalHelpContent="When validationState is set to danger."
         />

--- a/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
@@ -21,28 +21,36 @@ function radioFill(color) {
 }
 
 const RadioLabel = styled(Label)`
-  color: ${props => props.theme.colors[props.validationState]};
-  display: ${props => (props.inline ? 'inline-flex' : 'flex')};
+  color: ${props =>
+    props.disabled
+      ? props.theme.colors.gray7
+      : props.theme.colors[props.validationState]};
+  cursor: pointer;
+  display: flex;
   font-size: ${props => props.theme.sizes.baseFontSize};
   font-weight: bold;
-  margin-bottom: 0;
-  margin-right: ${props => (props.inline ? '15px' : 'initial')};
+  margin-bottom: 10px;
   position: relative;
-  padding: 5px 0;
+  padding: 10px 0 10px 10px;
   text-transform: none;
 
   &:hover .es-radio__fill:before {
     ${props => radioFill(props.hoverFillColor)};
   }
 
-  @media (max-width: ${props => props.theme.screenSize.phone}) {
-    display: flex;
-    margin-right: initial;
+  @media (min-width: ${props => props.theme.screenSize.phone}) {
+    display: ${props => (props.inline ? 'inline-flex' : 'flex')};
+    margin-right: ${props => (props.inline ? '15px' : '0')};
+  }
+
+  @media (min-width: ${props => props.theme.screenSize.tablet}) {
+    padding: 5px 0;
   }
 `;
 
 const RadioInput = styled.input`
-  opacity: 0;
+  clip: rect(0, 0, 0, 0);
+  pointer-events: none;
   position: absolute;
 
   &:focus ~ .es-radio__fill {
@@ -55,7 +63,7 @@ const RadioDisplay = styled.span`
   border-radius: 50%;
   box-sizing: border-box;
   height: 25px;
-  margin-right: 5px;
+  margin-right: 8px;
   width: 25px;
 
   &:before {

--- a/packages/es-components/src/components/controls/radio-buttons/RadioButton.specs.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioButton.specs.js
@@ -6,12 +6,12 @@ import viaTheme from 'es-components-via-theme';
 import getRadioFillVariables from './radio-fill-variables';
 
 describe('getRadioFillVariables', () => {
-  it('returns { fill: gray5, hover: white } when unchecked, disabled, and valid', () => {
+  it('returns { fill: gray5 } when unchecked, disabled, and valid', () => {
     const checked = false;
     const disabled = true;
     const validationState = 'default';
 
-    const { fill, hover } = getRadioFillVariables(
+    const { fill } = getRadioFillVariables(
       checked,
       disabled,
       validationState,
@@ -19,10 +19,9 @@ describe('getRadioFillVariables', () => {
     );
 
     expect(fill).toBe(viaTheme.colors.gray5);
-    expect(hover).toBe(viaTheme.colors.white);
   });
 
-  it('returns { fill: info } when checked, not disabled, and valid', () => {
+  it('returns { fill: primary } when checked, not disabled, and valid', () => {
     const checked = true;
     const disabled = false;
     const validationState = 'default';
@@ -34,7 +33,7 @@ describe('getRadioFillVariables', () => {
       viaTheme.colors
     );
 
-    expect(fill).toBe(viaTheme.colors.info);
+    expect(fill).toBe(viaTheme.colors.primary);
   });
 
   it('returns { fill: gray5 } when checked, disabled, and valid', () => {
@@ -52,7 +51,7 @@ describe('getRadioFillVariables', () => {
     expect(fill).toBe(viaTheme.colors.gray5);
   });
 
-  it('returns { fill: danger, hover: gray8 } when unchecked, not disabled, and invalid', () => {
+  it('returns { fill: danger, hover: gray3 } when unchecked, not disabled, and invalid', () => {
     const checked = false;
     const disabled = false;
     const validationState = 'danger';
@@ -65,10 +64,10 @@ describe('getRadioFillVariables', () => {
     );
 
     expect(fill).toBe(viaTheme.colors.danger);
-    expect(hover).toBe(viaTheme.colors.gray8);
+    expect(hover).toBe(viaTheme.colors.gray3);
   });
 
-  it('returns { fill: info } when checked, not disabled, and invalid', () => {
+  it('returns { fill: danger } when checked, not disabled, and invalid', () => {
     const checked = true;
     const disabled = false;
     const validationState = 'danger';
@@ -80,10 +79,10 @@ describe('getRadioFillVariables', () => {
       viaTheme.colors
     );
 
-    expect(fill).toBe(viaTheme.colors.info);
+    expect(fill).toBe(viaTheme.colors[validationState]);
   });
 
-  it('returns { fill: gray8, hover: gray8 } when unchecked, not disabled, and valid', () => {
+  it('returns { fill: gray8, hover: gray3 } when unchecked, not disabled, and valid', () => {
     const checked = false;
     const disabled = false;
     const validationState = 'default';
@@ -96,6 +95,6 @@ describe('getRadioFillVariables', () => {
     );
 
     expect(fill).toBe(viaTheme.colors.gray8);
-    expect(hover).toBe(viaTheme.colors.gray8);
+    expect(hover).toBe(viaTheme.colors.gray3);
   });
 });

--- a/packages/es-components/src/components/controls/radio-buttons/RadioGroup.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioGroup.js
@@ -19,7 +19,7 @@ const AdditionalHelpContent = styled.div`
   color: ${props => props.theme.colors[props.validationState]};
   font-size: ${props => props.theme.sizes.baseFontSize};
   font-weight: 400;
-  margin: 10px 0 10px 0;
+  margin-bottom: 10px;
   text-transform: none;
 `;
 

--- a/packages/es-components/src/components/controls/radio-buttons/radio-fill-variables.js
+++ b/packages/es-components/src/components/controls/radio-buttons/radio-fill-variables.js
@@ -4,38 +4,28 @@ export default function getRadioFillVariables(
   validationState,
   colors
 ) {
-  const isNotChecked = !isChecked;
   const isNotDisabled = !isDisabled;
   const isValid = validationState === 'default';
 
-  if (isNotChecked && isDisabled && isValid) {
-    return {
-      hover: colors.white,
-      fill: colors.gray5
-    };
+  if (isDisabled) {
+    return { fill: colors.gray5 };
   }
 
-  if (isNotChecked && isNotDisabled && !isValid) {
+  if (isNotDisabled && !isValid) {
     return {
       fill: colors[validationState],
-      hover: colors.gray8
+      hover: colors.gray3
     };
   }
 
   if (isChecked && isNotDisabled) {
     return {
-      fill: colors.info
-    };
-  }
-
-  if (isChecked && isDisabled && isValid) {
-    return {
-      fill: colors.gray5
+      fill: colors.primary
     };
   }
 
   return {
-    hover: colors.gray8,
-    fill: colors.gray8
+    fill: colors.gray8,
+    hover: colors.gray3
   };
 }

--- a/packages/es-components/src/components/controls/textbox/Textbox.md
+++ b/packages/es-components/src/components/controls/textbox/Textbox.md
@@ -60,7 +60,7 @@ The `labelSuffix` prop will display additional styled content after the label te
 ```
 <Textbox
   labelText="Middle name"
-  labelSuffix="Optional"
+  labelSuffix={<span>Optional</span>}
 />
 ```
 
@@ -174,10 +174,10 @@ Provide an `appendText` or `prependText` prop for appending and prepending input
 </div>
 ```
 
-
 ### Custom masks
 
 Create your own text mask using the structure documented [here](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#text-mask-documentation).
+
 ```
 const mask = {
     mask: [/[A-Za-z]/, /[A-Za-z]/, /[A-Za-z]/, '-', /[A-Za-z]/, /[A-Za-z]/, /[A-Za-z]/],
@@ -188,7 +188,6 @@ const mask = {
 
 <Textbox name="maskExample" labelText="Enter 6 Letters (No Numbers)" maskType="custom" customMask={mask} />
 ```
-
 
 ### Additional props
 

--- a/packages/es-components/src/components/theme/Themes.md
+++ b/packages/es-components/src/components/theme/Themes.md
@@ -1,6 +1,7 @@
 To apply a theme wrap your root react app component in a `<ThemeProvider theme='[themeName]'>` wrapper component. The `ThemeProvider` wrapper provides the supplied theme to any components underneath it. See [styled-components Theming](https://www.styled-components.com/docs/advanced#theming).
 
 Example:
+
 ```html
 import { ThemeProvider } from 'styled-components';
 import viaTheme from 'es-components-via-theme';
@@ -19,20 +20,24 @@ The [via benefits theme](https://www.npmjs.com/package/es-components-via-theme) 
 
 <table style="margin-bottom: 1.5em">
 	<tbody>
-		<tr><th colspan="7" style="text-align: left">Via</th></tr>
+		<tr><th colspan="3" style="text-align: left">Via</th></tr>
 		<tr>
 			<td>Primary <div style="background-color: #007fa7; padding: 1em; width: 50px"></div></td>
 			<td>Default <div style="background-color: #d8d8d8; padding: 1em; width: 50px"></div></td>
 			<td>Info <div style="background-color: #069; padding: 1em; width: 50px"></div></td>
+		</tr>
+		<tr>
 			<td>Success <div style="background-color: #298544; padding: 1em; width: 50px"></div></td>
 			<td>Warning <div style="background-color: #b35f00; padding: 1em; width: 50px"></div></td>
 			<td>Danger <div style="background-color: #c00; padding: 1em; width: 50px"></div></td>
 		</tr>
-		<tr><th colspan="7" style="text-align: left">WTW</th></tr>
+		<tr><th colspan="3" style="text-align: left">WTW</th></tr>
 		<tr>
 			<td>Primary <div style="background-color: #702082; padding: 1em; width: 50px"></div></td>
 			<td>Default <div style="background-color: #444; padding: 1em; width: 50px"></div></td>
 			<td>Info <div style="background-color: #1b6284; padding: 1em; width: 50px"></div></td>
+		</tr>
+		<tr>
 			<td>Success <div style="background-color: #009865; padding: 1em; width: 50px"></div></td>
 			<td>Warning <div style="background-color: #de7400; padding: 1em; width: 50px"></div></td>
 			<td>Danger <div style="background-color: #a31e22; padding: 1em; width: 50px"></div></td>

--- a/packages/es-components/styleguide.config.js
+++ b/packages/es-components/styleguide.config.js
@@ -32,6 +32,11 @@ module.exports = {
         input, button, select, textarea {
           font-family: inherit;
         }
+        
+        code {
+          white-space: pre-wrap !important;
+          word-break: break-word !important;
+        }
       </style>
       <link rel="stylesheet" href="https://cdn.rawgit.com/WTW-IM/es-assets/8fbaf85d/font.css">
       <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,200i,300,300i,400,400i,600,600i,700,700i,900,900i" rel="stylesheet">`


### PR DESCRIPTION
Updates styles and padding to match UX Toolkit updates. Makes radio & checkbox controls a little easier to use on touch/smaller devices.

Note: Discussed with Geoff C. and it was decided to make the checked styles match the validationState colors. This is not reflected yet on the UX Toolkit.

Also updates some styles in the style guide website so it can actually behave responsively.