### PR TITLE
Fix: set popover buttons to display: auto

### DIFF
--- a/packages/es-components/src/components/containers/popover/Popover.js
+++ b/packages/es-components/src/components/containers/popover/Popover.js
@@ -50,6 +50,7 @@ const PopoverContent = styled.div`
 `;
 
 const PopoverCloseButton = styled(Button)`
+  display: auto;
   width: auto;
 `;
 


### PR DESCRIPTION
Popover buttons were rendering on the left in viewports less than tablet size because there is an automatic 'display: block' that aligns it to the left. Setting display to auto allows the button to be aligned to the right by inheriting the text-align: right property.

See [this codepen](https://codepen.io/jacobrios/pen/zbwmJZ) for an example of this at work.