### PR TITLE
Heading component

### DIFF
--- a/packages/es-components/src/components/containers/heading/Heading.js
+++ b/packages/es-components/src/components/containers/heading/Heading.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled, { css } from 'styled-components';
+
+// should eventually come from theme
+const fontSize = {
+  1: '44.78976px',
+  2: '37.3248px',
+  3: '31.104px',
+  4: '25.92px',
+  5: '21.6px',
+  6: '18px'
+};
+
+const BaseHeading = css`
+  color: inherit;
+  font-size: ${props => fontSize[props.adjustedSize]};
+  font-weight: 300;
+  line-height: 1.1;
+  margin-bottom: 12.5px;
+  margin-top: 25px;
+
+  small {
+    font-size: ${props => (props.adjustedSize > 3 ? '75%' : '65%')};
+    line-height: 1;
+  }
+`;
+
+// most of these, along with the switch statement, can be removed when we
+// upgrade to styled-components v4 and can use the "as" prop
+const Heading1 = styled.h1`
+  ${BaseHeading};
+`;
+
+const Heading2 = styled.h2`
+  ${BaseHeading};
+`;
+
+const Heading3 = styled.h3`
+  ${BaseHeading};
+`;
+
+const Heading4 = styled.h4`
+  ${BaseHeading};
+`;
+
+const Heading5 = styled.h5`
+  ${BaseHeading};
+`;
+
+const Heading6 = styled.h6`
+  ${BaseHeading};
+`;
+
+function Heading({ children, level, size, ...other }) {
+  const adjustedSize = size || level;
+
+  let HeaderStyled;
+  switch (level) {
+    case 2:
+      HeaderStyled = Heading2;
+      break;
+    case 3:
+      HeaderStyled = Heading3;
+      break;
+    case 4:
+      HeaderStyled = Heading4;
+      break;
+    case 5:
+      HeaderStyled = Heading5;
+      break;
+    case 6:
+      HeaderStyled = Heading6;
+      break;
+    default:
+      HeaderStyled = Heading1;
+      break;
+  }
+  return (
+    <HeaderStyled adjustedSize={adjustedSize} {...other}>
+      {children}
+    </HeaderStyled>
+  );
+}
+
+Heading.propTypes = {
+  children: PropTypes.node,
+  /** Heading level element */
+  level: PropTypes.oneOf([1, 2, 3, 4, 5, 6]).isRequired,
+  /** Override the default font size with another level */
+  size: PropTypes.oneOf([1, 2, 3, 4, 5, 6])
+};
+
+Heading.defaultProps = {
+  children: undefined,
+  size: undefined
+};
+
+export default Heading;

--- a/packages/es-components/src/components/containers/heading/Heading.md
+++ b/packages/es-components/src/components/containers/heading/Heading.md
@@ -1,0 +1,20 @@
+A `Heading` component can be used for various heading levels. Wrap secondary text in `<small>` tags.
+
+```
+<div>
+  <Heading level={1}>h1. Heading <small>Secondary Text</small></Heading>
+  <Heading level={2}>h2. Heading <small>Secondary Text</small></Heading>
+  <Heading level={3}>h3. Heading <small>Secondary Text</small></Heading>
+  <Heading level={4}>h4. Heading <small>Secondary Text</small></Heading>
+  <Heading level={5}>h5. Heading <small>Secondary Text</small></Heading>
+  <Heading level={6}>h6. Heading <small>Secondary Text</small></Heading>
+</div>
+```
+
+The font size may be overridden by that of another level by providing the `size` prop.
+
+```
+<div>
+  <Heading level={1} size={3}>h1. Heading in h3 size</Heading>
+</div>
+```

--- a/packages/es-components/src/components/containers/heading/Heading.specs.js
+++ b/packages/es-components/src/components/containers/heading/Heading.specs.js
@@ -1,0 +1,28 @@
+/* eslint-env jest */
+
+import React from 'react';
+import { renderWithTheme } from '../../util/test-utils';
+
+import Heading from './Heading';
+
+it('renders proper heading level', () => {
+  const { queryByText } = renderWithTheme(
+    <Heading level={1}>Heading level 1</Heading>
+  );
+
+  expect(queryByText('Heading level 1')).not.toBeNull();
+});
+
+it('renders heading level with another size', () => {
+  const { container } = renderWithTheme(
+    <div>
+      <Heading level={1}>Heading level 1</Heading>
+      <Heading level={3}>Heading level 3</Heading>
+      <Heading level={3} size={1}>
+        Heading level 3 size 1
+      </Heading>
+    </div>
+  );
+
+  expect(container).toMatchSnapshot();
+});

--- a/packages/es-components/src/components/containers/heading/__snapshots__/Heading.specs.js.snap
+++ b/packages/es-components/src/components/containers/heading/__snapshots__/Heading.specs.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders heading level with another size 1`] = `
+<div>
+  <div>
+    <h1
+      class="sc-bdVaJa epHIGJ"
+    >
+      Heading level 1
+    </h1>
+    <h3
+      class="sc-htpNat fscdUm"
+    >
+      Heading level 3
+    </h3>
+    <h3
+      class="sc-htpNat eUqHgu"
+    >
+      Heading level 3 size 1
+    </h3>
+  </div>
+</div>
+`;

--- a/packages/es-components/src/components/controls/DismissButton.js
+++ b/packages/es-components/src/components/controls/DismissButton.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import screenReaderOnly from '../patterns/screenReaderOnly/screenReaderOnly';
 
 const DismissButtonBase = styled.button`
   background: transparent;
@@ -9,16 +10,7 @@ const DismissButtonBase = styled.button`
   font-weight: bold;
 `;
 
-const ScreenReaderText = styled.span`
-  border: 0;
-  clip: rect(0, 0, 0, 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-`;
+const ScreenReaderText = screenReaderOnly('span');
 
 const DismissButton = props => (
   <DismissButtonBase aria-label="Close" {...props}>

--- a/packages/es-components/src/index.js
+++ b/packages/es-components/src/index.js
@@ -10,6 +10,7 @@ export Menu from './components/containers/menu/Menu';
 export TabPanel from './components/containers/tabPanels/TabPanel';
 export StripedContainer from './components/containers/striped-container/StripedContainer';
 export CheckboxLabel from './components/containers/checkboxLabel/CheckboxLabel';
+export Heading from './components/containers/heading/Heading';
 
 export Textbox from './components/controls/textbox/Textbox';
 export Button from './components/controls/buttons/Button';


### PR DESCRIPTION
I'm not sure if I should add this here or to the #229 branch. Being able to use the styled-components `as` prop in v4 would significantly reduce the amount of code used, but I'm not sure how far out we are from merging that.

Anyway, take a look and see if this is in line with our needs.

I also updated the DismissButton to use the existing screenReader HoC.