### PR TITLE
Fix: reset for sub and sup tags

### DIFF
--- a/packages/es-components/src/components/util/StyleReset.js
+++ b/packages/es-components/src/components/util/StyleReset.js
@@ -19,6 +19,14 @@ const StyleReset = createGlobalStyle`
     vertical-align: baseline;
   }
 
+  sub {
+    vertical-align: sub;
+  }
+
+  sup {
+    vertical-align: super;
+  }
+
   input, button {
     font: inherit;
   }


### PR DESCRIPTION
`<sup>` and `<sub>` tags were getting the `vertical-align: baseline;` treatment when there defaults should be `super` and `sub` respectively.