### PR TITLE
Fix: box-sizing on textbox prepend/append

### DIFF
--- a/packages/es-components/src/components/containers/modal/Modal.md
+++ b/packages/es-components/src/components/containers/modal/Modal.md
@@ -18,7 +18,7 @@ an informational dialog that contains no focusable elements, use a popover or so
   >
     <Modal.Header hideCloseButton={state.hideCloseButton}>This is the header.</Modal.Header>
     <Modal.Body>Body Content. Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch.This is the popover's content. Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid.</Modal.Body>
-    <Modal.Footer>This is the footer. <Button handleOnClick={()=> setState({show: false})} style={{margin:0}}>Ok</Button></Modal.Footer>
+    <Modal.Footer>This is the footer. <Button handleOnClick={()=> setState({show: false})}>Ok</Button></Modal.Footer>
   </Modal>
 </div>
 ```

--- a/packages/es-components/src/components/controls/textbox/Textbox.js
+++ b/packages/es-components/src/components/controls/textbox/Textbox.js
@@ -101,6 +101,7 @@ const AddOn = css`
         ? props.theme.colors.gray5
         : props.addOnBgColor};
   border-radius: ${defaultBorderRadius};
+  box-sizing: border-box;
   color: ${props => props.addOnTextColor};
   display: table-cell;
   height: 39px;

--- a/packages/es-components/styleguide.config.js
+++ b/packages/es-components/styleguide.config.js
@@ -25,10 +25,6 @@ module.exports = {
           font-weight: 400;
         }
 
-        * {
-          box-sizing: border-box;
-        }
-
         input, button, select, textarea {
           font-family: inherit;
         }


### PR DESCRIPTION
One more followup fix to textbox. We were setting `box-sizing: border-box` in the styleguide head which made everything look good in the guide, but not necessarily in downstream projects. Removed it from our head so we can spot those in the future, and added it to the textbox.