### PR TITLE
Styled Components v4

### DIFF
--- a/packages/es-components/package-lock.json
+++ b/packages/es-components/package-lock.json
@@ -1335,6 +1335,27 @@
         }
       }
     },
+    "@emotion/is-prop-valid": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.6.8.tgz",
+      "integrity": "sha512-IMSL7ekYhmFlILXcouA6ket3vV7u9BqStlXzbKOF9HBtpUPMMlHU+bBxrLOa2NvleVwNIxeq/zL8LafLbeUXcA==",
+      "dev": true,
+      "requires": {
+        "@emotion/memoize": "^0.6.6"
+      }
+    },
+    "@emotion/memoize": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
+      "integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ==",
+      "dev": true
+    },
+    "@emotion/unitless": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.3.tgz",
+      "integrity": "sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg==",
+      "dev": true
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -2838,16 +2859,6 @@
         }
       }
     },
-    "buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
-      "dev": true,
-      "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
-      }
-    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -3989,9 +4000,9 @@
       }
     },
     "css-to-react-native": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.2.1.tgz",
-      "integrity": "sha512-v++LRcf633phJiYZBDqtmGPj3+BVof0isd2jgwYLWZJ5YSuhCkrfYtDsNhM6oJthiEco0f9tDVJ1vUkDJNgGEA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.2.2.tgz",
+      "integrity": "sha512-w99Fzop1FO8XKm0VpbQp3y5mnTnaS+rtCvS+ylSEOK76YXO5zoHQx/QMB1N54Cp+Ya9jB9922EHrh14ld4xmmw==",
       "dev": true,
       "requires": {
         "css-color-keywords": "^1.0.0",
@@ -6323,28 +6334,24 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "bundled": true,
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": false,
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6354,14 +6361,12 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "bundled": true,
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -6370,40 +6375,34 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "bundled": true,
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "bundled": true,
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "bundled": true,
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6412,29 +6411,25 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6443,15 +6438,13 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6467,8 +6460,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": false,
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6482,15 +6474,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-          "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6499,8 +6489,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6509,8 +6498,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6520,21 +6508,18 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "bundled": true,
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -6542,15 +6527,13 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -6558,14 +6541,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "bundled": true,
           "dev": true
         },
         "minipass": {
           "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
-          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "safe-buffer": "^5.1.1",
@@ -6574,8 +6555,7 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-          "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6584,8 +6564,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -6593,15 +6572,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
-          "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6612,8 +6589,7 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
-          "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6631,8 +6607,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6642,15 +6617,13 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
-          "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
-          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6660,8 +6633,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6673,21 +6645,18 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "bundled": true,
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -6695,22 +6664,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6720,22 +6686,19 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
-          "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6747,8 +6710,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -6756,8 +6718,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6772,8 +6733,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6782,49 +6742,42 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+          "bundled": true,
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -6834,8 +6787,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6844,8 +6796,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -6853,15 +6804,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
-          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6876,15 +6825,13 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": false,
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6893,14 +6840,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "dev": true
         },
         "yallist": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+          "bundled": true,
           "dev": true
         }
       }
@@ -7265,12 +7210,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "hoist-non-react-statics": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
-      "dev": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -10332,6 +10271,12 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "memoize-one": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
+      "integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw==",
+      "dev": true
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -10566,9 +10511,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
       "dev": true,
       "optional": true
     },
@@ -15003,34 +14948,50 @@
       }
     },
     "styled-components": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.4.6.tgz",
-      "integrity": "sha512-HiEVVY93oH/PuekPuIE7ownn2wmO708rS8MM1yS20i0TCyFgPs3mbop8fJqKLRtC2/npVn2fO5Je6azaL6T2tg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.1.1.tgz",
+      "integrity": "sha512-UzT/qyoOyKpYooeLdwKrPHZ85R8KWl8i0fbyH9I3z6B2WT9uGDCV7J4kbfKsBeSWFD9EytBriEODOkybcUFD/Q==",
       "dev": true,
       "requires": {
-        "buffer": "^5.0.3",
-        "css-to-react-native": "^2.0.3",
-        "fbjs": "^0.8.16",
-        "hoist-non-react-statics": "^2.5.0",
+        "@emotion/is-prop-valid": "^0.6.8",
+        "@emotion/unitless": "^0.7.0",
+        "babel-plugin-styled-components": ">= 1",
+        "css-to-react-native": "^2.2.2",
+        "memoize-one": "^4.0.0",
         "prop-types": "^15.5.4",
-        "react-is": "^16.3.1",
+        "react-is": "^16.6.0",
         "stylis": "^3.5.0",
         "stylis-rule-sheet": "^0.0.10",
-        "supports-color": "^3.2.3"
+        "supports-color": "^5.5.0"
       },
       "dependencies": {
-        "react-is": {
-          "version": "16.5.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.5.0.tgz",
-          "integrity": "sha512-kpkCGLsChXTEQJVmowQqHpCjHKJFwB4SIChYaaaiAkq8OtE2aBg5pQe8/xnFlGmz9KmMx1H4oQRUyxP7qC9v5A==",
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
+        },
+        "react-is": {
+          "version": "16.6.3",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.3.tgz",
+          "integrity": "sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },
     "stylis": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.3.tgz",
-      "integrity": "sha512-TxU0aAscJghF9I3V9q601xcK3Uw1JbXvpsBGj/HULqexKOKlOEzzlIpLFRbKkCK990ccuxfXUqmPbIIo7Fq/cQ==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
+      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==",
       "dev": true
     },
     "stylis-rule-sheet": {

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -4,7 +4,7 @@
   "description": "React components built for Exchange Solutions products",
   "repository": "https://github.com/wtw-im/es-components",
   "main": "bundle/main.min.js",
-  "module": "es6/index.js",
+  "module": "lib/index.js",
   "sideEffects": false,
   "scripts": {
     "build": "npm run build:es6 && npm run webpack",
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "react": ">=16.7",
-    "styled-components": "*"
+    "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.1.0",

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -76,7 +76,7 @@
     "rollup": "^0.67.3",
     "rollup-plugin-babel": "^4.0.3",
     "style-loader": "^0.13.1",
-    "styled-components": "^3.4.6",
+    "styled-components": "^4.1.1",
     "webpack": "^4.18.0",
     "webpack-cli": "^3.1.0"
   },

--- a/packages/es-components/src/components/containers/drawer/Drawer.js
+++ b/packages/es-components/src/components/containers/drawer/Drawer.js
@@ -3,7 +3,7 @@
  * It's a prop used by uncontrollable, and needs to be documented */
 import React, { Children } from 'react';
 import PropTypes from 'prop-types';
-import styled, { withTheme } from 'styled-components';
+import styled from 'styled-components';
 import { noop } from 'lodash';
 import uncontrollable from 'uncontrollable';
 import classnames from 'classnames';
@@ -138,4 +138,4 @@ const UncontrolledDrawer = uncontrollable(Drawer, {
 
 UncontrolledDrawer.Panel = DrawerPanel;
 
-export default withTheme(UncontrolledDrawer);
+export default UncontrolledDrawer;

--- a/packages/es-components/src/components/containers/modal/Modal.js
+++ b/packages/es-components/src/components/containers/modal/Modal.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled, { withTheme } from 'styled-components';
+import styled from 'styled-components';
 import { noop } from 'lodash';
 import BaseModal from 'react-overlays/lib/Modal';
 
 import genId from '../../util/generateAlphaName';
+import { useTheme } from '../../util/useTheme';
 import Fade from '../../util/Fade';
 import { ModalContext } from './ModalContext';
 import Header from './ModalHeader';
@@ -81,10 +82,10 @@ function Modal(props) {
     onExit,
     onHide,
     show,
-    size,
-    theme
+    size
   } = props;
 
+  const theme = useTheme();
   const backdropStyle = {
     backgroundColor: theme.colors.black,
     bottom: 0,
@@ -153,12 +154,7 @@ Modal.propTypes = {
   /** When `true` The modal will show itself. */
   show: PropTypes.bool,
   /** Sets the size of the modal */
-  size: PropTypes.oneOf(['small', 'medium', 'large']),
-  /**
-   * Theme object used by the ThemeProvider,
-   * automatically passed by any parent component using a ThemeProvider
-   */
-  theme: PropTypes.object.isRequired
+  size: PropTypes.oneOf(['small', 'medium', 'large'])
 };
 
 Modal.defaultProps = {
@@ -177,4 +173,4 @@ Modal.Header = Header;
 Modal.Body = Body;
 Modal.Footer = Footer;
 
-export default withTheme(Modal);
+export default Modal;

--- a/packages/es-components/src/components/containers/notification/Notification.js
+++ b/packages/es-components/src/components/containers/notification/Notification.js
@@ -3,11 +3,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { noop } from 'lodash';
-import styled, { withTheme } from 'styled-components';
+import styled from 'styled-components';
 
 import Icon from '../../base/icons/Icon';
 import Button from '../../controls/buttons/Button';
 import DismissButton from '../../controls/DismissButton';
+import { useTheme } from '../../util/useTheme';
 
 const DismissNotification = styled(DismissButton)`
   line-height: 80%;
@@ -204,11 +205,11 @@ function Notification({
   isAlert,
   onDismiss,
   extraAlert,
-  theme,
   useLightVariant,
   useMessageOnlyVariant,
   ...otherProps
 }) {
+  const theme = useTheme();
   const hasCallsToAction = callsToAction.length > 0;
   const roleType = isAlert ? 'alert' : 'dialog';
   let bgType = 'base';
@@ -287,12 +288,7 @@ Notification.propTypes = {
   /** Use the light color variants of the alert */
   useLightVariant: PropTypes.bool,
   /** Display only the message without a colored background */
-  useMessageOnlyVariant: PropTypes.bool,
-  /**
-   * Theme object used by the ThemeProvider,
-   * automatically passed by any parent component using a ThemeProvider
-   */
-  theme: PropTypes.object.isRequired
+  useMessageOnlyVariant: PropTypes.bool
 };
 
 Notification.defaultProps = {
@@ -309,4 +305,4 @@ Notification.defaultProps = {
   useMessageOnlyVariant: false
 };
 
-export default withTheme(Notification);
+export default Notification;

--- a/packages/es-components/src/components/containers/popover/Popover.js
+++ b/packages/es-components/src/components/containers/popover/Popover.js
@@ -153,12 +153,7 @@ function Popover(props) {
   }
 
   const closeButton = (
-    <Button
-      handleOnClick={toggleShow}
-      ref={btn => {
-        closeBtnRef.current = btn;
-      }}
-    >
+    <Button handleOnClick={toggleShow} ref={closeBtnRef}>
       Close
     </Button>
   );
@@ -168,9 +163,7 @@ function Popover(props) {
       aria-label="Close"
       hasTitle={hasTitle}
       handleOnClick={toggleShow}
-      ref={btn => {
-        closeBtnRef.current = btn;
-      }}
+      ref={closeBtnRef}
     >
       <Icon name="remove" />
     </AlternateCloseButton>
@@ -184,9 +177,7 @@ function Popover(props) {
       isLinkButton={isLinkButton}
       suppressUnderline={suppressUnderline}
       buttonBorderStyle={buttonBorderStyle}
-      ref={btn => {
-        triggerBtnRef.current = btn;
-      }}
+      ref={triggerBtnRef}
       aria-expanded={isOpen}
     >
       <span aria-hidden={!!ariaLabel}>{children}</span>
@@ -244,18 +235,14 @@ function Popover(props) {
         <PopoverContainer
           className="es-popover__container"
           role="dialog"
-          ref={elem => {
-            contentRef.current = elem;
-          }}
+          ref={contentRef}
         >
           <PopoverHeader className="es-popover__header" hasTitle={hasTitle}>
             {hasTitle && <TitleBar>{title}</TitleBar>}
             {hasAltCloseButton && altCloseButton}
             <CloseHelpText
               tabIndex={-1}
-              ref={elem => {
-                headerRef.current = elem;
-              }}
+              ref={headerRef}
               aria-label="Press escape to close the Popover"
             />
           </PopoverHeader>

--- a/packages/es-components/src/components/containers/popover/Popover.js
+++ b/packages/es-components/src/components/containers/popover/Popover.js
@@ -155,7 +155,7 @@ function Popover(props) {
   const closeButton = (
     <Button
       handleOnClick={toggleShow}
-      innerRef={btn => {
+      ref={btn => {
         closeBtnRef.current = btn;
       }}
     >
@@ -168,7 +168,7 @@ function Popover(props) {
       aria-label="Close"
       hasTitle={hasTitle}
       handleOnClick={toggleShow}
-      innerRef={btn => {
+      ref={btn => {
         closeBtnRef.current = btn;
       }}
     >
@@ -184,7 +184,7 @@ function Popover(props) {
       isLinkButton={isLinkButton}
       suppressUnderline={suppressUnderline}
       buttonBorderStyle={buttonBorderStyle}
-      innerRef={btn => {
+      ref={btn => {
         triggerBtnRef.current = btn;
       }}
       aria-expanded={isOpen}
@@ -244,7 +244,7 @@ function Popover(props) {
         <PopoverContainer
           className="es-popover__container"
           role="dialog"
-          innerRef={elem => {
+          ref={elem => {
             contentRef.current = elem;
           }}
         >
@@ -253,7 +253,7 @@ function Popover(props) {
             {hasAltCloseButton && altCloseButton}
             <CloseHelpText
               tabIndex={-1}
-              innerRef={elem => {
+              ref={elem => {
                 headerRef.current = elem;
               }}
               aria-label="Press escape to close the Popover"

--- a/packages/es-components/src/components/containers/popover/Popup.js
+++ b/packages/es-components/src/components/containers/popover/Popup.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withTheme, createGlobalStyle } from 'styled-components';
 
 import { Manager, Target, Popper, Arrow } from 'react-popper';
 import Transition from 'react-transition-group/Transition';
 import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
 
-import popoverStyles from './popoverStyles';
+import { ArrowStyles } from './popoverStyles';
 
 const defaultStyle = {
   transition: 'opacity 0.2s ease-in-out',
@@ -17,19 +16,6 @@ const transitionStyles = {
   entering: { opacity: 0 },
   entered: { opacity: 1 }
 };
-
-function getArrowSize(size) {
-  switch (size) {
-    case 'sm':
-      return '5';
-    case 'lg':
-      return '20';
-    case 'none':
-      return '0';
-    default:
-      return '10';
-  }
-}
 
 function Popup({
   name,
@@ -43,18 +29,8 @@ function Popup({
   transitionTimeout,
   disableFlipping,
   disableRootClose,
-  theme,
   popperRef
 }) {
-  const arrowStyles = popoverStyles(
-    name,
-    theme.colors,
-    getArrowSize(arrowSize),
-    hasTitle
-  );
-
-  const Styles = createGlobalStyle`${arrowStyles}`; // eslint-disable-line no-unused-expressions
-
   let popperObj = (
     <Manager>
       <Target>{trigger}</Target>
@@ -99,7 +75,7 @@ function Popup({
 
   return (
     <>
-      <Styles />
+      <ArrowStyles name={name} arrowSize={arrowSize} hasTitle={hasTitle} />
       {popperObj}
     </>
   );
@@ -117,7 +93,6 @@ Popup.propTypes = {
   hasTitle: PropTypes.bool,
   disableRootClose: PropTypes.bool,
   disableFlipping: PropTypes.bool,
-  theme: PropTypes.object,
   popperRef: PropTypes.func
 };
 
@@ -126,4 +101,4 @@ Popup.defaultProps = {
   placement: 'bottom'
 };
 
-export default withTheme(Popup);
+export default Popup;

--- a/packages/es-components/src/components/containers/popover/Popup.js
+++ b/packages/es-components/src/components/containers/popover/Popup.js
@@ -57,7 +57,7 @@ function Popup({
               ...defaultStyle,
               ...transitionStyles[state]
             }}
-            ref={popperRef}
+            innerRef={popperRef}
           >
             {children}
             <Arrow className={`${name}-popper__arrow`} />

--- a/packages/es-components/src/components/containers/popover/Popup.js
+++ b/packages/es-components/src/components/containers/popover/Popup.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withTheme, injectGlobal } from 'styled-components';
+import { withTheme, createGlobalStyle } from 'styled-components';
 
 import { Manager, Target, Popper, Arrow } from 'react-popper';
 import Transition from 'react-transition-group/Transition';
@@ -53,7 +53,7 @@ function Popup({
     hasTitle
   );
 
-  injectGlobal`${arrowStyles}`; // eslint-disable-line no-unused-expressions
+  const Styles = createGlobalStyle`${arrowStyles}`; // eslint-disable-line no-unused-expressions
 
   let popperObj = (
     <Manager>
@@ -97,7 +97,12 @@ function Popup({
     );
   }
 
-  return popperObj;
+  return (
+    <>
+      <Styles />
+      {popperObj}
+    </>
+  );
 }
 
 Popup.propTypes = {

--- a/packages/es-components/src/components/containers/popover/Popup.js
+++ b/packages/es-components/src/components/containers/popover/Popup.js
@@ -57,7 +57,7 @@ function Popup({
               ...defaultStyle,
               ...transitionStyles[state]
             }}
-            innerRef={popperRef}
+            ref={popperRef}
           >
             {children}
             <Arrow className={`${name}-popper__arrow`} />

--- a/packages/es-components/src/components/containers/popover/popoverStyles.js
+++ b/packages/es-components/src/components/containers/popover/popoverStyles.js
@@ -1,90 +1,116 @@
-export default function arrowStyles(name, colors, arrowSize, hasTitle) {
-  const sharedStyles = `
-        content: '';
-        position: absolute;
-        border-style: solid;
-        border-color: transparent;
-        border-width: ${arrowSize}px;
-    `;
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import { ThemeContext, createGlobalStyle } from 'styled-components';
 
-  return `
-        .${name}-popper { margin: ${arrowSize}px; }
-        .${name}-popper .${name}-popper__arrow {
-            width: 0;
-            height: 0;
-            border-style: solid;
-            position: absolute;
-        }
-
-        .${name}-popper[data-placement^="top"] .${name}-popper__arrow {
-            border-color: transparent;
-            border-width: ${arrowSize}px;
-            border-bottom-width: 0;
-            border-top-color: rgba(0, 0, 0, 0.3);
-            bottom: -${arrowSize}px;
-            left: calc(50% - ${arrowSize}px);
-
-            &::after {
-                ${sharedStyles}
-                border-top-color: ${colors.white};
-                border-bottom-width: 0;
-                margin-left: -${arrowSize}px;
-                bottom: 1px;
-            }
-        }
-        
-        .${name}-popper[data-placement^="bottom"] .${name}-popper__arrow {
-            border-color: transparent;
-            border-width: ${arrowSize}px;
-            border-top-width: 0;
-            border-bottom-color: rgba(0, 0, 0, 0.3);
-            top: -${arrowSize}px;
-            left: calc(50% - ${arrowSize}px);
-
-            &::after {
-                ${sharedStyles}
-                border-bottom-color: ${
-                  hasTitle ? colors.popoverHeader : colors.white
-                };
-                border-top-width: 0;
-                margin-left: -${arrowSize}px;
-                top: 1px;
-            }
-        }
-
-        .${name}-popper[data-placement^="left"] .${name}-popper__arrow {
-            border-color: transparent;
-            border-width: ${arrowSize}px;
-            border-right-width: 0;
-            border-left-color: rgba(0, 0, 0, 0.3);
-            right: -${arrowSize}px;
-            top: calc(50% - ${arrowSize}px);
-
-            &::after {
-                ${sharedStyles}
-                border-left-color: ${colors.white};
-                border-right-width: 0;
-                margin-left: -${arrowSize}px;
-                right: 1px;
-                top: calc(50% - ${arrowSize}px);
-            }
-        }
-
-        .${name}-popper[data-placement^="right"] .${name}-popper__arrow {
-            border-color: transparent;
-            border-width: ${arrowSize}px;
-            border-left-width: 0;
-            border-right-color: rgba(0, 0, 0, 0.3);
-            left: -${arrowSize}px;
-
-            &::after {
-                ${sharedStyles}
-                border-right-color: ${colors.white};
-                border-left-width: 0;
-                margin-right: -${arrowSize}px;
-                left: 1px;
-                top: calc(50% - ${arrowSize}px);
-            }
-        }
-    `;
+function getArrowSize(size) {
+  switch (size) {
+    case 'sm':
+      return '5';
+    case 'lg':
+      return '20';
+    case 'none':
+      return '0';
+    default:
+      return '10';
+  }
 }
+
+export function ArrowStyles(props) {
+  const { name, arrowSize: size, hasTitle } = props;
+  const { colors } = useContext(ThemeContext);
+  const arrowSize = getArrowSize(size);
+  const sharedStyles = `
+    content: '';
+    position: absolute;
+    border-style: solid;
+    border-color: transparent;
+    border-width: ${getArrowSize(arrowSize)}px;
+  `;
+
+  const Styles = createGlobalStyle`
+    .${name}-popper { margin: ${arrowSize}px; }
+    .${name}-popper .${name}-popper__arrow {
+      width: 0;
+      height: 0;
+      border-style: solid;
+      position: absolute;
+    }
+
+    .${name}-popper[data-placement^="top"] .${name}-popper__arrow {
+      border-color: transparent;
+      border-width: ${arrowSize}px;
+      border-bottom-width: 0;
+      border-top-color: rgba(0, 0, 0, 0.3);
+      bottom: -${arrowSize}px;
+      left: calc(50% - ${arrowSize}px);
+
+      &::after {
+        ${sharedStyles}
+        border-top-color: ${colors.white};
+        border-bottom-width: 0;
+        margin-left: -${arrowSize}px;
+        bottom: 1px;
+      }
+    }
+    
+    .${name}-popper[data-placement^="bottom"] .${name}-popper__arrow {
+      border-color: transparent;
+      border-width: ${arrowSize}px;
+      border-top-width: 0;
+      border-bottom-color: rgba(0, 0, 0, 0.3);
+      top: -${arrowSize}px;
+      left: calc(50% - ${arrowSize}px);
+
+      &::after {
+        ${sharedStyles}
+        border-bottom-color: ${hasTitle ? colors.popoverHeader : colors.white};
+        border-top-width: 0;
+        margin-left: -${arrowSize}px;
+        top: 1px;
+      }
+    }
+
+    .${name}-popper[data-placement^="left"] .${name}-popper__arrow {
+      border-color: transparent;
+      border-width: ${arrowSize}px;
+      border-right-width: 0;
+      border-left-color: rgba(0, 0, 0, 0.3);
+      right: -${arrowSize}px;
+      top: calc(50% - ${arrowSize}px);
+
+      &::after {
+        ${sharedStyles}
+        border-left-color: ${colors.white};
+        border-right-width: 0;
+        margin-left: -${arrowSize}px;
+        right: 1px;
+        top: calc(50% - ${arrowSize}px);
+      }
+    }
+
+    .${name}-popper[data-placement^="right"] .${name}-popper__arrow {
+      border-color: transparent;
+      border-width: ${arrowSize}px;
+      border-left-width: 0;
+      border-right-color: rgba(0, 0, 0, 0.3);
+      left: -${arrowSize}px;
+
+      &::after {
+        ${sharedStyles}
+        border-right-color: ${colors.white};
+        border-left-width: 0;
+        margin-right: -${arrowSize}px;
+        left: 1px;
+        top: calc(50% - ${arrowSize}px);
+      }
+    }
+  `;
+
+  return <Styles />;
+}
+
+ArrowStyles.propTypes = {
+  name: PropTypes.string.isRequired,
+  arrowSize: PropTypes.oneOf(['sm', 'lg', 'none', 'default']).isRequired,
+  hasTitle: PropTypes.bool.isRequired
+};

--- a/packages/es-components/src/components/containers/popover/popoverStyles.js
+++ b/packages/es-components/src/components/containers/popover/popoverStyles.js
@@ -1,6 +1,7 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { ThemeContext, createGlobalStyle } from 'styled-components';
+import { createGlobalStyle } from 'styled-components';
+import { useTheme } from '../../util/useTheme';
 
 function getArrowSize(size) {
   switch (size) {
@@ -17,7 +18,7 @@ function getArrowSize(size) {
 
 export function ArrowStyles(props) {
   const { name, arrowSize: size, hasTitle } = props;
-  const { colors } = useContext(ThemeContext);
+  const { colors } = useTheme();
   const arrowSize = getArrowSize(size);
   const sharedStyles = `
     content: '';

--- a/packages/es-components/src/components/containers/striped-container/StripedContainer.js
+++ b/packages/es-components/src/components/containers/striped-container/StripedContainer.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled, { withTheme } from 'styled-components';
+import styled from 'styled-components';
+
+import { useTheme } from '../../util/useTheme';
 
 const StripedContainerWrapper = styled.div`
   > * {
@@ -18,7 +20,7 @@ const StripedContainerWrapper = styled.div`
 `;
 
 function StripedContainer(props) {
-  const { theme } = props;
+  const theme = useTheme();
 
   return (
     <StripedContainerWrapper
@@ -31,11 +33,6 @@ function StripedContainer(props) {
 }
 
 StripedContainer.propTypes = {
-  /**
-   * Theme object used by the ThemeProvider,
-   * automatically passed by any parent component using a ThemeProvider
-   */
-  theme: PropTypes.object.isRequired,
   children: PropTypes.node
 };
 
@@ -43,4 +40,4 @@ StripedContainer.defaultProps = {
   children: undefined
 };
 
-export default withTheme(StripedContainer);
+export default StripedContainer;

--- a/packages/es-components/src/components/controls/buttons/Button.js
+++ b/packages/es-components/src/components/controls/buttons/Button.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled, { withTheme } from 'styled-components';
+import styled from 'styled-components';
 import classnames from 'classnames';
+
+import { useTheme } from '../../util/useTheme';
 
 function getBlockPropertyValues(isBlock) {
   if (isBlock) {
@@ -129,11 +131,11 @@ function InnerButton({
   size,
   block,
   isOutline,
-  theme,
   name,
   innerRef,
   ...buttonProps
 }) {
+  const theme = useTheme();
   const buttonSize = theme.buttonSizes[size];
   const { className, ...otherProps } = buttonProps;
   const sharedProps = {
@@ -236,11 +238,6 @@ Button.propTypes = {
   block: PropTypes.bool,
   /** Render the outline button variant */
   isOutline: PropTypes.bool,
-  /**
-   * Theme object used by the ThemeProvider,
-   * automatically passed by any parent component using a ThemeProvider
-   */
-  theme: PropTypes.object,
   /** The name of the button to be sent with the form. */
   name: PropTypes.string
 };
@@ -255,4 +252,4 @@ Button.defaultProps = {
   size: 'default'
 };
 
-export default withTheme(Button);
+export default Button;

--- a/packages/es-components/src/components/controls/buttons/Button.js
+++ b/packages/es-components/src/components/controls/buttons/Button.js
@@ -120,7 +120,7 @@ const LinkButton = styled(ButtonBase)`
   }
 `;
 
-function Button({
+function InnerButton({
   handleOnClick,
   children,
   buttonClasses,
@@ -131,6 +131,7 @@ function Button({
   isOutline,
   theme,
   name,
+  innerRef,
   ...buttonProps
 }) {
   const buttonSize = theme.buttonSizes[size];
@@ -141,6 +142,7 @@ function Button({
     name,
     onClick: handleOnClick,
     baseLineHeight: theme.sizes.baseLineHeight,
+    ref: innerRef,
     ...otherProps
   };
 
@@ -212,6 +214,10 @@ function Button({
 
   return button;
 }
+
+const Button = React.forwardRef((props, ref) => (
+  <InnerButton innerRef={ref} {...props} />
+));
 
 const buttonSizes = ['lg', 'default', 'sm', 'xs'];
 

--- a/packages/es-components/src/components/controls/buttons/DropdownButton.js
+++ b/packages/es-components/src/components/controls/buttons/DropdownButton.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, Children } from 'react';
+import React, { useState, useEffect, useRef, Children } from 'react';
 import PropTypes from 'prop-types';
 import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
 import styled from 'styled-components';
@@ -129,8 +129,8 @@ function DropdownButton(props) {
   const [buttonValue, setButtonValue] = useState(props.buttonValue);
   const [isOpen, setIsOpen] = useState(false);
 
-  const buttonDropdown = React.createRef();
-  const triggerButton = React.createRef();
+  const buttonDropdown = useRef();
+  const triggerButton = useRef();
 
   useEffect(
     () => {

--- a/packages/es-components/src/components/controls/buttons/DropdownButton.js
+++ b/packages/es-components/src/components/controls/buttons/DropdownButton.js
@@ -191,7 +191,7 @@ function DropdownButton(props) {
           handleOnClick={toggleDropdown}
           aria-haspopup="true"
           aria-pressed={isOpen}
-          innerRef={triggerButton}
+          ref={triggerButton}
         >
           {manualButtonValue || buttonValue}
           <Caret />

--- a/packages/es-components/src/components/controls/buttons/ToggleButton.js
+++ b/packages/es-components/src/components/controls/buttons/ToggleButton.js
@@ -1,11 +1,13 @@
 /* eslint no-confusing-arrow: 0 */
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import styled, { withTheme } from 'styled-components';
+import styled from 'styled-components';
 
 import Button from './Button';
+import { useTheme } from '../../util/useTheme';
 
 function ToggleButton(props) {
+  const theme = useTheme();
   const [isPressed, setIsPressed] = useState(props.isPressed);
 
   function toggleButton(event) {
@@ -20,7 +22,6 @@ function ToggleButton(props) {
     size,
     block,
     isOutline,
-    theme,
     ...buttonProps
   } = props;
 
@@ -88,11 +89,6 @@ ToggleButton.propTypes = {
   size: PropTypes.oneOf(buttonSizes),
   block: PropTypes.bool,
   isOutline: PropTypes.bool,
-  /**
-   * Theme object used by the ThemeProvider,
-   * automatically passed by any parent component using a ThemeProvider
-   */
-  theme: PropTypes.object.isRequired,
   isPressed: PropTypes.bool
 };
 
@@ -106,4 +102,4 @@ ToggleButton.defaultProps = {
   isPressed: false
 };
 
-export default withTheme(ToggleButton);
+export default ToggleButton;

--- a/packages/es-components/src/components/controls/checkbox/Checkbox.js
+++ b/packages/es-components/src/components/controls/checkbox/Checkbox.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled, { withTheme } from 'styled-components';
+import styled from 'styled-components';
 
 import { Label } from '../BaseControls';
+import { useTheme } from '../../util/useTheme';
 
 const backgroundColorSelect = (checked, theme, validationState) => {
   if (checked) {
@@ -121,9 +122,9 @@ function Checkbox({
   labelText,
   validationState,
   additionalHelpContent,
-  theme,
   ...checkboxProps
 }) {
+  const theme = useTheme();
   const helpId = additionalHelpContent ? `${name}-help` : undefined;
   const additionalHelp = additionalHelpContent && (
     <AdditionalHelpContent
@@ -162,12 +163,7 @@ Checkbox.propTypes = {
   /** Display checkbox with contextual state colorings */
   validationState: PropTypes.oneOf(['default', 'success', 'warning', 'danger']),
   /** Content to display underneath the check box */
-  additionalHelpContent: PropTypes.node,
-  /**
-   * Theme object used by the ThemeProvider,
-   * automatically passed by any parent component using a ThemeProvider
-   */
-  theme: PropTypes.object.isRequired
+  additionalHelpContent: PropTypes.node
 };
 
 Checkbox.defaultProps = {
@@ -175,4 +171,4 @@ Checkbox.defaultProps = {
   additionalHelpContent: undefined
 };
 
-export default withTheme(Checkbox);
+export default Checkbox;

--- a/packages/es-components/src/components/controls/dropdown/Dropdown.js
+++ b/packages/es-components/src/components/controls/dropdown/Dropdown.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { noop } from 'lodash';
-import styled, { withTheme } from 'styled-components';
+import styled from 'styled-components';
 import classnames from 'classnames';
 
 import { Label, LabelText, SelectBase } from '../BaseControls';
+import { useTheme } from '../../util/useTheme';
 
 const optionsShape = {
   /** Text to display in drop down */
@@ -34,9 +35,9 @@ function Dropdown({
   onBlur,
   validationState,
   additionalHelpContent,
-  theme,
   ...rest
 }) {
+  const theme = useTheme();
   const helpId = additionalHelpContent ? `${name}-help` : undefined;
   const additionalHelp = additionalHelpContent && (
     <AdditionalHelpContent
@@ -116,11 +117,6 @@ Dropdown.propTypes = {
   /** Function to execute when the dropdown loses focus */
   onBlur: PropTypes.func,
   /**
-   * Theme object used by the ThemeProvider,
-   * automatically passed by any parent component using a ThemeProvider
-   */
-  theme: PropTypes.object.isRequired,
-  /**
    * class name is applied to top level label
    */
   className: PropTypes.string
@@ -142,4 +138,4 @@ Dropdown.defaultProps = {
   className: undefined
 };
 
-export default withTheme(Dropdown);
+export default Dropdown;

--- a/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled, { withTheme } from 'styled-components';
+import styled from 'styled-components';
 
 import { Label } from '../BaseControls';
 import getRadioFillVariables from './radio-fill-variables';
+import { useTheme } from '../../util/useTheme';
 
 function radioFill(color) {
   return `
@@ -76,9 +77,9 @@ export function RadioButton({
   name,
   inline,
   validationState,
-  theme,
   ...radioProps
 }) {
+  const theme = useTheme();
   const { hover, fill } = getRadioFillVariables(
     radioProps.checked,
     radioProps.disabled,
@@ -119,12 +120,7 @@ RadioButton.propTypes = {
   name: PropTypes.string.isRequired,
   inline: PropTypes.bool,
   /** Display radio button with contextual state colorings */
-  validationState: PropTypes.oneOf(['default', 'success', 'warning', 'danger']),
-  /**
-   * Theme object used by the ThemeProvider,
-   * automatically passed by any parent component using a ThemeProvider
-   */
-  theme: PropTypes.object.isRequired
+  validationState: PropTypes.oneOf(['default', 'success', 'warning', 'danger'])
 };
 
 RadioButton.defaultProps = {
@@ -132,4 +128,4 @@ RadioButton.defaultProps = {
   validationState: 'default'
 };
 
-export default withTheme(RadioButton);
+export default RadioButton;

--- a/packages/es-components/src/components/controls/radio-buttons/RadioGroup.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioGroup.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { noop } from 'lodash';
-import styled, { withTheme } from 'styled-components';
-
-import Fieldset from '../../containers/fieldset/Fieldset';
+import styled from 'styled-components';
 
 import RadioButton from './RadioButton';
+import Fieldset from '../../containers/fieldset/Fieldset';
+import { useTheme } from '../../util/useTheme';
 
 const RadioFieldset = styled(Fieldset)`
   legend {
@@ -33,9 +33,9 @@ function RadioGroup({
   onChange,
   introContent,
   validationState,
-  additionalHelpContent,
-  theme
+  additionalHelpContent
 }) {
+  const theme = useTheme();
   const helpId = additionalHelpContent ? `${name}-help` : undefined;
   const additionalHelp = additionalHelpContent && (
     <AdditionalHelpContent
@@ -101,12 +101,7 @@ RadioGroup.propTypes = {
   /** Intro content that can be rendered after the Legend but before the radio buttons, allows
    * content to be put in that will not affect the accessability of the Legend/Radio button relationship.
    */
-  introContent: PropTypes.node,
-  /**
-   * Theme object used by the ThemeProvider,
-   * automatically passed by any parent component using a ThemeProvider
-   */
-  theme: PropTypes.object.isRequired
+  introContent: PropTypes.node
 };
 
 RadioGroup.defaultProps = {
@@ -120,4 +115,4 @@ RadioGroup.defaultProps = {
   additionalHelpContent: undefined
 };
 
-export default withTheme(RadioGroup);
+export default RadioGroup;

--- a/packages/es-components/src/components/controls/textbox/Textbox.js
+++ b/packages/es-components/src/components/controls/textbox/Textbox.js
@@ -177,7 +177,7 @@ const Textbox = props => {
       return <input ref={setRef} {...maskedProps} />;
     };
   } else {
-    additionalTextProps.innerRef = inputRef;
+    additionalTextProps.ref = inputRef;
   }
 
   const addOnTextColor = hasValidationIcon

--- a/packages/es-components/src/components/controls/textbox/Textbox.js
+++ b/packages/es-components/src/components/controls/textbox/Textbox.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled, { css, withTheme } from 'styled-components';
+import styled, { css } from 'styled-components';
 import { noop, omit } from 'lodash';
 import MaskedInput from 'react-text-mask';
 import classnames from 'classnames';
@@ -9,6 +9,7 @@ import Icon from '../../base/icons/Icon';
 import { Label, LabelText, InputBase } from '../BaseControls';
 import inputMaskType from './inputMaskType';
 import genId from '../../util/generateAlphaName';
+import { useTheme } from '../../util/useTheme';
 
 const defaultInputPad = '12px';
 const defaultBorderRadius = '2px';
@@ -140,12 +141,12 @@ const Textbox = props => {
     appendIconName,
     maskType,
     customMask,
-    theme,
     className,
     labelSuffix,
     ...additionalTextProps
   } = props;
   const textboxId = id || genId();
+  const theme = useTheme();
   const helpId = additionalHelpContent ? `${textboxId}-help` : undefined;
   const additionalHelp = additionalHelpContent && (
     <AdditionalHelpContent id={helpId} className="es-textbox__help">
@@ -280,11 +281,6 @@ Textbox.propTypes = {
    * used for denoting optional fields or other states
    */
   labelSuffix: PropTypes.element,
-  /**
-   * Theme object used by the ThemeProvider,
-   * automatically passed by any parent component using a ThemeProvider
-   */
-  theme: PropTypes.object.isRequired,
   className: PropTypes.string
 };
 
@@ -304,4 +300,4 @@ Textbox.defaultProps = {
   labelSuffix: undefined
 };
 
-export default withTheme(Textbox);
+export default Textbox;

--- a/packages/es-components/src/components/navigation/breadcrumb/Breadcrumb.js
+++ b/packages/es-components/src/components/navigation/breadcrumb/Breadcrumb.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled, { withTheme } from 'styled-components';
+import styled from 'styled-components';
 import tinycolor from 'tinycolor2';
 
 import genId from '../../util/generateAlphaName';
@@ -71,4 +71,4 @@ Breadcrumb.propTypes = {
   children: PropTypes.node.isRequired
 };
 
-export default withTheme(Breadcrumb);
+export default Breadcrumb;

--- a/packages/es-components/src/components/navigation/sidenav/SideNav.js
+++ b/packages/es-components/src/components/navigation/sidenav/SideNav.js
@@ -4,7 +4,7 @@
 
 import React, { Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
-import styled, { withTheme } from 'styled-components';
+import styled from 'styled-components';
 import { noop } from 'lodash';
 import uncontrollable from 'uncontrollable';
 
@@ -73,4 +73,4 @@ const UncontrolledSideNav = uncontrollable(SideNav, {
 
 UncontrolledSideNav.Item = NavItem;
 
-export default withTheme(UncontrolledSideNav);
+export default UncontrolledSideNav;

--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.js
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.js
@@ -3,9 +3,8 @@ import PropTypes from 'prop-types';
 import { noop, pick, omit } from 'lodash';
 import ReactDatePicker from 'react-datepicker';
 import uncontrollable from 'uncontrollable';
-import { injectGlobal, withTheme } from 'styled-components';
 
-import datepickerStyles from './datePickerStyles';
+import { DatepickerStyles } from './datePickerStyles';
 import Textbox from '../../controls/textbox/Textbox';
 
 export function DatePicker(props) {
@@ -16,7 +15,6 @@ export function DatePicker(props) {
     onBlur,
     placeholder,
     selectedDate,
-    theme,
     ...otherProps
   } = props;
 
@@ -29,13 +27,6 @@ export function DatePicker(props) {
 
   /* eslint-enable */
 
-  const dpStyles = datepickerStyles(theme.colors, theme.datepickerColors);
-  /* eslint-disable no-unused-expressions */
-  injectGlobal`
-    ${dpStyles}
-  `;
-  /* eslint-enable */
-
   const textbox = (
     <Textbox
       maskType="date"
@@ -46,17 +37,20 @@ export function DatePicker(props) {
   );
 
   return (
-    <ReactDatePicker
-      customInput={textbox}
-      customInputRef="inputRef"
-      onChange={onChange}
-      onBlur={onBlur}
-      placeholderText={placeholder}
-      selected={selectedDate}
-      {...datepickerProps}
-    >
-      {children}
-    </ReactDatePicker>
+    <>
+      <DatepickerStyles />
+      <ReactDatePicker
+        customInput={textbox}
+        customInputRef="inputRef"
+        onChange={onChange}
+        onBlur={onBlur}
+        placeholderText={placeholder}
+        selected={selectedDate}
+        {...datepickerProps}
+      >
+        {children}
+      </ReactDatePicker>
+    </>
   );
 }
 
@@ -96,12 +90,7 @@ DatePicker.propTypes = {
   /** Sets the end date in a range */
   endDate: PropTypes.instanceOf(Date),
   /** Display checkbox with contextual state colorings */
-  validationState: PropTypes.oneOf(['default', 'success', 'warning', 'danger']),
-  /**
-   * Theme object used by the ThemeProvider,
-   * automatically passed by any parent component using a ThemeProvider
-   */
-  theme: PropTypes.object.isRequired
+  validationState: PropTypes.oneOf(['default', 'success', 'warning', 'danger'])
 };
 
 DatePicker.defaultProps = {
@@ -127,4 +116,4 @@ const UncontrolledDatePicker = uncontrollable(DatePicker, {
   selectedDate: 'onChange'
 });
 
-export default withTheme(UncontrolledDatePicker);
+export default UncontrolledDatePicker;

--- a/packages/es-components/src/components/patterns/datepicker/datePickerStyles.js
+++ b/packages/es-components/src/components/patterns/datepicker/datePickerStyles.js
@@ -1,8 +1,9 @@
-import React, { useContext } from 'react';
-import { createGlobalStyle, ThemeContext } from 'styled-components';
+import React from 'react';
+import { createGlobalStyle } from 'styled-components';
+import { useTheme } from '../../util/useTheme';
 
 export function DatepickerStyles() {
-  const { colors, datepickerColors: dpColors } = useContext(ThemeContext);
+  const { colors, datepickerColors: dpColors } = useTheme();
   const Styles = createGlobalStyle`
   .react-datepicker-popper[data-placement^="bottom"] .react-datepicker__triangle,
   .react-datepicker-popper[data-placement^="top"] .react-datepicker__triangle,

--- a/packages/es-components/src/components/patterns/datepicker/datePickerStyles.js
+++ b/packages/es-components/src/components/patterns/datepicker/datePickerStyles.js
@@ -1,5 +1,9 @@
-export default function datepickerStyles(colors, dpColors) {
-  return `
+import React, { useContext } from 'react';
+import { createGlobalStyle, ThemeContext } from 'styled-components';
+
+export function DatepickerStyles() {
+  const { colors, datepickerColors: dpColors } = useContext(ThemeContext);
+  const Styles = createGlobalStyle`
   .react-datepicker-popper[data-placement^="bottom"] .react-datepicker__triangle,
   .react-datepicker-popper[data-placement^="top"] .react-datepicker__triangle,
   .react-datepicker__year-read-view--down-arrow,
@@ -566,4 +570,5 @@ export default function datepickerStyles(colors, dpColors) {
     cursor: default;
   }
 `;
+  return <Styles />;
 }

--- a/packages/es-components/src/components/patterns/incrementer/Incrementer.js
+++ b/packages/es-components/src/components/patterns/incrementer/Incrementer.js
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { noop, isNumber } from 'lodash';
-import styled, { withTheme } from 'styled-components';
+import styled from 'styled-components';
 
 import Icon from '../../base/icons/Icon';
 import Button from '../../controls/buttons/Button';
 import { InputBase } from '../../controls/BaseControls';
 import screenReaderOnly from '../screenReaderOnly/screenReaderOnly';
+import { useTheme } from '../../util/useTheme';
 
 const IncrementerTextbox = styled(InputBase)`
   margin: 0 10px;
@@ -17,6 +18,7 @@ const IncrementerTextbox = styled(InputBase)`
 const ScreenReaderButtonText = screenReaderOnly('span');
 
 function Incrementer(props) {
+  const theme = useTheme();
   const [value, setValue] = useState(props.startingValue);
 
   function determineIsDisabled(threshold, newValue) {
@@ -59,7 +61,7 @@ function Incrementer(props) {
         <Icon name="minus" />
       </Button>
       <IncrementerTextbox
-        {...props.theme.validationInputColor.default}
+        {...theme.validationInputColor.default}
         type="text"
         value={value}
         readOnly
@@ -92,12 +94,7 @@ Incrementer.propTypes = {
   /** The lowest value the incrementer can be decremented to */
   lowerThreshold: PropTypes.number,
   /** Function to execute with the new value */
-  onValueUpdated: PropTypes.func,
-  /**
-   * Theme object used by the ThemeProvider,
-   * automatically passed by any parent component using a ThemeProvider
-   */
-  theme: PropTypes.object.isRequired
+  onValueUpdated: PropTypes.func
 };
 
 Incrementer.defaultProps = {
@@ -109,4 +106,4 @@ Incrementer.defaultProps = {
   lowerThreshold: null
 };
 
-export default withTheme(Incrementer);
+export default Incrementer;

--- a/packages/es-components/src/components/util/useTheme.js
+++ b/packages/es-components/src/components/util/useTheme.js
@@ -1,0 +1,4 @@
+import { useContext } from 'react';
+import { ThemeContext } from 'styled-components';
+
+export const useTheme = () => useContext(ThemeContext);


### PR DESCRIPTION
Upgrade checklist per the [migration guide](https://www.styled-components.com/docs/faqs#what-do-i-need-to-do-to-migrate-to-v4)

- [x] install latest `styled-components`
- [x] ~~use react@^16.3 react-dom@^16.3~~ Irrelevant since we're built using the 16.7 alpha
- [x] ~~replace `.extend(Component)` with `styled(Component)`~~ no existing usage
- [x] replace `injectGlobal` with `createGlobalStyle`
- [x] replace `innerRef` with `ref`
- [x] ~~use `css` helper on partials using `keyframes`~~ no existing usage
- [x] ~~repalce `attrs({})` with `attrs(props => ({}))`~~ no existing usage