### PR TITLE
Fix: prevent dropdownbutton auto focus on initial render

### DIFF
--- a/packages/es-components/src/components/controls/buttons/DropdownButton.js
+++ b/packages/es-components/src/components/controls/buttons/DropdownButton.js
@@ -135,6 +135,7 @@ function DropdownButton(props) {
   const [buttonValue, setButtonValue] = useState(props.buttonValue);
   const [isOpen, setIsOpen] = useState(false);
 
+  const initialRender = useRef(true);
   const buttonDropdown = useRef();
   const triggerButton = useRef();
   const panelId = useUniqueId();
@@ -154,7 +155,10 @@ function DropdownButton(props) {
 
   useEffect(
     () => {
-      triggerButton.current.focus();
+      if (!initialRender.current) {
+        triggerButton.current.focus();
+      }
+      initialRender.current = false;
     },
     [isOpen]
   );

--- a/packages/es-components/src/components/controls/buttons/DropdownButton.specs.js
+++ b/packages/es-components/src/components/controls/buttons/DropdownButton.specs.js
@@ -64,6 +64,7 @@ it('allows arrow movement and traps focus when dropdown is opened', () => {
   );
 
   const firstButton = getByText('Button').closest('button');
+  firstButton.focus();
   firstButton.click();
   expect(firstButton).toHaveFocus();
 

--- a/packages/es-components/src/components/navigation/horizontalnav/HorizontalNav.md
+++ b/packages/es-components/src/components/navigation/horizontalnav/HorizontalNav.md
@@ -1,4 +1,6 @@
-Use `HorizontalNav` to create an uncontrolled navigation menu. Each `HorizontalNav.Item` will render with the same styling. A `HorizontalNav.Item` only accepts one child component and will typically be a `a`, `button`, or client side routing `Link`-type component.```
+Use `HorizontalNav` to create an uncontrolled navigation menu. Each `HorizontalNav.Item` will render with the same styling. A `HorizontalNav.Item` only accepts one child component and will typically be a `a`, `button`, or client side routing `Link`-type component.
+
+```
 <>
   <h3>Standard</h3>
   <HorizontalNav selected="home">
@@ -43,7 +45,7 @@ Use `HorizontalNav` to create an uncontrolled navigation menu. Each `HorizontalN
 Change the `selected` prop that is passed to `HorizontalNav` to change when an item is clicked.
 
 ```
-function Link({ className, children, ...rest }) {
+function Link({ className, children, isVertical, ...rest }) {
   return <a className={className} href="#" {...rest}>{children}</a>;
 }
 

--- a/packages/es-components/src/components/navigation/sidenav/SideNav.md
+++ b/packages/es-components/src/components/navigation/sidenav/SideNav.md
@@ -45,7 +45,7 @@ Use `SideNav` to create an uncontrolled navigation menu. Each `SideNav.Item` wil
 Change the `selected` prop that is passed to `SideNav` to change when an item is clicked.
 
 ```
-function Link({ className, children, ...rest }) {
+function Link({ className, children, isVertical, ...rest }) {
   return <a className={className} href="#" {...rest}>{children}</a>;
 }
 


### PR DESCRIPTION
`DropdownButton` has an effect that sets focus on the trigger button. This was firing on the initial rendering of the component, causing the page to jump directly to it. This change just prevents that on initial render.

Also fixed a couple of warnings caused by the side/horizontal nav examples.