### PR TITLE
Update: changes Tooltip/Popover links to use text-decoration-style

### DIFF
--- a/packages/es-components/src/components/containers/tooltip/Tooltip.js
+++ b/packages/es-components/src/components/containers/tooltip/Tooltip.js
@@ -87,18 +87,17 @@ const TooltipArrowLeft = styled(TooltipArrowBase)`
 `;
 
 const StyledButton = styled(LinkButton)`
-  border-bottom: 1px dashed;
   border-radius: 0;
   color: ${props => props.theme.colors.primary};
   line-height: initial;
   margin-bottom: 3px;
-  text-decoration: none;
+  text-decoration-style: dashed;
+  text-underline-position: under;
 
   &:hover,
   :focus {
     color: ${props => props.theme.colors.primary};
-    text-decoration: none;
-    border-bottom: 1px solid;
+    text-decoration: underline;
   }
 `;
 

--- a/packages/es-components/src/components/controls/buttons/PopoverLink.js
+++ b/packages/es-components/src/components/controls/buttons/PopoverLink.js
@@ -5,15 +5,14 @@ import LinkButton from './LinkButton';
 import { useTheme } from '../../util/useTheme';
 
 const StyledButton = styled(LinkButton)`
-  border-bottom-width: 1px;
-  border-bottom-style: dashed;
-  border-bottom-color: ${props =>
-    props.suppressUnderline ? 'transparent' : 'initial'};
   margin-bottom: 2px;
-  text-decoration: none;
+  text-decoration-style: ${props =>
+    props.suppressUnderline ? 'none' : 'dashed'};
+  text-underline-position: under;
 
-  &:hover {
-    border-bottom-style: solid;
+  &:hover,
+  :focus {
+    text-decoration: underline;
   }
 `;
 


### PR DESCRIPTION
After a discussion with our UX team it has been decided that using this approach is desirable even as it does not fully work with IE. It makes sure that even with wrapped words the underline behaves correctly.