### PR TITLE
Fix: add babel-polyfill to head

### DIFF
--- a/packages/es-components/styleguide.config.js
+++ b/packages/es-components/styleguide.config.js
@@ -39,7 +39,8 @@ module.exports = {
         }
       </style>
       <link rel="stylesheet" href="https://cdn.rawgit.com/WTW-IM/es-assets/8fbaf85d/font.css">
-      <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,200i,300,300i,400,400i,600,600i,700,700i,900,900i" rel="stylesheet">`
+      <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,200i,300,300i,400,400i,600,600i,700,700i,900,900i" rel="stylesheet">
+      <script src="https://unpkg.com/@babel/polyfill@7.0.0/dist/polyfill.min.js"></script>`
     }
   },
   ribbon: {


### PR DESCRIPTION
For IE11 compatibility, there are some missing features that babel does
not support out of the box. babel-polyfill is a package that fills in
those gaps and allows common ES6 features to work even in IE11.

Add a script tag that points to babel-polyfill to the head of the template
in order to ensure that the polyfill is loaded before all components are
loaded.