### PR TITLE
New notifications and Calls To Action

### DIFF
--- a/packages/es-components/src/.eslintrc
+++ b/packages/es-components/src/.eslintrc
@@ -31,7 +31,8 @@
     "linebreak-style": 0,
     "import/no-extraneous-dependencies": ["error", {
         "devDependencies": ["**/*.specs.js", "**/ExampleWrapper.js", "src/components/util/test-utils.js"]
-      }]
+      }],
+      "prefer-arrow-callback": 0
   },
   "env": {
     "browser": true

--- a/packages/es-components/src/components/containers/notification/LightNotification.js
+++ b/packages/es-components/src/components/containers/notification/LightNotification.js
@@ -4,13 +4,13 @@ import { noop } from 'lodash';
 
 import { useNotification } from './useNotification';
 
-const DefaultNotification = useNotification();
+const Notification = useNotification('light');
 
-function Notification(props) {
-  return <DefaultNotification {...props} />;
+function LightNotification(props) {
+  return <Notification {...props} />;
 }
 
-Notification.propTypes = {
+LightNotification.propTypes = {
   /* The type of notification to render */
   type: PropTypes.oneOf(['success', 'info', 'warning', 'danger', 'advisor'])
     .isRequired,
@@ -24,7 +24,7 @@ Notification.propTypes = {
   children: PropTypes.node
 };
 
-Notification.defaultProps = {
+LightNotification.defaultProps = {
   includeIcon: false,
   isDismissable: false,
   children: null,
@@ -32,4 +32,4 @@ Notification.defaultProps = {
   onDismiss: noop
 };
 
-export default Notification;
+export default LightNotification;

--- a/packages/es-components/src/components/containers/notification/LightNotification.md
+++ b/packages/es-components/src/components/containers/notification/LightNotification.md
@@ -1,0 +1,29 @@
+These notifications are rendered with a lighter background.
+
+```
+<div>
+  <LightNotification
+    type="success"
+  >
+    <p>This is a successful notification!</p>
+  </LightNotification>
+
+  <LightNotification
+    type="info"
+  >
+    <p>This is an informational notification!</p>
+  </LightNotification>
+
+  <LightNotification
+    type="warning"
+  >
+    <p>This is a warning notification!</p>
+  </LightNotification>
+
+  <LightNotification
+    type="danger"
+  >
+    <p>This is a danger notification!</p>
+  </LightNotification>
+</div>
+```

--- a/packages/es-components/src/components/containers/notification/Message.js
+++ b/packages/es-components/src/components/containers/notification/Message.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+  emphasizedText: PropTypes.string,
+  text: PropTypes.string.isRequired
+};
+
+const defaultProps = {
+  emphasizedText: undefined
+};
+
+export function InlineMessage({ emphasizedText, text }) {
+  return (
+    <p>
+      {emphasizedText !== undefined ? <strong>{emphasizedText}</strong> : null}
+      {' '}
+      {text}
+    </p>
+  );
+}
+
+InlineMessage.propTypes = propTypes;
+InlineMessage.defaultProps = defaultProps;
+
+export function Message({ emphasizedText, text }) {
+  return (
+    <p>
+      {emphasizedText !== undefined ? (
+        <>
+          <strong>{emphasizedText}</strong>
+          <br />
+        </>
+      ) : null}
+      {text}
+    </p>
+  );
+}
+
+Message.propTypes = propTypes;
+Message.defaultProps = defaultProps;

--- a/packages/es-components/src/components/containers/notification/MessageNotification.js
+++ b/packages/es-components/src/components/containers/notification/MessageNotification.js
@@ -4,13 +4,13 @@ import { noop } from 'lodash';
 
 import { useNotification } from './useNotification';
 
-const DefaultNotification = useNotification();
+const Notification = useNotification('messageOnly');
 
-function Notification(props) {
-  return <DefaultNotification {...props} />;
+function MessageNotification(props) {
+  return <Notification {...props} />;
 }
 
-Notification.propTypes = {
+MessageNotification.propTypes = {
   /* The type of notification to render */
   type: PropTypes.oneOf(['success', 'info', 'warning', 'danger', 'advisor'])
     .isRequired,
@@ -24,7 +24,7 @@ Notification.propTypes = {
   children: PropTypes.node
 };
 
-Notification.defaultProps = {
+MessageNotification.defaultProps = {
   includeIcon: false,
   isDismissable: false,
   children: null,
@@ -32,4 +32,4 @@ Notification.defaultProps = {
   onDismiss: noop
 };
 
-export default Notification;
+export default MessageNotification;

--- a/packages/es-components/src/components/containers/notification/MessageNotification.md
+++ b/packages/es-components/src/components/containers/notification/MessageNotification.md
@@ -1,0 +1,30 @@
+A `MessageNotification` component renders the same as a `Notification` would without a background.
+
+```
+<div>
+  <MessageNotification
+    type="success"
+  >
+    <p>This is a successful notification!</p>
+  </MessageNotification>
+
+  <MessageNotification
+    type="info"
+  >
+    <p>This is an informational notification!</p>
+  </MessageNotification>
+
+  <MessageNotification
+    type="warning"
+    
+  >
+    <p>This is a warning notification!</p>
+  </MessageNotification>
+
+  <MessageNotification
+    type="danger"
+  >
+    <p>This is a danger notification!</p>
+  </MessageNotification>
+</div>
+```

--- a/packages/es-components/src/components/containers/notification/Notification.md
+++ b/packages/es-components/src/components/containers/notification/Notification.md
@@ -1,239 +1,100 @@
-### Notification Types
+Notifications are static containers that will render any children passed to it. They come in three different variations.
 
-```
+There are two additional components `InlineMessage` and `Message` that can be used to display text in a `Notification`.
+
+```jsx
+const Message = require('./Message').Message;
+const InlineMessage = require('./Message').InlineMessage;
+
 <div>
   <Notification
     type="success"
-    header="Success!"
-    additionalText="You did a thing."
-  />
+  >
+    <Message emphasizedText="Success" text="This is a successful notification!" />
+  </Notification>
 
   <Notification
     type="info"
-    header="Information!"
-    additionalText="Here's some information you need to know."
-  />
+  >
+    <InlineMessage emphasizedText="Info" text="This is an inline informational notification!" />
+  </Notification>
 
   <Notification
     type="warning"
-    additionalText="Here's a warning."
-  />
+  >
+    <Message text="This is a warning notification!" />
+  </Notification>
 
   <Notification
     type="danger"
-    header="Danger!"
-    additionalText="You're about to do something dangerous!"
-  />
+  >
+    <InlineMessage text="This is a danger notification!" />
+  </Notification>
 
   <Notification
     type="advisor"
-    header="Advisor!"
-    additionalText="This message is for benefit advisors."
-  />
+  >
+    <div style={{ flexBasis: '100%' }}>
+      <h3>This is an advisor alert!</h3>
+      <p>
+        Children are rendered in a flex container and <a href="#notification">links</a> render with underlined text, but <Popover
+              name="notification-popover"
+              title="Advisor popover"
+              content="Some content that is helpful to advisors!"
+              placement="top"
+              isLinkButton
+            >
+              popovers
+            </Popover> get dashed underlined text.
+      </p>
+      <h4>Any element can be rendered!</h4>
+      <ul>
+        <li>Item A</li>
+        <li>Item B</li>
+        <li>Item C</li>
+      </ul>
+    </div>
+
+    </Notification>
 </div>
 ```
 
-Adding the `dismissable` prop will render a dismiss button that will execute the provided `onDismiss` function.
-```
+Setting the `includeIcon` prop to `true` will render the icon associated with the `type` prop. 
+
+If the screen size is less than `768px`, it will not be displayed.
+
+```jsx
 <Notification
   type="success"
-  additionalText="I have a dismiss button. Click it!"
-  dismissable
-  onDismiss={() => alert('Why so dismissive?')}
-/>
-```
-
-Adding the `includeIcon` prop will render an appropriate icon for the alert type. <em>If the viewport is less than 768px, it will not render any icons in the notification.</em>
-```
-<Notification
-  type="advisor"
-  additionalText="Please read"
   includeIcon
-/>
-```
-
-Providing `callsToAction` will render a button for each which executes that action. The first button will receive the `primary` style type and any additional button will receive the `default` style type.
-```
-class CustomButton extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      content: 'Secondary',
-    };
-
-    this.handleClick = this.handleClick.bind(this);
-  }
-
-  handleClick() {
-    if (this.state.isProcessing) return;
-
-    this.setState({ content: 'Processing', isProcessing: true });
-
-    setTimeout(() => this.setState({ content: 'Secondary', isProcessing: false }), 3000);
-  }
-
-  render() {
-    const { isProcessing, content } = this.state;
-    return (
-      <Button
-        handleOnClick={this.handleClick}
-        disabled={isProcessing}
-      >
-        {content}
-      </Button>
-    );
-  }
-}
-
-const callsToAction = [
-      {
-        actionButtonContent: 'Primary',
-        action() {
-          confirm('You clicked a button!');
-        }
-      },
-      <CustomButton />,
-      {
-        actionButtonContent: 'Tertiary',
-        action() {
-          alert('You clicked the tertiary button')
-        }
-      }
-    ];
-<Notification
-  type="warning"
-  header="Action is required"
-  additionalText="Please click one of the buttons"
-  callsToAction={callsToAction}
-/>
-```
-
-Providing `extraAlert` with an object will render the selected icon and the provided text in the upper-right corner of the notification. If no icon is chosen, the `federal` icon will be used by default.
-```
-const extraAlert = {
-  alertText: 'I\'m an extra little alert!',
-  alertIcon: 'bell'
- };
-
-<Notification
-  type="success"
-  additionalText="Look at the extra alert!"
-  extraAlert={extraAlert}
-/>
-```
-
-Any additional children will get rendered before call to action buttons.
-```
-<Notification
-  type="info"
-  additionalText="Here's some information to get you started"
 >
-  This is <a href="#">how a link looks</a>.
-  <ol>
-    <li>Item A</li>
-    <li>Item B</li>
-    <li>Item C</li>
-  </ol>
+  <p>Congrats! You did it!</p>
 </Notification>
 ```
 
-### Color Variants
+Setting the `isDismissable` prop to `true` will add a button to remove the `Notification`. If an `onDismiss` prop is passed, it will be invoked when the `Notification` is removed.
 
-Applying the `useLightVariant` prop will use a lighter background color for the given notification type.
+```jsx
+function NotificationApp() {
+  const [message, setMessage] = React.useState('This message is displayed until notification is removed');
 
+  function notificationDismissed() {
+    setMessage('Notification was removed!');
+  }
+
+  return (
+    <>
+      <Notification
+        type="success"
+        isDismissable
+        onDismiss={notificationDismissed}
+      >
+        <p>Try dismissing this notification!</p>
+      </Notification>
+      <p>{message}</p>
+    </>
+  );
+}
+
+<NotificationApp />
 ```
-const callsToAction = [
-      {
-        actionButtonContent: 'Primary',
-        action() {
-          confirm('You clicked a button!');
-        }
-      },
-      {
-        actionButtonContent: 'Secondary',
-        action() {
-          alert('You clicked the secondary button')
-        }
-      }
-    ];
-
-<div>
-  <Notification
-    type="success"
-    header="Success!"
-    additionalText="You did a thing."
-    useLightVariant
-    callsToAction={callsToAction}
-  />
-
-  <Notification
-    type="info"
-    header="Information!"
-    additionalText="Here's some information you need to know."
-    useLightVariant
-  />
-
-  <Notification
-    type="warning"
-    additionalText="Here's a warning."
-    useLightVariant
-  />
-
-  <Notification
-    type="danger"
-    header="Danger!"
-    additionalText="You're about to do something dangerous!"
-    useLightVariant
-  />
-
-  <Notification
-    type="advisor"
-    header="Advisor!"
-    additionalText="This message is for benefit advisors."
-    useLightVariant
-  />
-</div>
-```
-
-The `useMessageOnlyVariant` prop can be applied to display the message in the appropriate text color without applying a background color.
-
-```
-<div>
-  <Notification
-    type="success"
-    header="Success!"
-    additionalText="You did a thing."
-    useMessageOnlyVariant
-  />
-
-  <Notification
-    type="info"
-    header="Information!"
-    additionalText="Here's some information you need to know."
-    useMessageOnlyVariant
-  />
-
-  <Notification
-    type="warning"
-    additionalText="Here's a warning."
-    useMessageOnlyVariant
-  />
-
-  <Notification
-    type="danger"
-    header="Danger!"
-    additionalText="You're about to do something dangerous!"
-    useMessageOnlyVariant
-  />
-
-  <Notification
-    type="advisor"
-    header="Advisor!"
-    additionalText="This message is for benefit advisors."
-    useMessageOnlyVariant
-  />
-</div>
-```
-
-If `useLightVariant` and `useMessageOnlyVariant` are both present `useMessageOnlyVariant` will take precedence.

--- a/packages/es-components/src/components/containers/notification/Notification.specs.js
+++ b/packages/es-components/src/components/containers/notification/Notification.specs.js
@@ -5,28 +5,16 @@ import React from 'react';
 import Notification from './Notification';
 import { renderWithTheme } from '../../util/test-utils';
 
-import Button from '../../controls/buttons/Button';
-
 it('notification has the dialog role by default', () => {
-  const { queryByRole } = renderWithTheme(
-    <Notification type="success" />
-  );
+  const { queryByRole } = renderWithTheme(<Notification type="success" />);
   expect(queryByRole('dialog')).not.toBeNull();
 });
 
-it('notification has the alert role when isAlert prop is true', () => {
+it('notification has the alert role when role is "alert"', () => {
   const { queryByRole } = renderWithTheme(
-    <Notification type="success" isAlert />
+    <Notification type="success" role="alert" />
   );
   expect(queryByRole('alert')).not.toBeNull();
-});
-
-it('dismissable notifications render button to dismiss', () => {
-  const { container } = renderWithTheme(
-    <Notification type="success" dismissable />
-  );
-
-  expect(container.querySelector('.notification__dismiss')).not.toBeNull();
 });
 
 it('notification prepends icon when includeIcon is true', () => {
@@ -37,69 +25,30 @@ it('notification prepends icon when includeIcon is true', () => {
   expect(container.querySelector('i')).not.toBeNull();
 });
 
-describe('when callsToAction are provided', () => {
-  const primaryAction = jest.fn();
-  const secondaryAction = jest.fn();
-  const tertiaryAction = jest.fn();
-
-  const callsToAction = [
-    {
-      actionButtonContent: 'primary',
-      action: primaryAction
-    },
-    {
-      actionButtonContent: 'secondary',
-      action: secondaryAction
-    },
-    {
-      actionButtonContent: 'tertiary',
-      action: tertiaryAction
-    }
-  ];
-
-  it('each calls to action is executable', () => {
-    const { getByText } = renderWithTheme(
-      <Notification callsToAction={callsToAction} type="success" />
+describe('dismissable notifications', () => {
+  it('removes notification when dismiss button is clicked', () => {
+    const { container, getByText } = renderWithTheme(
+      <Notification type="success" isDismissable>
+        <p id="find-me">I am here!</p>
+      </Notification>
     );
-    getByText('primary').click();
-    expect(primaryAction).toHaveBeenCalled();
+    expect(() => getByText('I am here!')).not.toThrow();
 
-    getByText('secondary').click();
-    expect(secondaryAction).toHaveBeenCalled();
+    container.querySelector('.notification__dismiss').click();
 
-    getByText('tertiary').click();
-    expect(tertiaryAction).toHaveBeenCalled();
+    expect(() => getByText('I am here!')).toThrow();
   });
 
-  it('allows components to be provided directly', () => {
-    const myButton = (
-      <Button id="myButton" handleOnClick={jest.fn()}>
-        My button
-      </Button>
+  it('invokes the passed "onDismiss" function', () => {
+    const onDismiss = jest.fn();
+    const { container } = renderWithTheme(
+      <Notification type="success" isDismissable onDismiss={onDismiss}>
+        <p id="find-me">I am here!</p>
+      </Notification>
     );
-    const buttonedCallsToAction = [
-      callsToAction[0],
-      myButton,
-      callsToAction[2]
-    ];
-    const { queryByText } = renderWithTheme(
-      <Notification type="success" callsToAction={buttonedCallsToAction} />
-    );
-    expect(queryByText('My button')).not.toBeNull();
+
+    container.querySelector('.notification__dismiss').click();
+
+    expect(onDismiss).toHaveBeenCalled();
   });
-});
-
-it('adds an ExtraAlert to the notification when provided', () => {
-  const alert = { alertText: 'test' };
-  const { queryByText } = renderWithTheme(
-    <Notification extraAlert={alert} type="success" />
-  );
-  expect(queryByText('test')).not.toBeNull();
-});
-
-it('displays additionalText is provided', () => {
-  const { queryByText } = renderWithTheme(
-    <Notification type="success" additionalText="added text" />
-  );
-  expect(queryByText('added text')).not.toBeNull();
 });

--- a/packages/es-components/src/components/containers/notification/useNotification.js
+++ b/packages/es-components/src/components/containers/notification/useNotification.js
@@ -1,0 +1,114 @@
+import React, { useRef, useState, useMutationEffect } from 'react';
+import styled from 'styled-components';
+import Icon from '../../base/icons/Icon';
+import { useTheme } from '../../util/useTheme';
+
+const NotificationIcon = styled(Icon)`
+  display: none;
+
+  @media (min-width: ${props => props.theme.screenSize.tablet}) {
+    display: initial;
+    margin-right: 5px;
+  }
+`;
+
+const DismissButton = styled.button`
+  background-color: transparent;
+  border: 0;
+  color: ${props => props.theme.colors.white};
+  cursor: pointer;
+`;
+
+const iconNames = {
+  success: 'ok-circle',
+  info: 'info-circle',
+  warning: 'exclamation-sign',
+  danger: 'info-circle',
+  advisor: 'agent'
+};
+
+const NotificationContent = React.forwardRef(
+  ({ type, includeIcon, isDismissable, onDismiss, children }, ref) => {
+    const [isDismissed, setIsDismissed] = useState(false);
+
+    useMutationEffect(
+      function removeNotification() {
+        if (ref.current) {
+          ref.current.remove();
+        }
+      },
+      [isDismissed]
+    );
+
+    function dismissNotification() {
+      onDismiss();
+      setIsDismissed(true);
+    }
+
+    return (
+      <>
+        {includeIcon ? (
+          <NotificationIcon name={iconNames[type]} size={28} />
+        ) : null}
+        {children}
+        {isDismissable ? (
+          <DismissButton
+            onClick={dismissNotification}
+            className="notification__dismiss"
+          >
+            <Icon name="remove" size={27} />
+          </DismissButton>
+        ) : null}
+      </>
+    );
+  }
+);
+
+const Notification = styled.div`
+  align-items: center;
+  background-color: ${props => props.color.bgColor};
+  border-radius: 2px;
+  color: ${props => props.color.textColor};
+  display: flex;
+  flex-wrap: wrap;
+  margin-bottom: 25px;
+  padding: 15px;
+
+  > :not(i):not(button) {
+    flex-grow: 1;
+  }
+
+  a {
+    color: ${props => props.color.textColor};
+    text-decoration: underline;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  .es-popover .es-button--link {
+    color: ${props => props.color.textColor};
+  }
+`;
+
+export function useNotification(styleType = 'base') {
+  return function BaseNotification({ role, type, children, ...rest }) {
+    const theme = useTheme();
+    const notificationRef = useRef(null);
+    const color = theme.notificationStyles[type][styleType];
+
+    const notificationContentProps = { type, ...rest };
+
+    return (
+      <Notification ref={notificationRef} role={role} color={color}>
+        <NotificationContent
+          ref={notificationRef}
+          {...notificationContentProps}
+        >
+          {children}
+        </NotificationContent>
+      </Notification>
+    );
+  };
+}

--- a/packages/es-components/src/components/patterns/callToAction/Action.js
+++ b/packages/es-components/src/components/patterns/callToAction/Action.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import Button from '../../controls/buttons/Button';
+
+const ActionButton = styled(Button)`
+  :not(:first-of-type) {
+    margin-left: 15px;
+  }
+`;
+
+export default function Action({ isPrimary, children, ...rest }) {
+  return <ActionButton {...rest}>{children}</ActionButton>;
+}
+
+Action.propTypes = {
+  isPrimary: PropTypes.bool,
+  children: PropTypes.node
+};
+
+Action.defaultProps = {
+  isPrimary: false,
+  children: null
+};

--- a/packages/es-components/src/components/patterns/callToAction/CallToAction.js
+++ b/packages/es-components/src/components/patterns/callToAction/CallToAction.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import styled from 'styled-components';
+import Notification from '../../containers/notification/Notification';
+
+import { getCallToActionChildren } from './getCallToActionChildren';
+
+const Container = styled.div`
+  flex-basis: 100%;
+`;
+
+const CallToActionContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+function CallToAction({ children, ...rest }) {
+  const { actions, nonActions } = getCallToActionChildren(children);
+  const props = { ...rest, isDismissable: false };
+  return (
+    <>
+      <Notification {...props}>
+        <Container>{nonActions}</Container>
+      </Notification>
+      <CallToActionContainer>{actions}</CallToActionContainer>
+    </>
+  );
+}
+
+export default CallToAction;

--- a/packages/es-components/src/components/patterns/callToAction/CallToAction.md
+++ b/packages/es-components/src/components/patterns/callToAction/CallToAction.md
@@ -1,0 +1,26 @@
+This component combines the `Notification` and a set of `Action` components. This component takes all the same props as [Notification](#notification). It will replace any passed `isDismissable` prop and set it to `false`.
+
+```jsx
+const Action = require('./Action').default;
+
+function firstAction() {
+  console.log('first action fired');
+}
+
+function secondAction() {
+  console.log('second action fired');
+}
+
+function thirdAction() {
+  console.log('third action fired');
+}
+
+<CallToAction
+  type="danger"
+>
+  <p>What what what!</p>
+  <Action onClick={thirdAction}>Third</Action>
+  <Action onClick={secondAction}>Second</Action>
+  <Action onClick={firstAction} isPrimary>First</Action>
+</CallToAction>
+```

--- a/packages/es-components/src/components/patterns/callToAction/CallToAction.specs.js
+++ b/packages/es-components/src/components/patterns/callToAction/CallToAction.specs.js
@@ -1,0 +1,22 @@
+/* eslint-env jest */
+
+import React from 'react';
+
+import { getCallToActionChildren } from './getCallToActionChildren';
+import Action from './Action';
+
+it('separates Action elements from all other elements', () => {
+  const elements = [
+    <div>First</div>,
+    <Action>First Action</Action>,
+    <Action>Second Action</Action>,
+    <p>A paragraph</p>,
+    <Action isPrimary>Primary Action</Action>,
+    <h3>A third level header</h3>
+  ];
+
+  const { actions, nonActions } = getCallToActionChildren(elements);
+
+  expect(actions).toHaveLength(3);
+  expect(nonActions).toHaveLength(3);
+});

--- a/packages/es-components/src/components/patterns/callToAction/LightCallToAction.js
+++ b/packages/es-components/src/components/patterns/callToAction/LightCallToAction.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import styled from 'styled-components';
+import LightNotification from '../../containers/notification/LightNotification';
+
+import { getCallToActionChildren } from './getCallToActionChildren';
+
+const Container = styled.div`
+  flex-basis: 100%;
+`;
+
+const CallToActionContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+function LightCallToAction({ children, ...rest }) {
+  const { actions, nonActions } = getCallToActionChildren(children, 'light');
+  const props = { ...rest, isDismissable: false };
+  return (
+    <LightNotification {...props}>
+      <Container>
+        {nonActions}
+        <CallToActionContainer>{actions}</CallToActionContainer>
+      </Container>
+    </LightNotification>
+  );
+}
+
+export default LightCallToAction;

--- a/packages/es-components/src/components/patterns/callToAction/LightCallToAction.md
+++ b/packages/es-components/src/components/patterns/callToAction/LightCallToAction.md
@@ -1,0 +1,26 @@
+This component combines the `LightNotification` and a set of `Action` components. This component takes all the same props as [LightNotification](#lightnotification). It will replace any passed `isDismissable` prop and set it to `false`.
+
+```jsx
+const Action = require('./Action').default;
+
+function firstAction() {
+  console.log('first action fired');
+}
+
+function secondAction() {
+  console.log('second action fired');
+}
+
+function thirdAction() {
+  console.log('third action fired');
+}
+
+<LightCallToAction
+  type="danger"
+>
+  <p>What what what!</p>
+  <Action onClick={thirdAction}>Third</Action>
+  <Action onClick={secondAction}>Second</Action>
+  <Action onClick={firstAction} isPrimary>First</Action>
+</LightCallToAction>
+```

--- a/packages/es-components/src/components/patterns/callToAction/getCallToActionChildren.js
+++ b/packages/es-components/src/components/patterns/callToAction/getCallToActionChildren.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export function getCallToActionChildren(children, type = 'default') {
+  const allChildren = React.Children.toArray(children);
+  const actions = allChildren
+    .filter(child => child.type.name === 'Action')
+    .map(action => {
+      if (type === 'light') {
+        const styleType = action.props.isPrimary ? 'primary' : 'darkDefault';
+        return React.cloneElement(action, { styleType });
+      }
+      const styleType = action.props.isPrimary ? 'primary' : 'default';
+      return React.cloneElement(action, { styleType });
+    });
+
+  const nonActions = allChildren.filter(child => child.type.name !== 'Action');
+
+  return {
+    actions,
+    nonActions
+  };
+}

--- a/packages/es-components/src/index.js
+++ b/packages/es-components/src/index.js
@@ -1,6 +1,12 @@
 export Icon from './components/base/icons/Icon';
 
 export Notification from './components/containers/notification/Notification';
+export LightNotification from './components/containers/notification/LightNotification';
+export MessageNotification from './components/containers/notification/MessageNotification';
+export {
+  InlineMessage,
+  Message
+} from './components/containers/notification/Message';
 export Drawer from './components/containers/drawer/Drawer';
 export Fieldset from './components/containers/fieldset/Fieldset';
 export Tooltip from './components/containers/tooltip/Tooltip';

--- a/packages/es-components/src/index.js
+++ b/packages/es-components/src/index.js
@@ -29,6 +29,9 @@ export SideNav from './components/navigation/sidenav/SideNav';
 export DatePicker from './components/patterns/datepicker/DatePicker';
 export Incrementer from './components/patterns/incrementer/Incrementer';
 export screenReaderOnly from './components/patterns/screenReaderOnly/screenReaderOnly';
+export CallToAction from './components/patterns/callToAction/CallToAction';
+export LightCallToAction from './components/patterns/callToAction/LightCallToAction';
+export Action from './components/patterns/callToAction/Action';
 
 export Spinner from './components/base/spinner/Spinner';
 


### PR DESCRIPTION
This pull request adds two additional components (`LightNotification` and `MessageNotification`) to live alongside `Notification`.

I extracted the default messaging behaviors into two components: `Message` and `InlineMessage`. This will allow consumers of the `Notification` to be able to choose whether to use it or not without forcing their hand with required props on `Notification`.

I removed the `extraAlert` prop because they aren't really a concern of this library and should be implemented using `children` in a consuming application.

I removed the `callsToAction` prop because are now in the `CallsToAction` and `LightCallToAction` components.

---

This pull request also adds two new components to Patterns for calls to action. There is an `Action` component that can be used within `CallToAction` or `LightCallToAction`. Since those components don't do much except control display, I wrote a test for the `getCallToActionChildren` function that does the separation of action children and non-action children.
