### PR TITLE
Preventing browsers from adding custom styling to textboxes

### DIFF
--- a/packages/es-components/src/components/controls/textbox/Textbox.js
+++ b/packages/es-components/src/components/controls/textbox/Textbox.js
@@ -57,6 +57,7 @@ const CommonInputStyles = css`
   display: table-cell;
   line-height: ${props => props.theme.sizes.baseLineHeight};
   padding-right: 2em;
+  -webkit-appearance: none;
 `;
 /* eslint-enable */
 

--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.js
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.js
@@ -96,6 +96,7 @@ export const DatePicker = props => {
     <NativeDatePicker
       selectedDate={selectedDate}
       onChange={onChange}
+      onBlur={onBlur}
       name={name}
       {...textboxProps}
     />


### PR DESCRIPTION
There was an issue in IOS browsers where they would apply custom styling that caused icons and text inputs to be different heights.
<img width="343" alt="bad_ios_styling" src="https://user-images.githubusercontent.com/6923910/52349797-86a8c300-29e4-11e9-847b-701a069a09d3.PNG">

By adding `-webkit-appearance: none;` we tell the browser not to apply styling based on the operating system's theme ([MDN page with more info](https://developer.mozilla.org/en-US/docs/Web/CSS/appearance)).
<img width="343" alt="fixed_ios_styling" src="https://user-images.githubusercontent.com/6923910/52350590-21ee6800-29e6-11e9-8c3b-f26c2f318f97.PNG">

While I was making changes I also updated the native datepicker a little. Although I don't think it's an actual issue at the moment, I figured `onBlur` might be an event we want to handle in the future. The change is in a separate commit, so it'll be very easy for me to remove if there is strong opposition against it.