### PR TITLE
Fix Notification Icons in IE11

### DIFF
--- a/packages/es-components/src/components/containers/notification/useNotification.js
+++ b/packages/es-components/src/components/containers/notification/useNotification.js
@@ -9,7 +9,7 @@ const NotificationIcon = styled(Icon)`
   display: none;
 
   @media (min-width: ${props => props.theme.screenSize.tablet}) {
-    display: initial;
+    display: inline;
     margin-right: 8px;
   }
 `;


### PR DESCRIPTION
The `initial` css value isn't supported in IE11 (https://caniuse.com/#feat=css-initial-value). This change replaces `initial` with the `<i>` element's default display value of `inline` for the `Notification` component.