### PR TITLE
Fix: ensuring Tooltips have type='button'

### DIFF
--- a/packages/es-components/src/components/containers/tooltip/Tooltip.js
+++ b/packages/es-components/src/components/containers/tooltip/Tooltip.js
@@ -185,6 +185,7 @@ class Tooltip extends React.Component {
       <span>
         <StyledButton
           className="es-tooltip__target"
+          type="button"
           ref={span => {
             this.toolTipTarget = span;
           }}


### PR DESCRIPTION
Buttons are `type='submit'` by default. This causes Tooltips to submit forms when clicked.
For more info, see [the `type` attribute descriptions on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Attributes).