### PR TITLE
Incrementer manual input support

### DIFF
--- a/packages/es-components/src/components/patterns/incrementer/Incrementer.js
+++ b/packages/es-components/src/components/patterns/incrementer/Incrementer.js
@@ -11,6 +11,7 @@ import screenReaderOnly from '../screenReaderOnly/screenReaderOnly';
 import { useTheme } from '../../util/useTheme';
 
 const IncrementerWrapper = styled.div`
+  align-items: flex-start;
   display: flex;
 `;
 
@@ -30,6 +31,11 @@ const IncrementerTextbox = styled(InputBase)`
   &::-ms-clear {
     display: none;
   }
+`;
+
+const IncrementerButton = styled(Button)`
+  display: inline-block;
+  width: auto;
 `;
 
 function determineIsDisabled(threshold, newValue) {
@@ -88,7 +94,8 @@ function Incrementer({
   upperThreshold,
   lowerThreshold,
   useOutlineButton,
-  onValueUpdated
+  onValueUpdated,
+  ...other
 }) {
   const theme = useTheme();
 
@@ -135,11 +142,22 @@ function Incrementer({
     }
   }
 
+  function shortcutKeys(event) {
+    if (upperThreshold && event.keyCode === 35) {
+      dispatch({ type: 'set', amount: upperThreshold });
+    }
+
+    if (lowerThreshold && event.keyCode === 36) {
+      dispatch({ type: 'set', amount: lowerThreshold });
+    }
+  }
+
   const RenderedButton = useOutlineButton ? OutlineButton : Button;
 
   return (
     <IncrementerWrapper>
-      <RenderedButton
+      <IncrementerButton
+        as={RenderedButton}
         styleType="primary"
         onClick={decrementValue}
         disabled={isDecrementDisabled}
@@ -149,18 +167,25 @@ function Incrementer({
           {decrementAmount}
         </ScreenReaderButtonText>
         <Icon name="minus" />
-      </RenderedButton>
+      </IncrementerButton>
       <IncrementerTextbox
         {...theme.validationInputColor.default}
+        {...other}
         type="number"
+        role="spinbutton"
         max={upperThreshold}
         min={lowerThreshold}
         step={incrementAmount}
         value={state.count}
+        aria-valuemin={lowerThreshold}
+        aria-valuemax={upperThreshold}
+        aria-valuenow={state.count}
+        onKeyDown={shortcutKeys}
         onChange={setValue}
         onBlur={handleOnBlur}
       />
-      <RenderedButton
+      <IncrementerButton
+        as={RenderedButton}
         styleType="primary"
         onClick={incrementValue}
         disabled={isIncrementDisabled}
@@ -170,7 +195,7 @@ function Incrementer({
           {incrementAmount}
         </ScreenReaderButtonText>
         <Icon name="add" />
-      </RenderedButton>
+      </IncrementerButton>
     </IncrementerWrapper>
   );
 }

--- a/packages/es-components/src/components/patterns/incrementer/Incrementer.md
+++ b/packages/es-components/src/components/patterns/incrementer/Incrementer.md
@@ -26,14 +26,18 @@ Thresholds can be set that will set a range for values that the incrementer will
 Passing a function to `onValueUpdated` will execute that function with the new value.
 
 ```
+const Control = require('../../controls/Control').default;
+const AdditionalHelp = require('../../controls/AdditionalHelp').default;
+
 function printNewValue(value) {
   console.log(`The new value is ${value}`);
 }
 
-<div>
-  <p>This incrementer will print the new value to the console.</p>
-  <Incrementer
+<Control>
+  <Label htmlFor="example-inc">Example</Label>
+  <Incrementer id="example-inc" aria-describedby="example-help" useOutlineButton
     onValueUpdated={printNewValue}
   />
-</div>
+  <AdditionalHelp id="example-help">This incrementer will print the new value to the console.</AdditionalHelp>
+</Control>
 ```

--- a/packages/es-components/src/components/patterns/incrementer/Incrementer.md
+++ b/packages/es-components/src/components/patterns/incrementer/Incrementer.md
@@ -5,6 +5,7 @@ Default incrementers will start at 0 and increase and decrease by 1 with no uppe
 ```
 
 Setting the increment and decrement amounts will increase and decrease by those amounts. This incrementer will increase and decrease by 2.
+
 ```
 <Incrementer
   incrementAmount={2}
@@ -12,12 +13,13 @@ Setting the increment and decrement amounts will increase and decrease by those 
 />
 ```
 
-Thresholds can be set that will set a range for values that the incrementer will respect.
+Thresholds can be set that will set a range for values that the incrementer will respect. Make sure to set a `startingValue` that respects your `lowerThreshold`.
 
 ```
 <Incrementer
-  lowerThreshold={0}
-  upperThreshold={5}
+  lowerThreshold={5}
+  upperThreshold={12}
+  startingValue={5}
 />
 ```
 

--- a/packages/es-components/src/components/patterns/incrementer/Incrementer.specs.js
+++ b/packages/es-components/src/components/patterns/incrementer/Incrementer.specs.js
@@ -2,15 +2,15 @@
 import React from 'react';
 import viaTheme from 'es-components-via-theme';
 
-import { wait } from 'react-testing-library';
+import { fireEvent } from 'react-testing-library';
 import Incrementer from './Incrementer';
 import { renderWithTheme } from '../../util/test-utils';
 
 const valueUpdated = jest.fn();
 
-beforeEach(() => {
-  valueUpdated.mockClear();
-});
+beforeAll(() =>
+  jest.spyOn(React, 'useEffect').mockImplementation(React.useLayoutEffect));
+afterAll(() => React.useEffect.mockRestore());
 
 function createIncrementer(props) {
   return (
@@ -25,10 +25,23 @@ it('when decrement button is clicked the displayed value is decreased by decreme
     })
   );
   container.querySelectorAll('button')[0].click();
-  wait(() => {
-    expect(queryByValue('-5')).not.toBeNull();
-    expect(valueUpdated).toHaveBeenCalledWith(-5);
-  });
+
+  expect(queryByValue('-5')).not.toBeNull();
+  expect(valueUpdated).toHaveBeenCalledWith(-5);
+});
+
+it('when decrement button is clicked the displayed value does not exceed the lowerThreshold', () => {
+  const { container, queryByValue } = renderWithTheme(
+    createIncrementer({
+      decrementAmount: 5,
+      lowerThreshold: 3,
+      startingValue: 6
+    })
+  );
+  container.querySelectorAll('button')[0].click();
+
+  expect(queryByValue('3')).not.toBeNull();
+  expect(valueUpdated).toHaveBeenCalledWith(3);
 });
 
 it('when increment button is clicked, the displayed value is increased by incrementAmount', () => {
@@ -38,10 +51,23 @@ it('when increment button is clicked, the displayed value is increased by increm
     })
   );
   container.querySelectorAll('button')[1].click();
-  wait(() => {
-    expect(queryByValue('2')).not.toBeNull();
-    expect(valueUpdated).toHaveBeenCalledWith(2);
-  });
+
+  expect(queryByValue('2')).not.toBeNull();
+  expect(valueUpdated).toHaveBeenCalledWith(2);
+});
+
+it('when increment button is clicked, the displayed value does not exceed the upperThreshold', () => {
+  const { container, queryByValue } = renderWithTheme(
+    createIncrementer({
+      incrementAmount: 3,
+      upperThreshold: 8,
+      startingValue: 6
+    })
+  );
+  container.querySelectorAll('button')[1].click();
+
+  expect(queryByValue('8')).not.toBeNull();
+  expect(valueUpdated).toHaveBeenCalledWith(8);
 });
 
 it('disables decrementation button when current value equals lowerThreshold', () => {
@@ -68,4 +94,70 @@ it('disables incrementation button when current value equals upperThreshold', ()
   incrementButton.click();
   incrementButton.click();
   expect(incrementButton).toBeDisabled();
+});
+
+it('when a non-numeric value is entered the incrementer resets to 0', () => {
+  const { queryByValue } = renderWithTheme(
+    createIncrementer({
+      startingValue: 6
+    })
+  );
+
+  const input = queryByValue('6');
+  input.value = 'hi';
+  fireEvent.change(input);
+  fireEvent.blur(input);
+
+  expect(queryByValue('0')).not.toBeNull();
+  expect(valueUpdated).toHaveBeenCalledWith(0);
+});
+
+it('when a non-numeric value is entered the incrementer resets to lowerThreshold when available', () => {
+  const { queryByValue } = renderWithTheme(
+    createIncrementer({
+      startingValue: 6,
+      lowerThreshold: 3
+    })
+  );
+
+  const input = queryByValue('6');
+  input.value = 'hi';
+  fireEvent.change(input);
+  fireEvent.blur(input);
+
+  expect(queryByValue('3')).not.toBeNull();
+  expect(valueUpdated).toHaveBeenCalledWith(3);
+});
+
+it('when a value is entered that exceeds the upperThreshold, it resets to upperThreshold', () => {
+  const { queryByValue } = renderWithTheme(
+    createIncrementer({
+      upperThreshold: 10
+    })
+  );
+
+  const input = queryByValue('0');
+  input.value = '25';
+  fireEvent.change(input);
+  fireEvent.blur(input);
+
+  expect(queryByValue('10')).not.toBeNull();
+  expect(valueUpdated).toHaveBeenCalledWith(10);
+});
+
+it('when a value is entered that exceeds the lowerThreshold, it resets to lowerThreshold', () => {
+  const { queryByValue } = renderWithTheme(
+    createIncrementer({
+      lowerThreshold: 3,
+      startingValue: 5
+    })
+  );
+
+  const input = queryByValue('5');
+  input.value = '1';
+  fireEvent.change(input);
+  fireEvent.blur(input);
+
+  expect(queryByValue('3')).not.toBeNull();
+  expect(valueUpdated).toHaveBeenCalledWith(3);
 });


### PR DESCRIPTION
- Input type is number, so mobile users will get the numeric keyboard

- The increment/decrement amounts now respect the thresholds.

- Using Kent Dodds' preferred (for now?) method of [testing useEffect](https://github.com/kentcdodds/react-testing-library/issues/215#issuecomment-438294336).

- Switched from lodash's `IsNumber` to `IsFinite`, which handles `NaN` in a falsey way.