### PR TITLE
Update: accounting for partial string dates in DatePicker

### DIFF
--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.js
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.js
@@ -41,16 +41,8 @@ const getVerifiedDate = selectedDate => {
   return verifiedDate;
 };
 
-const NativeDatePicker = ({
-  selectedDate,
-  name,
-  onChange,
-  onChangeRaw,
-  ...props
-}) => {
+const NativeDatePicker = ({ selectedDate, name, onChange, ...props }) => {
   const onChangeIntercept = event => onChange(moment(event.target.value));
-  const onChangeRawIntercept = event =>
-    (onChangeRaw || noop)(moment(event.target.value));
   const verifiedDate = getVerifiedDate(selectedDate);
   const dateValue =
     !!verifiedDate && verifiedDate.isValid()
@@ -65,7 +57,6 @@ const NativeDatePicker = ({
       value={dateValue}
       {...props}
       onChange={onChangeIntercept}
-      onChangeRaw={onChangeRawIntercept}
     />
   );
 };

--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.js
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.js
@@ -30,26 +30,7 @@ class DateTextbox extends React.Component {
   }
 }
 
-const NativeDatePicker = props => {
-  const onChangeIntercept = event => props.onChange(moment(event.target.value));
-  const dateValue =
-    !!props.selectedDate && props.selectedDate.isValid()
-      ? props.selectedDate.format('YYYY-MM-DD')
-      : '';
-
-  return (
-    <DateTextbox
-      name={props.name}
-      prependIconName="calendar"
-      type="date"
-      value={dateValue}
-      {...props}
-      onChange={onChangeIntercept}
-    />
-  );
-};
-
-const ReactDatePickerWrapper = ({ selectedDate, children, ...props }) => {
+const getVerifiedDate = selectedDate => {
   let verifiedDate = selectedDate;
   if (typeof selectedDate === 'string') {
     const newDateMoment = moment(selectedDate, 'L');
@@ -57,7 +38,40 @@ const ReactDatePickerWrapper = ({ selectedDate, children, ...props }) => {
       selectedDate && newDateMoment.format('L') === selectedDate;
     verifiedDate = isFullDate ? newDateMoment : undefined;
   }
+  return verifiedDate;
+};
 
+const NativeDatePicker = ({
+  selectedDate,
+  name,
+  onChange,
+  onChangeRaw,
+  ...props
+}) => {
+  const onChangeIntercept = event => onChange(moment(event.target.value));
+  const onChangeRawIntercept = event =>
+    (onChangeRaw || noop)(moment(event.target.value));
+  const verifiedDate = getVerifiedDate(selectedDate);
+  const dateValue =
+    !!verifiedDate && verifiedDate.isValid()
+      ? verifiedDate.format('YYYY-MM-DD')
+      : '';
+
+  return (
+    <DateTextbox
+      name={name}
+      prependIconName="calendar"
+      type="date"
+      value={dateValue}
+      {...props}
+      onChange={onChangeIntercept}
+      onChangeRaw={onChangeRawIntercept}
+    />
+  );
+};
+
+const ReactDatePickerWrapper = ({ selectedDate, children, ...props }) => {
+  const verifiedDate = getVerifiedDate(selectedDate);
   return (
     <ReactDatePicker selected={verifiedDate} {...props}>
       {children}

--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.js
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.js
@@ -10,7 +10,7 @@ import datepickerStyles from './datePickerStyles';
 import withWindowSize from '../../util/withWindowSize';
 import Textbox from '../../controls/textbox/Textbox';
 
-const DatePickerWrapper = styled.div`
+const DatePickerBlockContainer = styled.div`
   display: inline-block;
 `;
 
@@ -41,12 +41,11 @@ const getVerifiedDate = selectedDate => {
   return verifiedDate;
 };
 
-const NativeDatePicker = ({ selectedDate, name, onChange, ...props }) => {
+function NativeDatePicker({ selectedDate, name, onChange, ...props }) {
   const onChangeIntercept = event => onChange(moment(event.target.value));
-  const verifiedDate = getVerifiedDate(selectedDate);
   const dateValue =
-    !!verifiedDate && verifiedDate.isValid()
-      ? verifiedDate.format('YYYY-MM-DD')
+    !!selectedDate && selectedDate.isValid()
+      ? selectedDate.format('YYYY-MM-DD')
       : '';
 
   return (
@@ -59,18 +58,9 @@ const NativeDatePicker = ({ selectedDate, name, onChange, ...props }) => {
       onChange={onChangeIntercept}
     />
   );
-};
+}
 
-const ReactDatePickerWrapper = ({ selectedDate, children, ...props }) => {
-  const verifiedDate = getVerifiedDate(selectedDate);
-  return (
-    <ReactDatePicker selected={verifiedDate} {...props}>
-      {children}
-    </ReactDatePicker>
-  );
-};
-
-export const DatePicker = props => {
+export function DatePicker(props) {
   /* eslint-disable no-unused-vars */
   const {
     children,
@@ -103,6 +93,7 @@ export const DatePicker = props => {
     ${dpStyles}
   `;
   /* eslint-enable */
+  const verifiedDate = getVerifiedDate(selectedDate);
 
   const textbox = (
     <DateTextbox
@@ -115,7 +106,7 @@ export const DatePicker = props => {
 
   const mobileDatePicker = (
     <NativeDatePicker
-      selectedDate={selectedDate}
+      selectedDate={verifiedDate}
       onChange={onChange}
       onBlur={onBlur}
       name={name}
@@ -124,16 +115,16 @@ export const DatePicker = props => {
   );
 
   const nonMobileDatePicker = (
-    <ReactDatePickerWrapper
+    <ReactDatePicker
       customInput={textbox}
       onChange={onChange}
       onBlur={onBlur}
       placeholderText={placeholder}
-      selectedDate={selectedDate}
+      selected={verifiedDate}
       {...datepickerProps}
     >
       {children}
-    </ReactDatePickerWrapper>
+    </ReactDatePicker>
   );
 
   const phoneWidth = parseInt(props.theme.screenSize.phone, 10) || 0;
@@ -142,8 +133,8 @@ export const DatePicker = props => {
       ? mobileDatePicker
       : nonMobileDatePicker;
 
-  return <DatePickerWrapper>{datePicker}</DatePickerWrapper>;
-};
+  return <DatePickerBlockContainer>{datePicker}</DatePickerBlockContainer>;
+}
 
 DatePicker.propTypes = {
   /** Additional text displayed below the input */

--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.js
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.js
@@ -49,6 +49,22 @@ const NativeDatePicker = props => {
   );
 };
 
+const ReactDatePickerWrapper = ({ selectedDate, children, ...props }) => {
+  let verifiedDate = selectedDate;
+  if (typeof selectedDate === 'string') {
+    const newDateMoment = moment(selectedDate, 'L');
+    const isFullDate =
+      selectedDate && newDateMoment.format('L') === selectedDate;
+    verifiedDate = isFullDate ? newDateMoment : undefined;
+  }
+
+  return (
+    <ReactDatePicker selected={verifiedDate} {...props}>
+      {children}
+    </ReactDatePicker>
+  );
+};
+
 export const DatePicker = props => {
   /* eslint-disable no-unused-vars */
   const {
@@ -103,16 +119,16 @@ export const DatePicker = props => {
   );
 
   const nonMobileDatePicker = (
-    <ReactDatePicker
+    <ReactDatePickerWrapper
       customInput={textbox}
       onChange={onChange}
       onBlur={onBlur}
       placeholderText={placeholder}
-      selected={selectedDate}
+      selectedDate={selectedDate}
       {...datepickerProps}
     >
       {children}
-    </ReactDatePicker>
+    </ReactDatePickerWrapper>
   );
 
   const phoneWidth = parseInt(props.theme.screenSize.phone, 10) || 0;
@@ -142,7 +158,7 @@ DatePicker.propTypes = {
   /** input field placeholder */
   placeholder: PropTypes.string,
   /** Moment object representing the selected date */
-  selectedDate: PropTypes.object,
+  selectedDate: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   /** Array of moment objects to exclude from the calendar */
   excludeDates: PropTypes.array,
   /** Array of moment objects to highlight on the calendar */

--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.specs.js
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.specs.js
@@ -70,3 +70,15 @@ it('renders the custom date input when the screen is bigger than phone sized', (
   const datePickerElement = getByLabelText('Big screen DatePicker');
   expect(datePickerElement.getAttribute('type')).toBe('text');
 });
+
+it('renders the date picker naturally when given a partial date in selectedDate', () => {
+  expect(() =>
+    renderWithTheme(
+      <DatePicker
+        labelText="Partial Date DatePicker"
+        selectedDate="04/04"
+        onChange={jest.fn()}
+      />
+    )
+  ).not.toThrow();
+});


### PR DESCRIPTION
Previously, when a partial date was passed in the `selectedDate` prop, the `DatePicker` component would error out. This will gracefully handle partial dates if they're passed in.