### PR TITLE
Update: add id as a when useUniqueId is used

### DIFF
--- a/packages/es-components/src/components/base/spinner/Spinner.js
+++ b/packages/es-components/src/components/base/spinner/Spinner.js
@@ -56,10 +56,8 @@ const SpinnerCircle = styled.circle`
 `;
 
 const Spinner = ({ title, description, ...props }) => {
-  const titleUnique = useUniqueId();
-  const descUnique = useUniqueId();
-  const titleId = title && titleUnique;
-  const descId = description && descUnique;
+  const titleId = title && `${useUniqueId(props.id)}-title`;
+  const descId = description && `${useUniqueId(props.id)}-desc`;
 
   return (
     <SpinnerSvg

--- a/packages/es-components/src/components/containers/drawer/DrawerPanel.js
+++ b/packages/es-components/src/components/containers/drawer/DrawerPanel.js
@@ -60,8 +60,8 @@ const DrawerPanel = props => {
     ...other
   } = props;
 
-  const headingAriaId = useUniqueId();
-  const regionAriaId = useUniqueId();
+  const headingAriaId = `${useUniqueId(other.id)}-heading`;
+  const regionAriaId = `${useUniqueId(other.id)}-region`;
   const aside = titleAside && <aside>{titleAside}</aside>;
 
   return (

--- a/packages/es-components/src/components/containers/modal/Modal.js
+++ b/packages/es-components/src/components/containers/modal/Modal.js
@@ -107,7 +107,7 @@ function Modal(props) {
 
   const ModalDialog = getModalBySize(size);
 
-  const ariaId = useUniqueId();
+  const ariaId = useUniqueId(other.id);
 
   return (
     <ModalContext.Provider value={{ onHide, ariaId }}>

--- a/packages/es-components/src/components/containers/tooltip/Tooltip.js
+++ b/packages/es-components/src/components/containers/tooltip/Tooltip.js
@@ -190,8 +190,7 @@ function Tooltip(props) {
   }
 
   const tooltipTarget = React.createRef();
-  const idHash = useUniqueId();
-  const descriptionId = `${idHash}-description`;
+  const descriptionId = `${useUniqueId(other.id)}-description`;
 
   return (
     <>

--- a/packages/es-components/src/components/controls/buttons/DropdownButton.js
+++ b/packages/es-components/src/components/controls/buttons/DropdownButton.js
@@ -137,7 +137,7 @@ function DropdownButton(props) {
 
   const buttonDropdown = useRef();
   const triggerButton = useRef();
-  const panelId = useUniqueId();
+  const panelId = useUniqueId(props.id);
 
   useEffect(
     () => {

--- a/packages/es-components/src/components/navigation/breadcrumb/Breadcrumb.js
+++ b/packages/es-components/src/components/navigation/breadcrumb/Breadcrumb.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import tinycolor from 'tinycolor2';
 
-import useUniqueId from '../../util/useUniqueId';
-
 function darkenPrimary(primary) {
   return tinycolor(primary)
     .darken(15)
@@ -58,11 +56,10 @@ const Crumb = styled.li`
 `;
 
 function Breadcrumb({ children, ...props }) {
-  const uniqueId = useUniqueId();
   return (
     <OrderedList {...props}>
-      {React.Children.map(children, child => (
-        <Crumb key={uniqueId}>{child}</Crumb>
+      {React.Children.map(children, (child, index) => (
+        <Crumb key={index}>{child}</Crumb>
       ))}
     </OrderedList>
   );


### PR DESCRIPTION
Downstream snapshots have a problem with fully generated unique identifiers. Use a passed in id prop if available for the unique identifier for any component that is currently using the useUniqueId hook.

This allows downstream projects to pass in a unique identifier for their tests instead of having to mock anything.

---

Remove the useUniqueId from breadcrumb and use the index from map as the key. This is safe because there is no manipulation of the list being rendered.