### PR TITLE
Update: remove default paddings

### DIFF
--- a/packages/es-components/src/components/controls/checkbox/Checkbox.js
+++ b/packages/es-components/src/components/controls/checkbox/Checkbox.js
@@ -19,9 +19,10 @@ const CheckboxLabel = styled(Label)`
   font-size: ${props => props.theme.sizes.baseFontSize};
   font-weight: bold;
   line-height: ${props => props.theme.sizes.baseLineHeight};
+  margin-bottom: 0;
   margin-left: -10px;
   min-height: 25px;
-  padding: 10px 0 10px 42px;
+  padding: 0 0 0 42px;
   position: relative;
   flex: 1 0 auto;
 
@@ -84,7 +85,6 @@ const CheckboxDisplay = styled.span`
   height: 25px;
   left: 10px;
   position: absolute;
-  top: 0.55em;
   transition: all 0.25s linear;
   width: 25px;
 

--- a/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
@@ -32,7 +32,7 @@ const RadioLabel = styled(Label)`
   margin-right: 15px;
   margin-bottom: 10px;
   position: relative;
-  padding: 10px 0 10px 10px;
+  padding: 0;
   text-transform: none;
 
   &:hover .es-radio__fill:before {


### PR DESCRIPTION
This pull request addresses an issue with how spacing looks in mobile view for check boxes and radio buttons.

Currently, the spacing between each radio button and checkbox is very large because it includes padding from the label as well as bottom margins when wrapped in a `Control`. Removing this padding in the default components reduces the spacing in between these elements.