### PR TITLE
Fix: modal content now left-aligned

### DIFF
--- a/packages/es-components/src/components/containers/modal/Modal.js
+++ b/packages/es-components/src/components/containers/modal/Modal.js
@@ -62,6 +62,7 @@ const ModalContent = styled.div`
   font-size: ${props => props.theme.sizes.baseFontSize};
   outline: 0;
   position: relative;
+  text-align: left;
 `;
 
 class Modal extends React.Component {


### PR DESCRIPTION
Modal dialog positioning uses `text-align: center`. This caused the contents of the modal to also be centered, which was unintended.