### PR TITLE
Textbox icon height fix

### DIFF
--- a/packages/es-components/src/components/controls/textbox/Textbox.js
+++ b/packages/es-components/src/components/controls/textbox/Textbox.js
@@ -57,6 +57,7 @@ const CommonInputStyles = css`
     props.hasAppend ? '0' : defaultBorderRadius};
   box-sizing: border-box;
   display: table-cell;
+  line-height: ${props => props.theme.sizes.baseLineHeight};
   padding-right: ${props =>
     props.hasValidationIcon ? '2em' : defaultInputPad};
 `;
@@ -102,9 +103,12 @@ const AddOn = css`
   border-radius: ${defaultBorderRadius};
   color: ${props => props.addOnTextColor};
   display: table-cell;
+  height: 39px;
+  line-height: 1.2;
   padding: 6px 11px;
 
   i {
+    line-height: 1;
     vertical-align: middle;
   }
 `;
@@ -201,7 +205,7 @@ const Textbox = props => {
       <InputWrapper className="es-textbox__wrapper">
         {hasPrepend && (
           <Prepend addOnTextColor={addOnTextColor} addOnBgColor={addOnBgColor}>
-            <Icon aria-hidden="true" name={prependIconName} size={20} />
+            <Icon aria-hidden="true" name={prependIconName} size={18} />
           </Prepend>
         )}
         <Input
@@ -222,13 +226,13 @@ const Textbox = props => {
             <ValidationIcon
               aria-hidden="true"
               name={theme.validationIconName[validationState]}
-              size={20}
+              size={18}
             />
           </ValidationIconWrapper>
         )}
         {hasAppend && (
           <Append addOnTextColor={addOnTextColor} addOnBgColor={addOnBgColor}>
-            <Icon aria-hidden="true" name={appendIconName} size={20} />
+            <Icon aria-hidden="true" name={appendIconName} size={18} />
           </Append>
         )}
       </InputWrapper>

--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.md
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.md
@@ -4,22 +4,23 @@ Passes props through to the TextBox component for additional functionality (for 
 
 **Keyboard support**
 
-* Left: Move to the previous day
-* Right: Move to the next day
-* Up: Move to the previous week
-* Down: Move to the next week
-* PgUp: Move to the previous month
-* PgDn: Move to the next month
-* Home: Move to the previous year
-* End: Move to the next year
-* Enter/Esc/Tab: Close the calendar
+- Left: Move to the previous day
+- Right: Move to the next day
+- Up: Move to the previous week
+- Down: Move to the next week
+- PgUp: Move to the previous month
+- PgDn: Move to the next month
+- Home: Move to the previous year
+- End: Move to the next year
+- Enter/Esc/Tab: Close the calendar
 
 ### Events
 
 The `DatePicker` component supports event handlers for `onChange`, `onBlur`, and `onChangeRaw`. The
 `onChange` event will return a moment object representing the selected date, and only fires when
-a valid date is selected.  The `onBlur` and `onChangeRaw` events will return an event with the
+a valid date is selected. The `onBlur` and `onChangeRaw` events will return an event with the
 raw value of the input.
+
 ```
 function handleOnChange(date) {
   console.log(`Date selected: ${date}`);
@@ -73,7 +74,7 @@ class RangeExample extends React.Component {
 
   render() {
     return (
-      <div style={{ display: 'flex', width: '65%', justifyContent: 'space-between' }}>
+      <div style={{ display: 'flex', width: '70%', justifyContent: 'space-between' }}>
         <DatePicker
           labelText="Start Date"
           onChange={this.handleChangeStart}
@@ -108,7 +109,6 @@ function isWeekday(date) {
 }
 
 <DatePicker labelText="No Weekends" onChange={()=>{}} filterDate={isWeekday} />
-
 ```
 
 ### Include Dates (whitelist)


### PR DESCRIPTION
A couple of small changes that ensure the prepend/append icon containers match the height of the accompanying textbox across browsers (was uneven in IE11).