### PR TITLE
Using Aria for RadioGroup labeling.

### DIFF
--- a/packages/es-components/src/components/containers/fieldset/Fieldset.js
+++ b/packages/es-components/src/components/containers/fieldset/Fieldset.js
@@ -15,13 +15,27 @@ const Legend = styled.legend`
   width: 100%;
 `;
 
-function renderLegend(content, legendClasses) {
-  return content ? (
-    <Legend className={classnames('es-fieldset__legend', legendClasses)}>
-      {content}
+const FieldsetLegend = ({ legendClasses, legendId, children }) =>
+  children ? (
+    <Legend
+      className={classnames('es-fieldset__legend', legendClasses)}
+      id={legendId}
+    >
+      {children}
     </Legend>
   ) : null;
-}
+
+FieldsetLegend.propTypes = {
+  legendClasses: PropTypes.string,
+  legendId: PropTypes.string,
+  children: PropTypes.node
+};
+
+FieldsetLegend.defaultProps = {
+  legendClasses: null,
+  legendId: null,
+  children: null
+};
 
 const StyledFieldset = styled.fieldset`
   border: 0;
@@ -29,11 +43,19 @@ const StyledFieldset = styled.fieldset`
   padding: 0;
 `;
 
-function Fieldset({ legendClasses, legendContent, children, className }) {
+function Fieldset({
+  legendClasses,
+  legendContent,
+  legendId,
+  children,
+  className
+}) {
   const fieldsetClasses = classnames('es-fieldset', className);
   return (
     <StyledFieldset className={fieldsetClasses}>
-      {renderLegend(legendContent, legendClasses)}
+      <FieldsetLegend {...{ legendClasses, legendId }}>
+        {legendContent}
+      </FieldsetLegend>
       {children}
     </StyledFieldset>
   );
@@ -44,6 +66,8 @@ Fieldset.propTypes = {
   legendContent: PropTypes.node,
   /** Additional classes to be applied to the legend element */
   legendClasses: PropTypes.string,
+  /** Additional id for the legend element */
+  legendId: PropTypes.string,
   children: PropTypes.node,
   className: PropTypes.string
 };
@@ -51,6 +75,7 @@ Fieldset.propTypes = {
 Fieldset.defaultProps = {
   legendContent: null,
   legendClasses: null,
+  legendId: null,
   children: undefined,
   className: undefined
 };

--- a/packages/es-components/src/components/containers/fieldset/Fieldset.js
+++ b/packages/es-components/src/components/containers/fieldset/Fieldset.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import classnames from 'classnames';
 
+import generateAlphaName from '../../util/generateAlphaName';
+
 const Legend = styled.legend`
   border: 0;
   border-bottom: 1px solid ${props => props.theme.colors.gray6};
@@ -15,11 +17,12 @@ const Legend = styled.legend`
   width: 100%;
 `;
 
-const FieldsetLegend = ({ legendClasses, legendId, children }) =>
+const FieldsetLegend = ({ legendClasses, legendId, children, ...otherProps }) =>
   children ? (
     <Legend
       className={classnames('es-fieldset__legend', legendClasses)}
       id={legendId}
+      {...otherProps}
     >
       {children}
     </Legend>
@@ -51,9 +54,15 @@ function Fieldset({
   className
 }) {
   const fieldsetClasses = classnames('es-fieldset', className);
+  const legId = legendId || `${generateAlphaName()}-legend`;
+
   return (
-    <StyledFieldset className={fieldsetClasses}>
-      <FieldsetLegend {...{ legendClasses, legendId }}>
+    <StyledFieldset className={fieldsetClasses} aria-labelledby={legId}>
+      <FieldsetLegend
+        aria-hidden
+        legendId={legId}
+        legendClasses={legendClasses}
+      >
         {legendContent}
       </FieldsetLegend>
       {children}

--- a/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
@@ -78,6 +78,7 @@ export function RadioButton({
   inline,
   validationState,
   theme,
+  descriptorIds,
   ...radioProps
 }) {
   const { hover, fill } = getRadioFillVariables(
@@ -87,6 +88,7 @@ export function RadioButton({
     theme.colors
   );
   const radioDisplayFill = radioProps.checked ? fill : theme.colors.white;
+  const radioId = radioProps.id;
 
   const labelProps = {
     inline,
@@ -96,6 +98,7 @@ export function RadioButton({
     validationState
   };
   const classNameState = `es-radio__input--${validationState}`;
+  const spanId = `${radioId}-text`;
 
   return (
     <RadioLabel className="es-radio" {...labelProps}>
@@ -103,6 +106,7 @@ export function RadioButton({
         type="radio"
         name={name}
         className={classNameState}
+        aria-labelledBy={`${descriptorIds} ${spanId}`.trim()}
         {...radioProps}
       />
       <RadioDisplay
@@ -110,7 +114,9 @@ export function RadioButton({
         borderColor={fill}
         fill={radioDisplayFill}
       />
-      {optionText}
+      <span aria-hidden id={spanId}>
+        {optionText}
+      </span>
     </RadioLabel>
   );
 }
@@ -121,6 +127,8 @@ RadioButton.propTypes = {
   inline: PropTypes.bool,
   /** Display radio button with contextual state colorings */
   validationState: PropTypes.oneOf(['default', 'success', 'warning', 'danger']),
+  /** Extra descriptor IDs for aria-labelledby */
+  descriptorIds: PropTypes.string,
   /**
    * Theme object used by the ThemeProvider,
    * automatically passed by any parent component using a ThemeProvider
@@ -130,7 +138,8 @@ RadioButton.propTypes = {
 
 RadioButton.defaultProps = {
   inline: true,
-  validationState: 'default'
+  validationState: 'default',
+  descriptorIds: ''
 };
 
 export default withTheme(RadioButton);

--- a/packages/es-components/src/components/controls/radio-buttons/RadioGroup.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioGroup.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { noop } from 'lodash';
 import styled from 'styled-components';
+import generateAlphaName from '../../util/generateAlphaName';
 
 import Fieldset from '../../containers/fieldset/Fieldset';
 
@@ -39,6 +40,8 @@ function RadioGroup({
   ...other
 }) {
   const helpId = additionalHelpContent ? `${name}-help` : undefined;
+  const idHash = generateAlphaName();
+  const legendId = `radio-legend-${idHash}`;
   const additionalHelp = additionalHelpContent && (
     <AdditionalHelpContent
       id={helpId}
@@ -49,7 +52,7 @@ function RadioGroup({
     </AdditionalHelpContent>
   );
   return (
-    <RadioFieldset legendContent={legendContent}>
+    <RadioFieldset {...{ legendContent, legendId }}>
       {introContent}
       {radioOptions.map((config, index) => {
         const radioId = `${name}-option-${index + 1}`;

--- a/packages/es-components/src/components/controls/radio-buttons/RadioGroup.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioGroup.js
@@ -51,11 +51,12 @@ function RadioGroup({
       {additionalHelpContent}
     </AdditionalHelpContent>
   );
+
   return (
     <RadioFieldset {...{ legendContent, legendId }}>
       {introContent}
       {radioOptions.map((config, index) => {
-        const radioId = `${name}-option-${index + 1}`;
+        const radioId = `${name}-option-${index + 1}-${idHash}`;
         const checked = config.optionValue === value;
         const disabled = disableAllOptions || config.disabled;
         const radioProps = {
@@ -68,6 +69,7 @@ function RadioGroup({
           id: radioId,
           optionText: config.optionText,
           value: config.optionValue,
+          descriptorIds: legendId,
           ...other
         };
         return <RadioButton key={radioId} {...radioProps} />;


### PR DESCRIPTION
When using JAWS and Voice Over in the `es-components` style guide, reading of `RadioGroups` was clear and understandable using both arrow keys and tabbing through as with a form. When integrated into a site, Radio Groups would act unpredictably.

These changes bring clarity and predictability to what JAWS will do with these components. Checked with both JAWS and Voice Over.

_Note: If there is a better way to get consistent, clear results, I would *love* to use it. This is the only way I've landed on for the desired outcome._