### PR TITLE
Use hooks where currently applicable

### DIFF
--- a/packages/es-components/package-lock.json
+++ b/packages/es-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components",
-  "version": "18.0.1",
+  "version": "18.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11627,15 +11627,15 @@
       }
     },
     "react": {
-      "version": "16.5.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.5.1.tgz",
-      "integrity": "sha512-E+23+rbpPsJgSX812LQkwupUCFnbVE84+L8uxlkqN5MU0DcraWMlVf9cRvKCKtGu0XvScyRnW7Z+9d7ymkjy3A==",
+      "version": "16.7.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.7.0-alpha.2.tgz",
+      "integrity": "sha512-Xh1CC8KkqIojhC+LFXd21jxlVtzoVYdGnQAi/I2+dxbmos9ghbx5TQf9/nDxc4WxaFfUQJkya0w1k6rMeyIaxQ==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "schedule": "^0.4.0"
+        "scheduler": "^0.12.0-alpha.2"
       },
       "dependencies": {
         "prop-types": {
@@ -11929,15 +11929,27 @@
       }
     },
     "react-dom": {
-      "version": "16.4.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
-      "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
+      "version": "16.7.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.7.0-alpha.2.tgz",
+      "integrity": "sha512-o0mMw8jBlwHjGZEy/vvKd/6giAX0+skREMOTs3/QHmgi+yAhUClp4My4Z9lsKy3SXV+03uPdm1l/QM7NTcGuMw==",
       "dev": true,
       "requires": {
-        "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.12.0-alpha.2"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-error-overlay": {
@@ -13276,12 +13288,13 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
-    "schedule": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/schedule/-/schedule-0.4.0.tgz",
-      "integrity": "sha512-hYjmoaEMojiMkWCxKr6ue+LYcZ29u29+AamWYmzwT2VOO9ws5UJp/wNhsVUPiUeNh+EdRfZm7nDeB40ffTfMhA==",
+    "scheduler": {
+      "version": "0.12.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.12.0-alpha.2.tgz",
+      "integrity": "sha512-bfqFzGH18MjjhePIzYQNR0uGQ1wMCX6Q83c2s+3fzyuqKT6zBI2wNQTpq01q72C7QItAp8if5w2LfMiXnI2SYw==",
       "dev": true,
       "requires": {
+        "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
       }
     },

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -37,7 +37,7 @@
     "singleQuote": true
   },
   "peerDependencies": {
-    "react": ">=0.14",
+    "react": ">=16.7",
     "styled-components": "*"
   },
   "devDependencies": {
@@ -68,8 +68,8 @@
     "jest-dom": "^2.1.0",
     "mockdate": "^2.0.1",
     "prettier": "^1.14.1",
-    "react": "^16.4.1",
-    "react-dom": "^16.4.1",
+    "react": "^16.7.0-alpha.2",
+    "react-dom": "^16.7.0-alpha.2",
     "react-styleguidist": "^7.3.8",
     "react-test-renderer": "^16.3.0",
     "react-testing-library": "^5.2.3",

--- a/packages/es-components/src/components/containers/menu/InlineContext.js
+++ b/packages/es-components/src/components/containers/menu/InlineContext.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const InlineContext = React.createContext(false);

--- a/packages/es-components/src/components/containers/menu/Menu.js
+++ b/packages/es-components/src/components/containers/menu/Menu.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import classnames from 'classnames';
@@ -6,6 +6,7 @@ import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
 import ToggleButton from '../../controls/buttons/ToggleButton';
 import MenuPanel from './MenuPanel';
 import MenuSection from './MenuSection';
+import { InlineContext } from './InlineContext';
 
 const Backdrop = styled.div`
   background-color: black;
@@ -20,69 +21,58 @@ const Backdrop = styled.div`
   display: ${props => (props.isMenuOpen ? 'inherit' : 'none')};
 `;
 
-export class Menu extends React.Component {
-  static childContextTypes = {
-    inline: PropTypes.bool
-  };
+function Menu(props) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-  state = {
-    isMenuOpen: false
-  };
-
-  getChildContext() {
-    return { inline: this.props.inline };
+  function toggleMenu() {
+    setIsMenuOpen(!isMenuOpen);
   }
 
-  toggleMenu = () => {
-    this.setState(previousState => ({ isMenuOpen: !previousState.isMenuOpen }));
-  };
+  function closeMenu() {
+    setIsMenuOpen(false);
+  }
 
-  closeMenu = () => {
-    if (this.state.isMenuOpen) {
-      this.setState({ isMenuOpen: false });
-    }
-  };
+  const {
+    inline,
+    children,
+    buttonContent,
+    className,
+    openButtonType,
+    rootClose,
+    hasBackdrop,
+    headerContent
+  } = props;
 
-  render() {
-    const {
-      children,
-      buttonContent,
-      className,
-      openButtonType,
-      rootClose,
-      hasBackdrop,
-      headerContent
-    } = this.props;
-
-    return (
-      <RootCloseWrapper onRootClose={this.closeMenu} disabled={!rootClose}>
-        <div className={classnames('es-menu', className)}>
-          {hasBackdrop && (
-            <Backdrop
-              className="es-menu__backdrop"
-              isMenuOpen={this.state.isMenuOpen}
-              onClick={this.closeMenu}
-            />
-          )}
-          <ToggleButton
-            handleOnClick={this.toggleMenu}
-            isPressed={this.state.isMenuOpen}
-            styleType={openButtonType}
-            aria-expanded={this.state.isMenuOpen}
-          >
-            {buttonContent}
-          </ToggleButton>
+  return (
+    <RootCloseWrapper onRootClose={closeMenu} disabled={!rootClose}>
+      <div className={classnames('es-menu', className)}>
+        {hasBackdrop && (
+          <Backdrop
+            className="es-menu__backdrop"
+            isMenuOpen={isMenuOpen}
+            onClick={closeMenu}
+          />
+        )}
+        <ToggleButton
+          handleOnClick={toggleMenu}
+          isPressed={isMenuOpen}
+          styleType={openButtonType}
+          aria-expanded={isMenuOpen}
+        >
+          {buttonContent}
+        </ToggleButton>
+        <InlineContext.Provider value={inline}>
           <MenuPanel
             headerContent={headerContent}
-            isOpen={this.state.isMenuOpen}
-            onClose={this.closeMenu}
+            isOpen={isMenuOpen}
+            onClose={closeMenu}
           >
             {children}
           </MenuPanel>
-        </div>
-      </RootCloseWrapper>
-    );
-  }
+        </InlineContext.Provider>
+      </div>
+    </RootCloseWrapper>
+  );
 }
 
 Menu.MenuSection = MenuSection;

--- a/packages/es-components/src/components/containers/menu/Menu.specs.js
+++ b/packages/es-components/src/components/containers/menu/Menu.specs.js
@@ -2,17 +2,13 @@
 
 import React from 'react';
 import { fireEvent } from 'react-testing-library';
-import { Menu } from './Menu';
+import Menu from './Menu';
 
 import { renderWithTheme } from '../../util/test-utils';
 
 function buildMenu() {
   return (
-    <Menu
-      headerContent="Small Menu"
-      buttonContent="Open Menu"
-      className="test"
-    >
+    <Menu headerContent="Small Menu" buttonContent="Open Menu" className="test">
       <Menu.MenuSection title="Menu Section" isFirst>
         <a href="#test">Test link</a>
       </Menu.MenuSection>

--- a/packages/es-components/src/components/containers/menu/MenuPanel.js
+++ b/packages/es-components/src/components/containers/menu/MenuPanel.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useEffect, useContext } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import DismissButton from '../../controls/DismissButton';
+import { InlineContext } from './InlineContext';
 
 const StyledPanel = styled.div`
   background-color: ${props => props.theme.colors.gray2};
@@ -31,37 +32,37 @@ const StyledChildrenContainer = styled.div`
   flex-wrap: wrap;
 `;
 
-class MenuPanel extends React.Component {
-  componentDidMount = () => {
-    document.addEventListener('keydown', this.onEscape);
-  };
-
-  componentWillUnmount = () => {
-    document.removeEventListener('keydown', this.onEscape);
-  };
-
-  onEscape = ({ keyCode }) => {
+function MenuPanel(props) {
+  function onEscape({ keyCode }) {
     if (keyCode === 27) {
-      this.props.onClose();
+      props.onClose();
     }
-  };
-
-  render() {
-    const { children, headerContent, isOpen, onClose } = this.props;
-    const hasHeaderContent = !!headerContent;
-
-    return (
-      <StyledPanel isOpen={isOpen} className="es-menu__panel">
-        <Header hasHeaderContent={hasHeaderContent}>
-          {hasHeaderContent && <span>{headerContent}</span>}
-          <StyledDismissButton onClick={onClose} />
-        </Header>
-        <StyledChildrenContainer inline={this.context.inline}>
-          {children}
-        </StyledChildrenContainer>
-      </StyledPanel>
-    );
   }
+
+  useEffect(() => {
+    document.addEventListener('keydown', onEscape);
+
+    return function removeKeydownListener() {
+      document.removeEventListener('keydown', onEscape);
+    };
+  });
+
+  const { children, headerContent, isOpen, onClose } = props;
+  const hasHeaderContent = !!headerContent;
+
+  const inline = useContext(InlineContext);
+
+  return (
+    <StyledPanel isOpen={isOpen} className="es-menu__panel">
+      <Header hasHeaderContent={hasHeaderContent}>
+        {hasHeaderContent && <span>{headerContent}</span>}
+        <StyledDismissButton onClick={onClose} />
+      </Header>
+      <StyledChildrenContainer inline={inline}>
+        {children}
+      </StyledChildrenContainer>
+    </StyledPanel>
+  );
 }
 
 MenuPanel.propTypes = {

--- a/packages/es-components/src/components/containers/modal/Modal.js
+++ b/packages/es-components/src/components/containers/modal/Modal.js
@@ -6,6 +6,7 @@ import BaseModal from 'react-overlays/lib/Modal';
 
 import genId from '../../util/generateAlphaName';
 import Fade from '../../util/Fade';
+import { ModalContext } from './ModalContext';
 import Header from './ModalHeader';
 import Body from './ModalBody';
 import Footer from './ModalFooter';
@@ -59,64 +60,49 @@ const ModalContent = styled.div`
   position: relative;
 `;
 
-class Modal extends React.Component {
-  constructor(props, context) {
-    super(props, context);
-
-    this.state = {
-      ariaId: genId()
-    };
+function getModalBySize(size) {
+  switch (size) {
+    case 'small':
+      return ModalDialogSmall;
+    case 'large':
+      return ModalDialogLarge;
+    default:
+      return ModalDialogMedium;
   }
+}
 
-  getChildContext() {
-    return {
-      modal: {
-        onHide: this.props.onHide,
-        ariaId: this.state.ariaId
-      }
-    };
-  }
+function Modal(props) {
+  const {
+    animation,
+    backdrop,
+    children,
+    escapeExits,
+    onEnter,
+    onExit,
+    onHide,
+    show,
+    size,
+    theme
+  } = props;
 
-  render() {
-    const {
-      animation,
-      backdrop,
-      children,
-      escapeExits,
-      onEnter,
-      onExit,
-      onHide,
-      show,
-      size,
-      theme
-    } = this.props;
+  const backdropStyle = {
+    backgroundColor: theme.colors.black,
+    bottom: 0,
+    cursor: backdrop === 'static' ? 'auto' : 'pointer',
+    left: 0,
+    opacity: 0.5,
+    position: 'fixed',
+    right: 0,
+    top: 0,
+    zIndex: 'auto'
+  };
 
-    const backdropStyle = {
-      backgroundColor: theme.colors.black,
-      bottom: 0,
-      cursor: backdrop === 'static' ? 'auto' : 'pointer',
-      left: 0,
-      opacity: 0.5,
-      position: 'fixed',
-      right: 0,
-      top: 0,
-      zIndex: 'auto'
-    };
+  const ModalDialog = getModalBySize(size);
 
-    let ModalDialog;
-    switch (size) {
-      case 'small':
-        ModalDialog = ModalDialogSmall;
-        break;
-      case 'large':
-        ModalDialog = ModalDialogLarge;
-        break;
-      default:
-        ModalDialog = ModalDialogMedium;
-        break;
-    }
+  const ariaId = genId();
 
-    return (
+  return (
+    <ModalContext.Provider value={{ onHide, ariaId }}>
       <DialogWrapper
         backdrop={backdrop}
         backdropStyle={backdropStyle}
@@ -130,14 +116,14 @@ class Modal extends React.Component {
       >
         <ModalDialog
           size={size}
-          aria-labelledby={this.state.ariaId}
+          aria-labelledby={ariaId}
           className="es-modal__dialog"
         >
           <ModalContent className="es-modal__content">{children}</ModalContent>
         </ModalDialog>
       </DialogWrapper>
-    );
-  }
+    </ModalContext.Provider>
+  );
 }
 
 Modal.propTypes = {
@@ -185,13 +171,6 @@ Modal.defaultProps = {
   show: false,
   size: 'medium',
   children: undefined
-};
-
-Modal.childContextTypes = {
-  modal: PropTypes.shape({
-    onHide: PropTypes.func,
-    ariaId: PropTypes.string
-  })
 };
 
 Modal.Header = Header;

--- a/packages/es-components/src/components/containers/modal/ModalContext.js
+++ b/packages/es-components/src/components/containers/modal/ModalContext.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const ModalContext = React.createContext({});

--- a/packages/es-components/src/components/containers/modal/ModalHeader.js
+++ b/packages/es-components/src/components/containers/modal/ModalHeader.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { noop } from 'lodash';
 import DismissButton from '../../controls/DismissButton';
+import { ModalContext } from './ModalContext';
 
 // Note: ModalHeader relies on a parent (Modal) with ThemeProvider wrapping it
 const Header = styled.div`
@@ -32,10 +32,9 @@ const DismissModal = styled(DismissButton)`
   }
 `;
 
-const ModalHeader = (props, { modal }) => {
+function ModalHeader(props) {
   const { hideCloseButton, children, ...otherProps } = props;
-  const onHide = modal ? modal.onHide : noop;
-  const ariaId = modal ? modal.ariaId : null;
+  const { onHide, ariaId } = useContext(ModalContext);
 
   return (
     <Header {...otherProps}>
@@ -44,7 +43,7 @@ const ModalHeader = (props, { modal }) => {
       {!hideCloseButton && <DismissModal onClick={onHide} />}
     </Header>
   );
-};
+}
 
 ModalHeader.propTypes = {
   /** Specify whether the modal header should contain a close button */

--- a/packages/es-components/src/components/containers/tabPanels/TabPanel.js
+++ b/packages/es-components/src/components/containers/tabPanels/TabPanel.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { noop } from 'lodash';
@@ -29,55 +29,43 @@ const TabContent = styled.div`
   border-top: 1px solid ${props => props.theme.colors.gray4};
 `;
 
-class TabPanel extends React.Component {
-  constructor(props) {
-    super(props);
-    const child = Array.isArray(this.props.children)
-      ? props.children[0]
-      : props.children;
-    this.state = {
-      value: child.props.name,
-      currentContent: child.props.children
-    };
-    this.tabChanged = this.tabChanged.bind(this);
-  }
+function TabPanel(props) {
+  const content = Array.isArray(props.children)
+    ? props.children[0]
+    : props.children;
 
-  componentDidUpdate(prevProp, prevState) {
-    if (this.state.value !== prevState.value) {
-      this.props.tabChanged(this.state.value);
+  const [value, setValue] = useState(content.props.name);
+  const [currentContent, setCurrentContent] = useState(content.props.children);
+
+  function tabChanged(name, child) {
+    if (name !== value) {
+      setValue(name);
+      setCurrentContent(child);
+      props.tabChanged(value);
     }
   }
 
-  tabChanged(name, child) {
-    this.setState({
-      value: name,
-      currentContent: child
+  const { children } = props;
+  const elements = React.Children.map(children, (child, i) => {
+    const isSelected = child.props.name.key ?
+      child.props.name.key === value.key :
+      child.props.name === value.name
+    return React.cloneElement(child, {
+      selected: isSelected,
+      action: tabChanged
     });
-  }
+  });
 
-  render() {
-    const { children } = this.props;
-    const elements = React.Children.map(children, (child, i) => {
-      const isSelected = child.props.name.key
-        ? child.props.name.key === this.state.value.key
-        : child.props.name === this.state.value;
-      return React.cloneElement(child, {
-        selected: isSelected,
-        action: this.tabChanged
-      });
-    });
-
-    return (
-      <div className="es-tab-panel">
-        <TabWrapper className="es-tab-panel__wrapper">
-          <TabFormatter className="es-tab-panel__tabs">{elements}</TabFormatter>
-        </TabWrapper>
-        <TabContent className="es-tab-panel__content">
-          {this.state.currentContent}
-        </TabContent>
-      </div>
-    );
-  }
+  return (
+    <div className="es-tab-panel">
+      <TabWrapper className="es-tab-panel__wrapper">
+        <TabFormatter className="es-tab-panel__tabs">{elements}</TabFormatter>
+      </TabWrapper>
+      <TabContent className="es-tab-panel__content">
+        {currentContent}
+      </TabContent>
+    </div>
+  );
 }
 
 function childrenRule(props, propName, component) {

--- a/packages/es-components/src/components/containers/tooltip/Tooltip.js
+++ b/packages/es-components/src/components/containers/tooltip/Tooltip.js
@@ -1,7 +1,7 @@
 /* eslint react/no-unused-prop-types: 0 */
 /* ^^^ We need to declare the Theme prop for documentation. */
 
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Overlay from 'react-overlays/lib/Overlay';
 import styled from 'styled-components';
@@ -159,61 +159,60 @@ Popup.defaultProps = {
   style: {}
 };
 
-class Tooltip extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { show: false };
+function Tooltip(props) {
+  const [show, setShow] = useState(false);
+
+  function showTooltip() {
+    setShow(true);
   }
 
-  show = () => this.setState({ show: true });
+  function hideTooltip() {
+    setShow(false);
+  }
 
-  hide = () => this.setState({ show: false });
+  function toggleShow() {
+    setShow(!show);
+  }
 
-  toggleShow = () => {
-    this.setState(({ show }) => ({ show: !show }));
-  };
-
-  closeOnEscape = event => {
+  function closeOnEscape(event) {
     if (event.keyCode === 27) {
-      this.setState({ show: false });
+      setShow(false);
     }
-  };
-
-  render() {
-    return (
-      <span>
-        <StyledButton
-          className="es-tooltip__target"
-          ref={span => {
-            this.toolTipTarget = span;
-          }}
-          isLinkButton
-          onBlur={this.hide}
-          onFocus={this.show}
-          onMouseEnter={!this.props.disableHover ? this.show : undefined}
-          onMouseLeave={!this.props.disableHover ? this.hide : undefined}
-          onMouseDown={this.toggleShow}
-          onKeyDown={this.closeOnEscape}
-          handleOnClick={() => {}}
-          aria-describedby={`es-tooltip__${this.props.name}`}
-        >
-          {this.props.children}
-        </StyledButton>
-
-        <Overlay
-          show={this.state.show}
-          placement={this.props.position}
-          container={document.body}
-          target={props => this.toolTipTarget}
-          transition={FadeTransition}
-        >
-          <Popup position={this.props.position} name={this.props.name}>
-            {this.props.content}
-          </Popup>
-        </Overlay>
-      </span>
-    );
   }
+
+  const tooltipTarget = React.createRef();
+
+  return (
+    <span>
+      <StyledButton
+        className="es-tooltip__target"
+        ref={tooltipTarget}
+        isLinkButton
+        onBlur={hideTooltip}
+        onFocus={showTooltip}
+        onMouseEnter={!props.disableHover ? showTooltip : undefined}
+        onMouseLeave={!props.disableHover ? hideTooltip : undefined}
+        onMouseDown={toggleShow}
+        onKeyDown={closeOnEscape}
+        handleOnClick={() => {}}
+        aria-describedby={`es-tooltip__${props.name}`}
+      >
+        {props.children}
+      </StyledButton>
+
+      <Overlay
+        show={show}
+        placement={props.position}
+        container={document.body}
+        target={() => tooltipTarget.current}
+        transition={FadeTransition}
+      >
+        <Popup position={props.position} name={props.name}>
+          {props.content}
+        </Popup>
+      </Overlay>
+    </span>
+  );
 }
 
 Tooltip.propTypes = {

--- a/packages/es-components/src/components/controls/buttons/DropdownButton.js
+++ b/packages/es-components/src/components/controls/buttons/DropdownButton.js
@@ -1,4 +1,4 @@
-import React, { Children } from 'react';
+import React, { useState, useEffect, Children } from 'react';
 import PropTypes from 'prop-types';
 import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
 import styled from 'styled-components';
@@ -84,7 +84,7 @@ function focusTrap(node) {
 
   node.addEventListener('keydown', handleTabFocus);
 
-  return () => {
+  return function removeKeydownListener() {
     node.removeEventListener('keydown', handleTabFocus);
   };
 }
@@ -120,110 +120,101 @@ function arrowMovement(node) {
 
   node.addEventListener('keydown', handleArrowMovementKeys);
 
-  return () => {
+  return function removeArrowMovementListener() {
     node.removeEventListener('keydown', handleArrowMovementKeys);
   };
 }
 
-export class DropdownButton extends React.Component {
-  constructor(props) {
-    super();
+function DropdownButton(props) {
+  const [buttonValue, setButtonValue] = useState(props.buttonValue);
+  const [isOpen, setIsOpen] = useState(false);
 
-    this.state = {
-      buttonValue: props.buttonValue,
-      isOpen: false
-    };
-  }
+  const buttonDropdown = React.createRef();
+  const triggerButton = React.createRef();
 
-  componentDidMount() {
-    this.removeFocusTrapListener = focusTrap(this.buttonDropdown);
-    this.removeArrowMovementListener = arrowMovement(this.buttonDropdown);
-  }
+  useEffect(
+    () => {
+      const removeFocusTrapListener = focusTrap(buttonDropdown.current);
+      const removeArrowMovementListener = arrowMovement(buttonDropdown.current);
 
-  componentDidUpdate(prevProps, prevState) {
-    if (prevState.isOpen !== this.state.isOpen) {
-      this.triggerButton.focus();
+      return function removeListeners() {
+        removeFocusTrapListener();
+        removeArrowMovementListener();
+      };
+    },
+    [isOpen]
+  );
+
+  useEffect(
+    () => {
+      triggerButton.current.focus();
+    },
+    [isOpen]
+  );
+
+  const toggleDropdown = () => setIsOpen(!isOpen);
+
+  function closeDropdown() {
+    if (isOpen) {
+      setIsOpen(false);
     }
   }
 
-  componentWillUnmount() {
-    this.removeFocusTrapListener();
-    this.removeArrowMovementListener();
-  }
-
-  setTriggerButton = ref => {
-    this.triggerButton = ref;
-  };
-
-  setButtonDropdownRef = ref => {
-    this.buttonDropdown = ref;
-  };
-
-  toggleDropdown = () => {
-    this.setState(previousState => ({ isOpen: !previousState.isOpen }));
-  };
-
-  closeDropdown = () => {
-    if (this.state.isOpen) {
-      this.setState({ isOpen: false });
-    }
-  };
-
-  handleDropdownItemClick = buttonProps => {
-    const { shouldCloseOnButtonClick, shouldUpdateButtonValue } = this.props;
+  function handleDropdownItemClick(buttonProps) {
+    const { shouldCloseOnButtonClick, shouldUpdateButtonValue } = props;
 
     return event => {
       if (shouldUpdateButtonValue) {
-        this.setState({ buttonValue: buttonProps.children });
+        setButtonValue(buttonProps.children);
       }
       if (shouldCloseOnButtonClick) {
-        this.closeDropdown();
+        closeDropdown();
       }
 
       buttonProps.handleOnClick(event, buttonProps.name);
     };
-  };
-
-  render() {
-    const { rootClose, children, className, manualButtonValue } = this.props;
-    const panelId = generateAlphaName();
-    return (
-      <RootCloseWrapper onRootClose={this.closeDropdown} disabled={!rootClose}>
-        <div
-          ref={this.setButtonDropdownRef}
-          className={className}
-          role="combobox"
-          aria-controls={panelId}
-          aria-expanded={this.state.isOpen}
-          aria-haspopup="listbox"
-        >
-          <Button
-            handleOnClick={this.toggleDropdown}
-            aria-haspopup="true"
-            aria-pressed={this.state.isOpen}
-            innerRef={this.setTriggerButton}
-          >
-            {manualButtonValue || this.state.buttonValue}
-            <Caret />
-          </Button>
-          <ButtonPanel isOpen={this.state.isOpen} id={panelId}>
-            <ButtonPanelChildrenContainer>
-              {Children.map(children, child => {
-                const onClickHandler = this.handleDropdownItemClick(
-                  child.props
-                );
-                const newProps = {
-                  handleOnClick: onClickHandler,
-                  role: 'option'
-                };
-                return React.cloneElement(child, newProps);
-              })}
-            </ButtonPanelChildrenContainer>
-          </ButtonPanel>
-        </div>
-      </RootCloseWrapper>
-    );
   }
+
+  const { rootClose, children, className, manualButtonValue } = props;
+  const panelId = generateAlphaName();
+  return (
+    <RootCloseWrapper onRootClose={closeDropdown} disabled={!rootClose}>
+      <div
+        ref={buttonDropdown}
+        className={className}
+        role="combobox"
+        aria-controls={panelId}
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+      >
+        <Button
+          handleOnClick={toggleDropdown}
+          aria-haspopup="true"
+          aria-pressed={isOpen}
+          innerRef={triggerButton}
+        >
+          {manualButtonValue || buttonValue}
+          <Caret />
+        </Button>
+        <ButtonPanel
+          className="es-button-dropdown__button-panel"
+          isOpen={isOpen}
+          id={panelId}
+        >
+          <ButtonPanelChildrenContainer>
+            {Children.map(children, child => {
+              const onClickHandler = handleDropdownItemClick(child.props);
+              const newProps = {
+                handleOnClick: onClickHandler,
+                role: 'option'
+              };
+              return React.cloneElement(child, newProps);
+            })}
+          </ButtonPanelChildrenContainer>
+        </ButtonPanel>
+      </div>
+    </RootCloseWrapper>
+  );
 }
 
 DropdownButton.Button = StyledButtonLink;

--- a/packages/es-components/src/components/controls/buttons/DropdownButton.specs.js
+++ b/packages/es-components/src/components/controls/buttons/DropdownButton.specs.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { cleanup, fireEvent, getByRole } from 'react-testing-library';
 
-import { DropdownButton } from './DropdownButton';
+import DropdownButton from './DropdownButton';
 import { renderWithTheme } from '../../util/test-utils';
 
 const onClick = jest.fn();

--- a/packages/es-components/src/components/controls/buttons/ToggleButton.js
+++ b/packages/es-components/src/components/controls/buttons/ToggleButton.js
@@ -1,82 +1,72 @@
 /* eslint no-confusing-arrow: 0 */
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled, { withTheme } from 'styled-components';
 
 import Button from './Button';
 
-export class ToggleButton extends React.Component {
-  state = {
-    isPressed: this.props.isPressed
-  };
+function ToggleButton(props) {
+  const [isPressed, setIsPressed] = useState(props.isPressed);
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.isPressed !== this.state.isPressed) {
-      this.setState({ isPressed: nextProps.isPressed });
-    }
+  function toggleButton(event) {
+    setIsPressed(!isPressed);
+    props.handleOnClick(event);
   }
 
-  toggleButton = event => {
-    this.setState(previousState => ({ isPressed: !previousState.isPressed }));
-    this.props.handleOnClick(event);
+  const {
+    buttonClasses,
+    styleType,
+    isLinkButton,
+    size,
+    block,
+    isOutline,
+    theme,
+    ...buttonProps
+  } = props;
+
+  const defaultButton = {
+    bgColor: theme.colors.defaultColor,
+    textColor: theme.colors.defaultBtnText,
+    hoverBgColor: theme.colors.defaultHover,
+    hoverTextColor: theme.colors.defaultBtnText,
+    activeBgColor: theme.colors.defaultHover,
+    activeTextColor: theme.colors.defaultBtnText,
+    boxShadowColor: theme.colors.defaultHover,
+    borderColor: theme.colors.defaultColor
+  };
+  const defaultOutline = {
+    bgColor: theme.colors.white,
+    textColor: theme.colors.defaultColor,
+    hoverBgColor: theme.colors.defaultColor,
+    hoverTextColor: theme.colors.white,
+    activeBgColor: theme.colors.defaultHover,
+    activeTextColor: theme.colors.white,
+    borderColor: theme.colors.defaultColor
   };
 
-  render() {
-    const {
-      buttonClasses,
-      styleType,
-      isLinkButton,
-      size,
-      block,
-      isOutline,
-      theme,
-      ...buttonProps
-    } = this.props;
-
-    const defaultButton = {
-      bgColor: theme.colors.defaultColor,
-      textColor: theme.colors.defaultBtnText,
-      hoverBgColor: theme.colors.defaultHover,
-      hoverTextColor: theme.colors.defaultBtnText,
-      activeBgColor: theme.colors.defaultHover,
-      activeTextColor: theme.colors.defaultBtnText,
-      boxShadowColor: theme.colors.defaultHover,
-      borderColor: theme.colors.defaultColor
-    };
-    const defaultOutline = {
-      bgColor: theme.colors.white,
-      textColor: theme.colors.defaultColor,
-      hoverBgColor: theme.colors.defaultColor,
-      hoverTextColor: theme.colors.white,
-      activeBgColor: theme.colors.defaultHover,
-      activeTextColor: theme.colors.white,
-      borderColor: theme.colors.defaultColor
-    };
-
-    let variant;
-    if (isOutline) {
-      variant = theme.buttonStyles.buttonsOutline[styleType] || defaultOutline;
-    } else {
-      variant = theme.buttonStyles.buttonsNormal[styleType] || defaultButton;
-    }
-
-    return (
-      <StyledToggleButton
-        {...buttonProps}
-        handleOnClick={this.toggleButton}
-        buttonClasses={buttonClasses}
-        styleType={styleType}
-        isLinkButton={isLinkButton}
-        size={size}
-        block={block}
-        isOutline={isOutline}
-        isPressed={this.state.isPressed}
-        variant={variant}
-      >
-        {this.props.children}
-      </StyledToggleButton>
-    );
+  let variant;
+  if (isOutline) {
+    variant = theme.buttonStyles.buttonsOutline[styleType] || defaultOutline;
+  } else {
+    variant = theme.buttonStyles.buttonsNormal[styleType] || defaultButton;
   }
+
+  return (
+    <StyledToggleButton
+      {...buttonProps}
+      handleOnClick={toggleButton}
+      buttonClasses={buttonClasses}
+      styleType={styleType}
+      isLinkButton={isLinkButton}
+      size={size}
+      block={block}
+      isOutline={isOutline}
+      isPressed={isPressed}
+      variant={variant}
+    >
+      {props.children}
+    </StyledToggleButton>
+  );
 }
 
 const StyledToggleButton = styled(Button)`

--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.js
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.js
@@ -8,23 +8,7 @@ import { injectGlobal, withTheme } from 'styled-components';
 import datepickerStyles from './datePickerStyles';
 import Textbox from '../../controls/textbox/Textbox';
 
-class DateTextbox extends React.Component {
-  static propTypes = Textbox.propTypes; // eslint-disable-line react/forbid-foreign-prop-types
-
-  setRef = ref => {
-    this.inputElement = ref;
-  };
-
-  focus() {
-    this.inputElement.focus();
-  }
-
-  render() {
-    return <Textbox inputRef={this.setRef} {...this.props} />;
-  }
-}
-
-export const DatePicker = props => {
+export function DatePicker(props) {
   const {
     children,
     name,
@@ -53,7 +37,7 @@ export const DatePicker = props => {
   /* eslint-enable */
 
   const textbox = (
-    <DateTextbox
+    <Textbox
       maskType="date"
       name={name}
       prependIconName="calendar"
@@ -64,6 +48,7 @@ export const DatePicker = props => {
   return (
     <ReactDatePicker
       customInput={textbox}
+      customInputRef="inputRef"
       onChange={onChange}
       onBlur={onBlur}
       placeholderText={placeholder}
@@ -73,7 +58,7 @@ export const DatePicker = props => {
       {children}
     </ReactDatePicker>
   );
-};
+}
 
 DatePicker.propTypes = {
   /** Additional text displayed below the input */
@@ -110,6 +95,8 @@ DatePicker.propTypes = {
   startDate: PropTypes.object,
   /** Sets the end date (moment) in a range */
   endDate: PropTypes.object,
+  /** Display checkbox with contextual state colorings */
+  validationState: PropTypes.oneOf(['default', 'success', 'warning', 'danger']),
   /**
    * Theme object used by the ThemeProvider,
    * automatically passed by any parent component using a ThemeProvider

--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.specs.js
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.specs.js
@@ -17,3 +17,15 @@ it('renders DatePicker when textbox is focused', () => {
   getByLabelText('Test date').focus();
   expect(queryByText('November 2018')).not.toBeNull();
 });
+
+it('renders DatePicker when textbox is clicked on', () => {
+  const { getByLabelText, queryByText } = renderWithTheme(
+    <DatePicker
+      labelText="Test date"
+      onChange={jest.fn()}
+      selectedDate={moment(new Date(2018, 10, 7))}
+    />
+  );
+  getByLabelText('Test date').click();
+  expect(queryByText('November 2018')).not.toBeNull();
+})

--- a/packages/es-components/src/components/patterns/incrementer/Incrementer.js
+++ b/packages/es-components/src/components/patterns/incrementer/Incrementer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { PropTypes } from 'prop-types';
 import { noop, isNumber } from 'lodash';
 import styled, { withTheme } from 'styled-components';
@@ -6,6 +6,7 @@ import styled, { withTheme } from 'styled-components';
 import Icon from '../../base/icons/Icon';
 import Button from '../../controls/buttons/Button';
 import { InputBase } from '../../controls/BaseControls';
+import screenReaderOnly from '../screenReaderOnly/screenReaderOnly';
 
 const IncrementerTextbox = styled(InputBase)`
   margin: 0 10px;
@@ -13,136 +14,99 @@ const IncrementerTextbox = styled(InputBase)`
   width: 60px;
 `;
 
-class Incrementer extends React.Component {
-  static propTypes = {
-    /** The value to start the incrementer at */
-    startingValue: PropTypes.number,
-    /** The amount to increment the value by */
-    incrementAmount: PropTypes.number,
-    /** The amount to decrement the value by */
-    decrementAmount: PropTypes.number,
-    /** The highest value the incrementer can be incremented to */
-    upperThreshold: PropTypes.number,
-    /** The lowest value the incrementer can be decremented to */
-    lowerThreshold: PropTypes.number,
-    /** Function to execute with the new value */
-    onValueUpdated: PropTypes.func,
-    /**
-     * Theme object used by the ThemeProvider,
-     * automatically passed by any parent component using a ThemeProvider
-     */
-    theme: PropTypes.object.isRequired
-  };
+const ScreenReaderButtonText = screenReaderOnly('span');
 
-  static defaultProps = {
-    startingValue: 0,
-    incrementAmount: 1,
-    decrementAmount: 1,
-    onValueUpdated: noop,
-    upperThreshold: null,
-    lowerThreshold: null
-  };
+function Incrementer(props) {
+  const [value, setValue] = useState(props.startingValue);
 
-  constructor(props) {
-    super(props);
-
-    const { startingValue } = this.props;
-
-    this.decrementValue = this.decrementValue.bind(this);
-    this.incrementValue = this.incrementValue.bind(this);
-
-    this.determineDisabledStates = this.determineDisabledStates.bind(this);
-
-    const disabledStates = this.determineDisabledStates(startingValue);
-    this.state = {
-      value: startingValue,
-      ...disabledStates
-    };
+  function determineIsDisabled(threshold, newValue) {
+    return isNumber(threshold) && newValue === threshold;
   }
 
-  componentWillReceiveProps({ startingValue }) {
-    const disabledStates = this.determineDisabledStates(startingValue);
-    this.setState(() => ({
-      value: startingValue,
-      ...disabledStates
-    }));
+  const [isIncrementDisabled, setIsIncrementDisabled] = useState(
+    determineIsDisabled(props.upperThreshold, value)
+  );
+  const [isDecrementDisabled, setIsDecrementDisabled] = useState(
+    determineIsDisabled(props.lowerThreshold, value)
+  );
+
+  function decrementValue() {
+    const newValue = value - props.decrementAmount;
+    setValue(newValue);
+    props.onValueUpdated(newValue);
+    setIsDecrementDisabled(determineIsDisabled(props.lowerThreshold, newValue));
   }
 
-  componentWillUpdate(nextProps, nextState) {
-    const { onValueUpdated } = this.props;
-    onValueUpdated(nextState.value);
+  function incrementValue() {
+    const newValue = value + props.incrementAmount;
+    setValue(newValue);
+    props.onValueUpdated(newValue);
+    setIsIncrementDisabled(determineIsDisabled(props.upperThreshold, newValue));
   }
 
-  determineDisabledStates(value) {
-    const { lowerThreshold, upperThreshold } = this.props;
-
-    return {
-      incrementButtonDisabled:
-        isNumber(upperThreshold) && value === upperThreshold,
-      decrementButtonDisabled:
-        isNumber(lowerThreshold) && value === lowerThreshold
-    };
-  }
-
-  decrementValue() {
-    this.setState(previous => {
-      const { decrementAmount } = this.props;
-      const newValue = previous.value - decrementAmount;
-      const disabledStates = this.determineDisabledStates(newValue);
-      return {
-        value: newValue,
-        ...disabledStates
-      };
-    });
-  }
-
-  incrementValue() {
-    this.setState(previous => {
-      const { incrementAmount } = this.props;
-      const newValue = previous.value + incrementAmount;
-      const disabledStates = this.determineDisabledStates(newValue);
-      return {
-        value: newValue,
-        ...disabledStates
-      };
-    });
-  }
-
-  render() {
-    const {
-      value,
-      decrementButtonDisabled,
-      incrementButtonDisabled
-    } = this.state;
-    const { theme } = this.props;
-
-    return (
-      <div>
-        <Button
-          className="decrement-button"
-          styleType="primary"
-          handleOnClick={this.decrementValue}
-          disabled={decrementButtonDisabled}
-        >
-          <Icon name="minus" />
-        </Button>
-        <IncrementerTextbox
-          {...theme.validationInputColor.default}
-          type="text"
-          value={value}
-          readOnly
-        />
-        <Button
-          className="increment-button"
-          styleType="primary"
-          handleOnClick={this.incrementValue}
-          disabled={incrementButtonDisabled}
-        >
-          <Icon name="add" />
-        </Button>
-      </div>
-    );
-  }
+  return (
+    <div>
+      <Button
+        className="decrement-button"
+        styleType="primary"
+        handleOnClick={decrementValue}
+        disabled={isDecrementDisabled}
+      >
+        <ScreenReaderButtonText>
+          Decrement value by
+          {props.decrementAmount}
+        </ScreenReaderButtonText>
+        <Icon name="minus" />
+      </Button>
+      <IncrementerTextbox
+        {...props.theme.validationInputColor.default}
+        type="text"
+        value={value}
+        readOnly
+      />
+      <Button
+        className="increment-button"
+        styleType="primary"
+        handleOnClick={incrementValue}
+        disabled={isIncrementDisabled}
+      >
+        <ScreenReaderButtonText>
+          Increment value by
+          {props.incrementAmount}
+        </ScreenReaderButtonText>
+        <Icon name="add" />
+      </Button>
+    </div>
+  );
 }
+
+Incrementer.propTypes = {
+  /** The value to start the incrementer at */
+  startingValue: PropTypes.number,
+  /** The amount to increment the value by */
+  incrementAmount: PropTypes.number,
+  /** The amount to decrement the value by */
+  decrementAmount: PropTypes.number,
+  /** The highest value the incrementer can be incremented to */
+  upperThreshold: PropTypes.number,
+  /** The lowest value the incrementer can be decremented to */
+  lowerThreshold: PropTypes.number,
+  /** Function to execute with the new value */
+  onValueUpdated: PropTypes.func,
+  /**
+   * Theme object used by the ThemeProvider,
+   * automatically passed by any parent component using a ThemeProvider
+   */
+  theme: PropTypes.object.isRequired
+};
+
+Incrementer.defaultProps = {
+  startingValue: 0,
+  incrementAmount: 1,
+  decrementAmount: 1,
+  onValueUpdated: noop,
+  upperThreshold: null,
+  lowerThreshold: null
+};
 
 export default withTheme(Incrementer);


### PR DESCRIPTION
This PR updates the react and react-dom `peerDependency` to `react@next` and `react-dom@next`, respectively. In doing so,  components can now use [hooks](https://reactjs.org/docs/hooks-reference.html) to manage state, manage DOM interactions, and use context objects.

All components that are currently using classes to manage these capabilities have been converted to using the built in hooks in this PR. 

Notice that there are nearly zero changes required for the tests! 😄 