### PR TITLE
NEXT: Mobile block button

### DIFF
--- a/packages/es-components/src/components/controls/buttons/Button.js
+++ b/packages/es-components/src/components/controls/buttons/Button.js
@@ -9,9 +9,14 @@ const StyledButton = styled.button`
   background: none;
   border: none;
   box-sizing: border-box;
-  display: ${props => (props.block ? 'block' : 'inline-block')};
+  display: block;
   padding: 0;
-  width: ${props => (props.block ? '100%' : 'initial')};
+  width: 100%;
+
+  @media (min-width: ${props => props.theme.screenSize.tablet}) {
+    display: ${props => (props.block ? 'block' : 'inline-block')};
+    width: ${props => (props.block ? '100%' : 'initial')};
+  }
 
   .es-button--display {
     background-color: ${props => props.variant.bgColor};
@@ -20,7 +25,6 @@ const StyledButton = styled.button`
     border-radius: ${props => props.buttonSize.borderRadius};
     color: ${props => props.variant.textColor};
     cursor: pointer;
-    display: ${props => (props.block ? 'block' : 'inline-block')};
     font-family: inherit;
     font-size: ${props => props.buttonSize.fontSize};
     font-weight: ${props => props.buttonSize.fontWeight || 'normal'};

--- a/packages/es-components/src/components/controls/buttons/Button.md
+++ b/packages/es-components/src/components/controls/buttons/Button.md
@@ -4,24 +4,23 @@ Additional props supplied to the Button component will be passed to the underlyi
 
 ```
 const buttonStyle = {
-  display: 'inline-block',
   margin: '10px 15px 0 0'
 };
 
 <div>
-  <div style={buttonStyle}><Button>Default</Button></div>
+  <Button style={buttonStyle}>Default</Button>
 
-  <div style={buttonStyle}><Button styleType="darkDefault">Dark Default</Button></div>
+  <Button styleType="darkDefault" style={buttonStyle}>Dark Default</Button>
 
-  <div style={buttonStyle}><Button styleType="primary">Primary</Button></div>
+  <Button styleType="primary" style={buttonStyle}>Primary</Button>
 
-  <div style={buttonStyle}><Button styleType="success">Success</Button></div>
+  <Button styleType="success" style={buttonStyle}>Success</Button>
 
-  <div style={buttonStyle}><Button styleType="info">Information</Button></div>
+  <Button styleType="info" style={buttonStyle}>Information</Button>
 
-  <div style={buttonStyle}><Button styleType="warning">Warning</Button></div>
+  <Button styleType="warning" style={buttonStyle}>Warning</Button>
 
-  <div style={buttonStyle}><Button styleType="danger">Danger</Button></div>
+  <Button styleType="danger" style={buttonStyle}>Danger</Button>
 </div>
 ```
 
@@ -65,7 +64,7 @@ const buttonStyle = {
 </div>
 ```
 
-Setting the `block` property will force the button to expand to the width of it's parent container.
+Setting the `block` property will force the button to expand to the width of it's parent container. Buttons will default to `block` at the mobile breakpoint.
 
 ```
 const buttonContainerStyle = {
@@ -89,18 +88,18 @@ const buttonStyle = {
 };
 
 <div>
-  <div style={buttonStyle}><Button disabled>Default</Button></div>
+  <Button disabled style={buttonStyle}>Default</Button>
 
-  <div style={buttonStyle}><Button styleType="primary" disabled>Primary</Button></div>
+  <Button styleType="primary" disabled style={buttonStyle}>Primary</Button>
 
-  <div style={buttonStyle}><Button isOutline styleType="success" disabled>Success</Button></div>
+  <Button isOutline styleType="success" disabled style={buttonStyle}>Success</Button>
 
-  <div style={buttonStyle}><Button styleType="info" disabled>Information</Button></div>
+  <Button styleType="info" disabled style={buttonStyle}>Information</Button>
 
-  <div style={buttonStyle}><Button styleType="warning" disabled>Warning</Button></div>
+  <Button styleType="warning" disabled style={buttonStyle}>Warning</Button>
 
-  <div style={buttonStyle}><Button styleType="danger" disabled>Danger</Button></div>
+  <Button styleType="danger" disabled style={buttonStyle}>Danger</Button>
 
-  <div style={buttonStyle}><Button styleType="primary" isLinkButton disabled>Link</Button></div>
+  <Button styleType="primary" isLinkButton disabled style={buttonStyle}>Link</Button>
 </div>
 ```

--- a/packages/es-components/src/components/controls/buttons/OutlineButton.js
+++ b/packages/es-components/src/components/controls/buttons/OutlineButton.js
@@ -12,7 +12,7 @@ const StyledButton = styled.button`
   box-sizing: border-box;
   color: ${props => props.variant.textColor};
   cursor: pointer;
-  display: ${props => (props.block ? 'block' : 'inline-block')};
+  display: block;
   font-family: inherit;
   font-size: ${props => props.buttonSize.fontSize};
   font-weight: ${props => props.buttonSize.fontWeight || 'normal'};
@@ -28,7 +28,12 @@ const StyledButton = styled.button`
   transition: background-color 250ms linear, color 250ms linear;
   vertical-align: middle;
   white-space: nowrap;
-  width: ${props => (props.block ? '100%' : 'initial')};
+  width: 100%;
+
+  @media (min-width: ${props => props.theme.screenSize.tablet}) {
+    display: ${props => (props.block ? 'block' : 'inline-block')};
+    width: ${props => (props.block ? '100%' : 'initial')};
+  }
 
   &:hover {
     background-color: ${props => props.variant.hoverBgColor};

--- a/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
@@ -35,7 +35,7 @@ const RadioLabel = styled(Label)`
   text-transform: none;
 
   &:hover .es-radio__fill:before {
-    ${props => radioFill(props.hoverFillColor)};
+    ${props => !props.checked && radioFill(props.hoverFillColor)};
   }
 
   @media (min-width: ${props => props.theme.screenSize.phone}) {
@@ -88,7 +88,8 @@ export function RadioButton({ name, children, ...radioProps }) {
     disabled: radioProps.disabled,
     htmlFor: id,
     hoverFillColor: hover,
-    validationState
+    validationState,
+    checked: radioProps.checked
   };
   const classNameState = `es-radio__input--${validationState}`;
 

--- a/packages/es-components/src/components/controls/textbox/Textbox.specs.js
+++ b/packages/es-components/src/components/controls/textbox/Textbox.specs.js
@@ -12,7 +12,7 @@ beforeEach(cleanup);
 
 const buildTextbox = props => (
   <Control>
-    <Label for="test">Text</Label>
+    <Label htmlFor="test">Text</Label>
     <Textbox id="test" {...props} />
   </Control>
 );
@@ -47,7 +47,9 @@ it('renders addons when provided', () => {
 
   expect(getNumberOfIcons({ prependIconName: 'prepend' })).toBe(1);
   expect(getNumberOfIcons({ appendIconName: 'append' })).toBe(1);
-  expect(getNumberOfIcons({ prependIconName: 'prepend', appendIconName: 'append' })).toBe(2);
+  expect(
+    getNumberOfIcons({ prependIconName: 'prepend', appendIconName: 'append' })
+  ).toBe(2);
 });
 
 it('applies mask to changed value', () => {
@@ -56,9 +58,11 @@ it('applies mask to changed value', () => {
   };
   const { getByLabelText } = renderWithTheme(buildTextbox(props));
 
-  fireEvent.change(getByLabelText('Text'), { target: {
-    value: '123452323'
-  }});
+  fireEvent.change(getByLabelText('Text'), {
+    target: {
+      value: '123452323'
+    }
+  });
 
   expect(getByLabelText('Text').value).toBe('123-45-2323');
 });
@@ -69,9 +73,13 @@ it('updates mask properly', () => {
   };
   const { getByLabelText } = renderWithTheme(buildTextbox(props));
 
-  fireEvent.change(getByLabelText('Text'), { target: {
-    value: '8'
-  }});
+  fireEvent.change(getByLabelText('Text'), {
+    target: {
+      value: '8'
+    }
+  });
 
-  expect(getByLabelText('Text').value).toBe('8\u2000\u2000-\u2000\u2000-\u2000\u2000\u2000\u2000')
+  expect(getByLabelText('Text').value).toBe(
+    '8\u2000\u2000-\u2000\u2000-\u2000\u2000\u2000\u2000'
+  );
 });


### PR DESCRIPTION
Changed Button and Outline button components to default to `block` at the mobile breakpoint.

Also made a slight tweak to RadioButton so hovering over a checked radio doesn't lighten it.