### PR TITLE
Fix: modal header level accessibility

### DIFF
--- a/packages/es-components/src/components/containers/modal/Modal.md
+++ b/packages/es-components/src/components/containers/modal/Modal.md
@@ -1,7 +1,9 @@
 Use the `closeButton` attribute on the Modal.Header to show or hide the "X" button.
 
 For accessbility, make sure to include the attribute `aria-haspopup='dialog'` on whatever link you create to activate the modal. If you need
-an informational dialog that contains no focusable elements, use a popover or something else more appropriate.
+an informational dialog that contains no focusable elements, use a popover or something else more appropriate. Additionally, you can supply
+a level prop to the `Modal.Header` to prevent skipping heading levels. The style of the `Modal.Header` will remain the same regardless of
+the level passed in.
 
 ```
 <div>
@@ -16,7 +18,7 @@ an informational dialog that contains no focusable elements, use a popover or so
     show={state.show}
     onHide={() => setState({show: false})}
   >
-    <Modal.Header hideCloseButton={state.hideCloseButton}>This is the header.</Modal.Header>
+    <Modal.Header level={2} hideCloseButton={state.hideCloseButton}>This is the header.</Modal.Header>
     <Modal.Body>Body Content. Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch.This is the popover's content. Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid.</Modal.Body>
     <Modal.Footer>
       <span style={{ flexGrow: 1, marginRight: '10px' }}>

--- a/packages/es-components/src/components/containers/modal/ModalHeader.js
+++ b/packages/es-components/src/components/containers/modal/ModalHeader.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import DismissButton from '../../controls/DismissButton';
 import { ModalContext } from './ModalContext';
+import Heading from '../heading/Heading';
 
 // Note: ModalHeader relies on a parent (Modal) with ThemeProvider wrapping it
 const Header = styled.div`
@@ -15,7 +16,7 @@ const Header = styled.div`
   padding: 15px;
 `;
 
-const Title = styled.h4`
+const Title = styled(Heading)`
   font-size: 24px;
   font-weight: 500;
   margin: 0;
@@ -33,12 +34,14 @@ const DismissModal = styled(DismissButton)`
 `;
 
 function ModalHeader(props) {
-  const { hideCloseButton, children, ...otherProps } = props;
+  const { hideCloseButton, children, level, ...otherProps } = props;
   const { onHide, ariaId } = useContext(ModalContext);
 
   return (
     <Header {...otherProps}>
-      <Title id={ariaId}>{children}</Title>
+      <Title id={ariaId} level={level}>
+        {children}
+      </Title>
 
       {!hideCloseButton && <DismissModal onClick={onHide} />}
     </Header>
@@ -48,12 +51,14 @@ function ModalHeader(props) {
 ModalHeader.propTypes = {
   /** Specify whether the modal header should contain a close button */
   hideCloseButton: PropTypes.bool,
-  children: PropTypes.any
+  children: PropTypes.any,
+  level: PropTypes.oneOf([1, 2, 3, 4, 5, 6])
 };
 
 ModalHeader.defaultProps = {
   hideCloseButton: false,
-  children: undefined
+  children: undefined,
+  level: 4
 };
 
 ModalHeader.contextTypes = {

--- a/packages/es-components/src/components/containers/modal/__snapshots__/Modal.specs.js.snap
+++ b/packages/es-components/src/components/containers/modal/__snapshots__/Modal.specs.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders different modal sections 1`] = `
 <h4
-  class="sc-bxivhb eouofC"
+  class="sc-ifAKCX fBKnDt sc-htpNat kauQMr"
   id="abcdef"
 >
   Header
@@ -11,7 +11,7 @@ exports[`renders different modal sections 1`] = `
 
 exports[`renders different modal sections 2`] = `
 <div
-  class="sc-EHOje fLjynL"
+  class="sc-bZQynM eVbtnu"
 >
   Body
 </div>
@@ -19,7 +19,7 @@ exports[`renders different modal sections 2`] = `
 
 exports[`renders different modal sections 3`] = `
 <div
-  class="sc-bZQynM fHePjF"
+  class="sc-gzVnrw ilnIUq"
 >
   Footer
 </div>


### PR DESCRIPTION
Having the `h4` tag was creating rigidity in the heading levels that raised accessibility concerns in downstream consumers. This fix utilizes [the `Heading` component](https://github.com/WTW-IM/es-components/blob/master/packages/es-components/src/components/containers/heading/Heading.js) to allow us to set whatever heading level we want, without changing the look of the modal header.