### PR TITLE
Notification, Control minor style updates

### DIFF
--- a/packages/es-components/src/components/containers/notification/LightNotification.md
+++ b/packages/es-components/src/components/containers/notification/LightNotification.md
@@ -5,25 +5,25 @@ These notifications are rendered with a lighter background.
   <LightNotification
     type="success"
   >
-    <p>This is a successful notification!</p>
+    <span>This is a successful notification!</span>
   </LightNotification>
 
   <LightNotification
     type="info"
   >
-    <p>This is an informational notification!</p>
+    <span>This is an informational notification!</span>
   </LightNotification>
 
   <LightNotification
     type="warning"
   >
-    <p>This is a warning notification!</p>
+    <span>This is a warning notification!</span>
   </LightNotification>
 
   <LightNotification
     type="danger"
   >
-    <p>This is a danger notification!</p>
+    <span>This is a danger notification!</span>
   </LightNotification>
 </div>
 ```

--- a/packages/es-components/src/components/containers/notification/Message.js
+++ b/packages/es-components/src/components/containers/notification/Message.js
@@ -12,11 +12,11 @@ const defaultProps = {
 
 export function InlineMessage({ emphasizedText, text }) {
   return (
-    <p>
+    <span>
       {emphasizedText !== undefined ? <strong>{emphasizedText}</strong> : null}
       {' '}
       {text}
-    </p>
+    </span>
   );
 }
 
@@ -25,7 +25,7 @@ InlineMessage.defaultProps = defaultProps;
 
 export function Message({ emphasizedText, text }) {
   return (
-    <p>
+    <span>
       {emphasizedText !== undefined ? (
         <>
           <strong>{emphasizedText}</strong>
@@ -33,7 +33,7 @@ export function Message({ emphasizedText, text }) {
         </>
       ) : null}
       {text}
-    </p>
+    </span>
   );
 }
 

--- a/packages/es-components/src/components/containers/notification/Notification.md
+++ b/packages/es-components/src/components/containers/notification/Notification.md
@@ -31,7 +31,7 @@ const InlineMessage = require('./Message').InlineMessage;
 
   <Notification type="advisor">
     <div style={{ flexBasis: '100%' }}>
-      <h3>This is an advisor alert!</h3>
+      <h3 style={{ 'margin-top': '0' }}>This is an advisor alert!</h3>
       <div>
         Children are rendered in a flex container and{' '}
         <a href="#notification">links</a> render with underlined text, but

--- a/packages/es-components/src/components/containers/notification/useNotification.js
+++ b/packages/es-components/src/components/containers/notification/useNotification.js
@@ -5,11 +5,12 @@ import { useTheme } from '../../util/useTheme';
 
 const NotificationIcon = styled(Icon)`
   align-self: start;
+  color: ${props => props.iconColor};
   display: none;
 
   @media (min-width: ${props => props.theme.screenSize.tablet}) {
     display: initial;
-    margin-right: 5px;
+    margin-right: 8px;
   }
 `;
 
@@ -20,6 +21,7 @@ const DismissButton = styled.button`
   color: ${props => props.color.textColor};
   cursor: pointer;
   opacity: 0.8;
+  padding: 0;
 `;
 
 const ContentWrapper = styled.div`
@@ -27,40 +29,46 @@ const ContentWrapper = styled.div`
   flex-grow: 1;
 `;
 
-const NotificationContent = React.forwardRef(
-  (
-    { includeIcon, isDismissable, onDismiss, children, iconName, color },
-    ref
-  ) => {
-    const [isDismissed, setIsDismissed] = useState(false);
+const NotificationContent = React.forwardRef((props, ref) => {
+  const {
+    includeIcon,
+    isDismissable,
+    onDismiss,
+    children,
+    iconName,
+    iconColor,
+    color
+  } = props;
+  const [isDismissed, setIsDismissed] = useState(false);
 
-    useEffect(
-      function removeNotification() {
-        if (isDismissed) {
-          ref.current.remove();
-        }
-      },
-      [isDismissed]
-    );
+  useEffect(
+    function removeNotification() {
+      if (isDismissed) {
+        ref.current.remove();
+      }
+    },
+    [isDismissed]
+  );
 
-    function dismissNotification() {
-      onDismiss();
-      setIsDismissed(true);
-    }
-
-    return (
-      <>
-        {includeIcon ? <NotificationIcon name={iconName} size={28} /> : null}
-        <ContentWrapper>{children}</ContentWrapper>
-        {isDismissable ? (
-          <DismissButton onClick={dismissNotification} color={color}>
-            <Icon name="remove" size={27} />
-          </DismissButton>
-        ) : null}
-      </>
-    );
+  function dismissNotification() {
+    onDismiss();
+    setIsDismissed(true);
   }
-);
+
+  return (
+    <>
+      {includeIcon && (
+        <NotificationIcon name={iconName} iconColor={iconColor} size={28} />
+      )}
+      <ContentWrapper>{children}</ContentWrapper>
+      {isDismissable && (
+        <DismissButton onClick={dismissNotification} color={color}>
+          <Icon name="remove" size={27} />
+        </DismissButton>
+      )}
+    </>
+  );
+});
 
 const Notification = styled.div`
   align-items: center;
@@ -91,7 +99,9 @@ export function useNotification(styleType = 'base') {
     const notificationRef = useRef(null);
     const color = theme.notificationStyles[type][styleType];
     const iconName = theme.validationIconName[type];
-    const notificationContentProps = { color, iconName, ...rest };
+    const iconColor =
+      styleType === 'light' ? theme.colors[type] : theme.colors.white;
+    const notificationContentProps = { color, iconName, iconColor, ...rest };
 
     return (
       <Notification ref={notificationRef} role={role} variant={color}>

--- a/packages/es-components/src/components/controls/Control.js
+++ b/packages/es-components/src/components/controls/Control.js
@@ -10,7 +10,7 @@ const FlexControl = styled.div`
   display: flex;
   flex-wrap: wrap;
   flex-direction: column;
-  margin-bottom: 15px;
+  margin-bottom: 25px;
 
   select {
     border-color: ${props => props.borderColor};


### PR DESCRIPTION
- `Notification` was updated to use spans rather than paragraph tags to prevent too much padding. 
- `LightNotification` icon colors updated to use the correct associated validation type color to conform to BDA toolkit.
- `Control` bottom margin increased to 25px.