### PR TITLE
Update tab panels to give parent more control

### DIFF
--- a/packages/es-components/src/components/containers/tabPanels/Tab.js
+++ b/packages/es-components/src/components/containers/tabPanels/Tab.js
@@ -57,7 +57,7 @@ const AriaAnnouncer = styled.p`
 /* eslint-enable */
 
 function Tab({
-  name,
+  header,
   selected,
   action,
   children,
@@ -67,9 +67,9 @@ function Tab({
 }) {
   return (
     <TabButton
-      onClick={() => action(name, children, simpleName, announcerText)}
+      onClick={() => action(header, children, simpleName, announcerText)}
       selected={selected}
-      aria-label={`${simpleName || name} tab`}
+      aria-label={`${simpleName || header} tab`}
       aria-expanded={selected}
       {...props}
     >
@@ -79,16 +79,16 @@ function Tab({
             {`${simpleName} ${announcerText}`}
           </AriaAnnouncer>
         )}
-      {name}
+      {header}
     </TabButton>
   );
 }
 
 Tab.propTypes = {
   /**
-   * The name of the tab, and the displayed value
+   * The header of the tab, and the displayed value
    */
-  name: PropTypes.node.isRequired,
+  header: PropTypes.node.isRequired,
   /**
    * Whether the tab is selected and should be rendered to appear selected.
    */

--- a/packages/es-components/src/components/containers/tabPanels/TabPanel.js
+++ b/packages/es-components/src/components/containers/tabPanels/TabPanel.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { noop } from 'lodash';
+import { noop, findIndex } from 'lodash';
 import Tab from './Tab';
 
 const TabWrapper = styled.div`
@@ -32,48 +32,40 @@ const TabContent = styled.div`
 class TabPanel extends React.Component {
   constructor(props) {
     super(props);
-    const child = Array.isArray(this.props.children)
-      ? props.children[0]
-      : props.children;
     this.state = {
-      value: child.props.name,
-      currentContent: child.props.children
+      parentTabChanged: props.tabChanged
     };
     this.tabChanged = this.tabChanged.bind(this);
   }
 
-  componentDidUpdate(prevProp, prevState) {
-    if (this.state.value !== prevState.value) {
-      this.props.tabChanged(this.state.value);
-    }
-  }
-
-  tabChanged(name, child) {
-    this.setState({
-      value: name,
-      currentContent: child
-    });
+  tabChanged(header) {
+    this.state.parentTabChanged(header);
   }
 
   render() {
-    const { children } = this.props;
+    const { children, selectedKey } = this.props;
+    let displayIndex = findIndex(children, (child) => 
+      child.props.header.key
+        ? child.props.header.key === selectedKey
+        : child.props.header === selectedKey
+      );
+      if(displayIndex < 0){
+        displayIndex = 0;
+      }
     const elements = React.Children.map(children, (child, i) => {
-      const isSelected = child.props.name.key
-        ? child.props.name.key === this.state.value.key
-        : child.props.name === this.state.value;
       return React.cloneElement(child, {
-        selected: isSelected,
+        selected: i === displayIndex,
         action: this.tabChanged
       });
     });
-
+    
     return (
       <div className="es-tab-panel">
         <TabWrapper className="es-tab-panel__wrapper">
           <TabFormatter className="es-tab-panel__tabs">{elements}</TabFormatter>
         </TabWrapper>
         <TabContent className="es-tab-panel__content">
-          {this.state.currentContent}
+          {elements[displayIndex].props.children}
         </TabContent>
       </div>
     );

--- a/packages/es-components/src/components/containers/tabPanels/TabPanel.md
+++ b/packages/es-components/src/components/containers/tabPanels/TabPanel.md
@@ -1,31 +1,53 @@
 Tab Panels allow us to store lots more data on the screen and only show the amount we want, when we want. This works by having a TabPanel.Tab which provides a quick peek into what information will be display in the content area when clicked. The TabPanel.Tab has a name, which is a string or JSX to be displayed, and an optional simpleName, which is a string that will be read by a screen reader. The TabPanel.Tab can have children inside of it that will be rendered inside of the TabPanel's content area.
 
 ```
-<TabPanel>
-  <TabPanel.Tab name="Hi there">
-    <p>
-      HELLO WORLD!!!!
-    </p>
-  </TabPanel.Tab>
-  <TabPanel.Tab simpleName="interesting" name={<div><Icon name="certificate" />Interesting 5 plans</div>}>
-    <div>
-      <p>
-        Nesting is fun
-      </p>
-    </div>
-  </TabPanel.Tab>
-  <TabPanel.Tab name="Lorem ipsum" announcerText="Tab is now selected">
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum
-    </p>
-  </TabPanel.Tab>
-  <TabPanel.Tab name="dolor sit">
-    <p>
-      Multiple paragraphs inside the Tab.
-    </p>
-    <p>
-      ed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?
-    </p>
-  </TabPanel.Tab>
-</TabPanel>
+class TabUser extends React.Component {
+
+  constructor(props){
+    super(props);
+    this.state = {
+      selected: ''
+    }
+    this.updateKey = this.updateKey.bind(this);
+  }
+
+  updateKey(header){
+    const key = header.key ? header.key : header;
+    this.setState({selected: key});
+  }
+
+  render(){
+    return (
+      <TabPanel selectedKey={this.state.selected} tabChanged={this.updateKey}>
+        <TabPanel.Tab header="Hi there">
+          <p>
+            HELLO WORLD!!!!
+          </p>
+        </TabPanel.Tab>
+        <TabPanel.Tab simpleName="interesting" header={<div key="second"><Icon name="certificate" />Interesting 5 plans</div>}>
+          <div>
+            <p>
+              Nesting is fun
+            </p>
+          </div>
+        </TabPanel.Tab>
+        <TabPanel.Tab header="Lorem ipsum" announcerText="Tab is now selected">
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum
+          </p>
+        </TabPanel.Tab>
+        <TabPanel.Tab header="dolor sit">
+          <p>
+            Multiple paragraphs inside the Tab.
+          </p>
+          <p>
+            ed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?
+          </p>
+        </TabPanel.Tab>
+      </TabPanel>
+    );
+  }
+}
+
+<TabUser /> 
 ```


### PR DESCRIPTION
Rather than control which tab is selected by ourselves, I moved the
logic into props which require the callback to change the prop.
The reason for the change is downstream when we really started using it,
the metadata around the content would change, but because we make a copy
of the elements they don't rerender correctly. This fixes things down
the line and makes the component more useful overall.