### PR TITLE
Mask & Datepicker fix

### DIFF
--- a/packages/es-components/src/components/controls/textbox/MaskedTextbox.js
+++ b/packages/es-components/src/components/controls/textbox/MaskedTextbox.js
@@ -1,19 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { omit, noop } from 'lodash';
 import MaskedInput from 'react-text-mask';
 
 import Icon from '../../base/icons/Icon';
-import InputBase from './InputText';
 import inputMaskType from './inputMaskType';
+import {
+  ValidationIconWrapper,
+  ValidationIcon,
+  Prepend,
+  Append,
+  InputWrapper,
+  TextboxBase
+} from './TextAddons';
 import { useTheme } from '../../util/useTheme';
 import ValidationContext from '../ValidationContext';
 
-const defaultBorderRadius = '2px';
-
 // apply styles to masked input, but remove props it doesn't use
-const StyledMaskInput = styled(props => (
+const StyledMask = styled(props => (
   <MaskedInput
     {...omit(props, [
       'borderColor',
@@ -25,74 +30,7 @@ const StyledMaskInput = styled(props => (
       'initialValue'
     ])}
   />
-))`
-  border-bottom-left-radius: ${props =>
-    props.hasPrepend ? '0' : defaultBorderRadius};
-  border-bottom-right-radius: ${props =>
-    props.hasAppend ? '0' : defaultBorderRadius};
-  border-top-left-radius: ${props =>
-    props.hasPrepend ? '0' : defaultBorderRadius};
-  border-top-right-radius: ${props =>
-    props.hasAppend ? '0' : defaultBorderRadius};
-  box-sizing: border-box;
-  color: inherit;
-  display: table-cell;
-  line-height: ${props => props.theme.sizes.baseLineHeight};
-  padding-right: 2em;
-  -webkit-appearance: none;
-`;
-
-const StyledMask = props => <InputBase as={StyledMaskInput} {...props} />;
-
-const ValidationIconWrapper = styled.span`
-  height: 0;
-  position: relative;
-  width: 0;
-`;
-
-const ValidationIcon = styled(Icon)`
-  height: 20px;
-  pointer-events: none;
-  position: absolute;
-  right: 11px;
-  top: 10px;
-`;
-
-const AddOn = css`
-  background-color: ${props => props.addOnBgColor};
-  border: 1px solid
-    ${props =>
-      props.addOnBgColor === props.theme.colors.gray3
-        ? props.theme.colors.gray5
-        : props.addOnBgColor};
-  border-radius: ${defaultBorderRadius};
-  box-sizing: border-box;
-  color: ${props => props.addOnTextColor};
-  display: table-cell;
-  height: 39px;
-  line-height: 1.2;
-  padding: 6px 11px;
-  i {
-    line-height: 1;
-    vertical-align: middle;
-  }
-`;
-
-const Prepend = styled.span`
-  ${AddOn} border-bottom-right-radius: 0;
-  border-right: none;
-  border-top-right-radius: 0;
-`;
-
-const Append = styled.span`
-  ${AddOn} border-bottom-left-radius: 0;
-  border-left: none;
-  border-top-left-radius: 0;
-`;
-
-const InputWrapper = styled.div`
-  display: flex;
-`;
+))``;
 
 function MaskedTextbox(props) {
   const {
@@ -135,7 +73,8 @@ function MaskedTextbox(props) {
           <Icon aria-hidden="true" name={prependIconName} size={18} />
         </Prepend>
       )}
-      <StyledMask
+      <TextboxBase
+        as={StyledMask}
         hasAppend={hasAppend}
         hasPrepend={hasPrepend}
         type="text"
@@ -184,7 +123,7 @@ MaskedTextbox.propTypes = {
     pipe: PropTypes.func,
     showMask: PropTypes.bool
   }),
-  /** Callback function to get inner mask input ref */
+  /** Callback function to get inner mask ref */
   inputRef: PropTypes.func
 };
 

--- a/packages/es-components/src/components/controls/textbox/MaskedTextbox.js
+++ b/packages/es-components/src/components/controls/textbox/MaskedTextbox.js
@@ -1,34 +1,181 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled, { css } from 'styled-components';
+import { omit, noop } from 'lodash';
 import MaskedInput from 'react-text-mask';
 
+import Icon from '../../base/icons/Icon';
+import InputBase from './InputText';
 import inputMaskType from './inputMaskType';
-import Textbox from './Textbox';
+import { useTheme } from '../../util/useTheme';
+import ValidationContext from '../ValidationContext';
 
-function MaskedTextbox({ maskType, customMask, ...rest }) {
+const defaultBorderRadius = '2px';
+
+// apply styles to masked input, but remove props it doesn't use
+const StyledMaskInput = styled(props => (
+  <MaskedInput
+    {...omit(props, [
+      'borderColor',
+      'boxShadow',
+      'focusBorderColor',
+      'focusBoxShadow',
+      'hasAppend',
+      'hasPrepend',
+      'initialValue'
+    ])}
+  />
+))`
+  border-bottom-left-radius: ${props =>
+    props.hasPrepend ? '0' : defaultBorderRadius};
+  border-bottom-right-radius: ${props =>
+    props.hasAppend ? '0' : defaultBorderRadius};
+  border-top-left-radius: ${props =>
+    props.hasPrepend ? '0' : defaultBorderRadius};
+  border-top-right-radius: ${props =>
+    props.hasAppend ? '0' : defaultBorderRadius};
+  box-sizing: border-box;
+  color: inherit;
+  display: table-cell;
+  line-height: ${props => props.theme.sizes.baseLineHeight};
+  padding-right: 2em;
+  -webkit-appearance: none;
+`;
+
+const StyledMask = props => <InputBase as={StyledMaskInput} {...props} />;
+
+const ValidationIconWrapper = styled.span`
+  height: 0;
+  position: relative;
+  width: 0;
+`;
+
+const ValidationIcon = styled(Icon)`
+  height: 20px;
+  pointer-events: none;
+  position: absolute;
+  right: 11px;
+  top: 10px;
+`;
+
+const AddOn = css`
+  background-color: ${props => props.addOnBgColor};
+  border: 1px solid
+    ${props =>
+      props.addOnBgColor === props.theme.colors.gray3
+        ? props.theme.colors.gray5
+        : props.addOnBgColor};
+  border-radius: ${defaultBorderRadius};
+  box-sizing: border-box;
+  color: ${props => props.addOnTextColor};
+  display: table-cell;
+  height: 39px;
+  line-height: 1.2;
+  padding: 6px 11px;
+  i {
+    line-height: 1;
+    vertical-align: middle;
+  }
+`;
+
+const Prepend = styled.span`
+  ${AddOn} border-bottom-right-radius: 0;
+  border-right: none;
+  border-top-right-radius: 0;
+`;
+
+const Append = styled.span`
+  ${AddOn} border-bottom-left-radius: 0;
+  border-left: none;
+  border-top-left-radius: 0;
+`;
+
+const InputWrapper = styled.div`
+  display: flex;
+`;
+
+function MaskedTextbox(props) {
+  const {
+    prependIconName,
+    appendIconName,
+    maskType,
+    customMask,
+    inputRef,
+    ...additionalTextProps
+  } = props;
+  const theme = useTheme();
+
+  const validationState = React.useContext(ValidationContext);
+
+  const hasPrepend = !!prependIconName;
+  const hasAppend = !!appendIconName;
+  const hasValidationIcon = validationState !== 'default';
   const maskArgs =
     maskType === 'custom' && customMask ? customMask : inputMaskType[maskType];
 
+  maskArgs.render = (maskRef, maskProps) => {
+    const setRef = inputElement => {
+      maskRef(inputElement);
+      inputRef(inputElement);
+    };
+    return <input ref={setRef} {...maskProps} />;
+  };
+
+  const addOnTextColor = hasValidationIcon
+    ? theme.colors.white
+    : theme.colors.gray8;
+  const addOnBgColor = hasValidationIcon
+    ? theme.validationTextColor[validationState]
+    : theme.colors.gray3;
+
   return (
-    <MaskedInput
-      {...maskArgs}
-      render={(ref, props) => <Textbox ref={ref} {...props} {...rest} />}
-    />
+    <InputWrapper>
+      {hasPrepend && (
+        <Prepend addOnTextColor={addOnTextColor} addOnBgColor={addOnBgColor}>
+          <Icon aria-hidden="true" name={prependIconName} size={18} />
+        </Prepend>
+      )}
+      <StyledMask
+        hasAppend={hasAppend}
+        hasPrepend={hasPrepend}
+        type="text"
+        {...maskArgs}
+        {...additionalTextProps}
+        {...theme.validationInputColor[validationState]}
+      />
+      {hasValidationIcon && (
+        <ValidationIconWrapper>
+          <ValidationIcon
+            aria-hidden="true"
+            name={theme.validationIconName[validationState]}
+            size={18}
+          />
+        </ValidationIconWrapper>
+      )}
+      {hasAppend && (
+        <Append addOnTextColor={addOnTextColor} addOnBgColor={addOnBgColor}>
+          <Icon aria-hidden="true" name={appendIconName} size={18} />
+        </Append>
+      )}
+    </InputWrapper>
   );
 }
 
 MaskedTextbox.propTypes = {
-  /** Sets a pre-configured mask type */
+  /** Content to prepend input box with */
+  prependIconName: PropTypes.string,
+  /** Content to append to input box */
+  appendIconName: PropTypes.string,
+  /** Sets a mask type on the input */
   maskType: PropTypes.oneOf([
-    'none',
     'date',
     'dollar',
     'phone',
     'ssnum',
     'zip',
     'custom'
-  ]),
-  /** Provide a custom mask object */
+  ]).isRequired,
+  /** Provide a custom mask */
   customMask: PropTypes.shape({
     mask: PropTypes.oneOfType([PropTypes.array, PropTypes.func]).isRequired,
     guide: PropTypes.bool,
@@ -36,12 +183,16 @@ MaskedTextbox.propTypes = {
     keepCharPositions: PropTypes.bool,
     pipe: PropTypes.func,
     showMask: PropTypes.bool
-  })
+  }),
+  /** Callback function to get inner mask input ref */
+  inputRef: PropTypes.func
 };
 
 MaskedTextbox.defaultProps = {
-  maskType: 'none',
-  customMask: undefined
+  prependIconName: undefined,
+  appendIconName: undefined,
+  customMask: undefined,
+  inputRef: noop
 };
 
 export default MaskedTextbox;

--- a/packages/es-components/src/components/controls/textbox/MaskedTextbox.md
+++ b/packages/es-components/src/components/controls/textbox/MaskedTextbox.md
@@ -35,6 +35,34 @@ const Control = require('../Control').default;
 </>
 ```
 
+```
+const Control = require('../Control').default
+
+function MaskExample() {
+  const [value, setValue] = React.useState('')
+
+  function handleOnTextChange(event) {
+    console.log(event.target.value)
+    setValue(event.target.value)
+  }
+
+  return (
+    <Control>
+      <Label htmlFor="controlled-example">Controlled Example</Label>
+      <MaskedTextbox
+        id="controlled-example"
+        maskType="ssnum"
+        value={value}
+        onChange={handleOnTextChange}
+        appendIconName="girl"
+      />
+    </Control>
+  )
+};
+
+<MaskExample />
+```
+
 ### Custom masks
 
 Create your own text mask using the structure documented [here](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#text-mask-documentation).

--- a/packages/es-components/src/components/controls/textbox/TextAddons.js
+++ b/packages/es-components/src/components/controls/textbox/TextAddons.js
@@ -1,0 +1,82 @@
+import styled, { css } from 'styled-components';
+import Icon from '../../base/icons/Icon';
+import InputBase from './InputText';
+
+const defaultBorderRadius = '2px';
+
+const TextboxBase = styled(InputBase)`
+  border-bottom-left-radius: ${props =>
+    props.hasPrepend ? '0' : defaultBorderRadius};
+  border-bottom-right-radius: ${props =>
+    props.hasAppend ? '0' : defaultBorderRadius};
+  border-top-left-radius: ${props =>
+    props.hasPrepend ? '0' : defaultBorderRadius};
+  border-top-right-radius: ${props =>
+    props.hasAppend ? '0' : defaultBorderRadius};
+  box-sizing: border-box;
+  color: inherit;
+  display: table-cell;
+  line-height: ${props => props.theme.sizes.baseLineHeight};
+  padding-right: 2em;
+  -webkit-appearance: none;
+`;
+
+const ValidationIconWrapper = styled.span`
+  height: 0;
+  position: relative;
+  width: 0;
+`;
+
+const ValidationIcon = styled(Icon)`
+  height: 20px;
+  pointer-events: none;
+  position: absolute;
+  right: 11px;
+  top: 10px;
+`;
+
+const AddOn = css`
+  background-color: ${props => props.addOnBgColor};
+  border: 1px solid
+    ${props =>
+      props.addOnBgColor === props.theme.colors.gray3
+        ? props.theme.colors.gray5
+        : props.addOnBgColor};
+  border-radius: ${defaultBorderRadius};
+  box-sizing: border-box;
+  color: ${props => props.addOnTextColor};
+  display: table-cell;
+  height: 39px;
+  line-height: 1.2;
+  padding: 6px 11px;
+
+  i {
+    line-height: 1;
+    vertical-align: middle;
+  }
+`;
+
+const Prepend = styled.span`
+  ${AddOn} border-bottom-right-radius: 0;
+  border-right: none;
+  border-top-right-radius: 0;
+`;
+
+const Append = styled.span`
+  ${AddOn} border-bottom-left-radius: 0;
+  border-left: none;
+  border-top-left-radius: 0;
+`;
+
+const InputWrapper = styled.div`
+  display: flex;
+`;
+
+export {
+  ValidationIconWrapper,
+  ValidationIcon,
+  Prepend,
+  Append,
+  InputWrapper,
+  TextboxBase
+};

--- a/packages/es-components/src/components/controls/textbox/Textbox.js
+++ b/packages/es-components/src/components/controls/textbox/Textbox.js
@@ -9,7 +9,7 @@ import ValidationContext from '../ValidationContext';
 
 const defaultBorderRadius = '2px';
 
-const CommonInputStyles = css`
+const Input = styled(InputBase)`
   border-bottom-left-radius: ${props =>
     props.hasPrepend ? '0' : defaultBorderRadius};
   border-bottom-right-radius: ${props =>
@@ -24,10 +24,6 @@ const CommonInputStyles = css`
   line-height: ${props => props.theme.sizes.baseLineHeight};
   padding-right: 2em;
   -webkit-appearance: none;
-`;
-
-const Input = styled(InputBase)`
-  ${CommonInputStyles};
 `;
 
 const ValidationIconWrapper = styled.span`

--- a/packages/es-components/src/components/controls/textbox/Textbox.js
+++ b/packages/es-components/src/components/controls/textbox/Textbox.js
@@ -1,81 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled, { css } from 'styled-components';
 
 import Icon from '../../base/icons/Icon';
-import InputBase from './InputText';
+import {
+  ValidationIconWrapper,
+  ValidationIcon,
+  Prepend,
+  Append,
+  InputWrapper,
+  TextboxBase
+} from './TextAddons';
 import { useTheme } from '../../util/useTheme';
 import ValidationContext from '../ValidationContext';
-
-const defaultBorderRadius = '2px';
-
-const Input = styled(InputBase)`
-  border-bottom-left-radius: ${props =>
-    props.hasPrepend ? '0' : defaultBorderRadius};
-  border-bottom-right-radius: ${props =>
-    props.hasAppend ? '0' : defaultBorderRadius};
-  border-top-left-radius: ${props =>
-    props.hasPrepend ? '0' : defaultBorderRadius};
-  border-top-right-radius: ${props =>
-    props.hasAppend ? '0' : defaultBorderRadius};
-  box-sizing: border-box;
-  color: inherit;
-  display: table-cell;
-  line-height: ${props => props.theme.sizes.baseLineHeight};
-  padding-right: 2em;
-  -webkit-appearance: none;
-`;
-
-const ValidationIconWrapper = styled.span`
-  height: 0;
-  position: relative;
-  width: 0;
-`;
-
-const ValidationIcon = styled(Icon)`
-  height: 20px;
-  pointer-events: none;
-  position: absolute;
-  right: 11px;
-  top: 10px;
-`;
-
-const AddOn = css`
-  background-color: ${props => props.addOnBgColor};
-  border: 1px solid
-    ${props =>
-      props.addOnBgColor === props.theme.colors.gray3
-        ? props.theme.colors.gray5
-        : props.addOnBgColor};
-  border-radius: ${defaultBorderRadius};
-  box-sizing: border-box;
-  color: ${props => props.addOnTextColor};
-  display: table-cell;
-  height: 39px;
-  line-height: 1.2;
-  padding: 6px 11px;
-
-  i {
-    line-height: 1;
-    vertical-align: middle;
-  }
-`;
-
-const Prepend = styled.span`
-  ${AddOn} border-bottom-right-radius: 0;
-  border-right: none;
-  border-top-right-radius: 0;
-`;
-
-const Append = styled.span`
-  ${AddOn} border-bottom-left-radius: 0;
-  border-left: none;
-  border-top-left-radius: 0;
-`;
-
-const InputWrapper = styled.div`
-  display: flex;
-`;
 
 const Textbox = React.forwardRef((props, ref) => {
   const { prependIconName, appendIconName, ...additionalTextProps } = props;
@@ -101,10 +37,9 @@ const Textbox = React.forwardRef((props, ref) => {
           <Icon aria-hidden="true" name={prependIconName} size={18} />
         </Prepend>
       )}
-      <Input
+      <TextboxBase
         hasAppend={hasAppend}
         hasPrepend={hasPrepend}
-        type="text"
         ref={ref}
         {...additionalTextProps}
         {...theme.validationInputColor[validationState]}

--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.js
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.js
@@ -9,6 +9,7 @@ import { useWindowWidth } from '../../util/useWindowWidth';
 
 import { DatepickerStyles } from './datePickerStyles';
 import Textbox from '../../controls/textbox/Textbox';
+import MaskedTextbox from '../../controls/textbox/MaskedTextbox';
 
 const BlockContainer = styled.div`
   display: inline-block;
@@ -31,17 +32,16 @@ const getVerifiedDate = selectedDate => {
 
 // required for react-datepicker 2.0.0 to properly set focus
 class DateTextbox extends React.Component {
-  constructor() {
-    super();
-    this.inputRef = React.createRef();
-  }
+  setRef = ref => {
+    this.inputElement = ref;
+  };
 
   focus() {
-    this.inputRef.current.focus();
+    this.inputElement.focus();
   }
 
   render() {
-    return <Textbox ref={this.inputRef} {...this.props} />;
+    return <MaskedTextbox inputRef={this.setRef} {...this.props} />;
   }
 }
 
@@ -92,7 +92,12 @@ function DatePicker(props) {
   const verifiedDate = getVerifiedDate(selectedDate);
 
   const textbox = (
-    <DateTextbox name={name} prependIconName="calendar" {...textboxProps} />
+    <DateTextbox
+      maskType="date"
+      name={name}
+      prependIconName="calendar"
+      {...textboxProps}
+    />
   );
 
   const mobileDatePicker = (

--- a/packages/es-components/src/components/util/useWindowWidth.specs.js
+++ b/packages/es-components/src/components/util/useWindowWidth.specs.js
@@ -17,10 +17,8 @@ const WindowSizeComponent = () => {
 
 const triggerResize = () => {
   const resizeEvent = global.document.createEvent('Event');
-  act(() => {
-    resizeEvent.initEvent('resize', true, true);
-    global.window.dispatchEvent(resizeEvent);
-  });
+  resizeEvent.initEvent('resize', true, true);
+  global.window.dispatchEvent(resizeEvent);
 };
 
 Object.defineProperty(global.document.body, 'clientWidth', {

--- a/packages/es-components/src/components/util/useWindowWidth.specs.js
+++ b/packages/es-components/src/components/util/useWindowWidth.specs.js
@@ -17,8 +17,10 @@ const WindowSizeComponent = () => {
 
 const triggerResize = () => {
   const resizeEvent = global.document.createEvent('Event');
-  resizeEvent.initEvent('resize', true, true);
-  global.window.dispatchEvent(resizeEvent);
+  act(() => {
+    resizeEvent.initEvent('resize', true, true);
+    global.window.dispatchEvent(resizeEvent);
+  });
 };
 
 Object.defineProperty(global.document.body, 'clientWidth', {


### PR DESCRIPTION
Reverting `MaskedTextbox` to use most of the `Textbox` guts. I refactored most of the common styled elements out into a shared file, but I'm sure more clever things could be done to get these two components running in a more concise way. Right now I just want them working.

I tried various methods to get new ref usages (createRef, forwardRef, useRef) working with react-text-mask so we don't have the hacky `DateTextbox` in `DatePicker` just to get the `focus()` working, but using the old callback method is the only combination I could find that works.
