### PR TITLE
Modal scrolling

### DIFF
--- a/packages/es-components/src/components/containers/checkboxLabel/CheckboxLabel.md
+++ b/packages/es-components/src/components/containers/checkboxLabel/CheckboxLabel.md
@@ -1,7 +1,0 @@
-The styled label used for the checkbox control
-
-```
-<CheckboxLabel>
-  Hi there
-</CheckboxLabel>
-```

--- a/packages/es-components/src/components/containers/modal/Modal.js
+++ b/packages/es-components/src/components/containers/modal/Modal.js
@@ -41,8 +41,6 @@ const ModalDialogMedium = styled.div`
 `;
 
 const ModalDialogSmall = styled(ModalDialogMedium)`
-  width: 100%;
-
   @media (min-width: ${props => props.theme.screenSize.phone}) {
     margin: 30px auto;
     width: ${modalSize.small};
@@ -50,8 +48,6 @@ const ModalDialogSmall = styled(ModalDialogMedium)`
 `;
 
 const ModalDialogLarge = styled(ModalDialogMedium)`
-  width: 100%;
-
   @media (min-width: ${props => props.theme.screenSize.desktop}) {
     width: ${modalSize.large};
   }
@@ -62,9 +58,12 @@ const ModalContent = styled.div`
   background-color: ${props => props.theme.colors.white};
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
   font-size: ${props => props.theme.sizes.baseFontSize};
+  max-height: 100vh;
   outline: 0;
+  overflow-y: auto;
   position: relative;
   text-align: left;
+  -webkit-overflow-scrolling: touch;
 `;
 
 function getModalBySize(size) {

--- a/packages/es-components/src/components/containers/notification/Notification.md
+++ b/packages/es-components/src/components/containers/notification/Notification.md
@@ -31,7 +31,7 @@ const InlineMessage = require('./Message').InlineMessage;
 
   <Notification type="advisor">
     <div style={{ flexBasis: '100%' }}>
-      <h3 style={{ 'margin-top': '0' }}>This is an advisor alert!</h3>
+      <h3 style={{ marginTop: '0' }}>This is an advisor alert!</h3>
       <div>
         Children are rendered in a flex container and{' '}
         <a href="#notification">links</a> render with underlined text, but

--- a/packages/es-components/src/components/containers/popover/Popover.js
+++ b/packages/es-components/src/components/containers/popover/Popover.js
@@ -102,7 +102,10 @@ function Popover(props) {
 
   const [isOpen, setIsOpen] = useState(false);
 
-  function toggleShow() {
+  function toggleShow(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
     setTimeout(() => {
       if (contentRef.current) {
         const focusableContent = contentRef.current.querySelector('a, button');

--- a/packages/es-components/src/components/controls/checkbox/Checkbox.js
+++ b/packages/es-components/src/components/controls/checkbox/Checkbox.js
@@ -23,7 +23,6 @@ const CheckboxLabel = styled(Label)`
   min-height: 25px;
   padding: 10px 0 10px 42px;
   position: relative;
-  flex: 1 0 auto;
 
   @media (min-width: ${props => props.theme.screenSize.tablet}) {
     margin-left: 0;

--- a/packages/es-components/src/components/controls/label/Label.js
+++ b/packages/es-components/src/components/controls/label/Label.js
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 const Label = styled.label`
   color: inherit;
   cursor: pointer;
-  display: flex;
   font-size: ${props => props.theme.sizes.baseFontSize};
   font-weight: 700;
   margin-bottom: 5px;


### PR DESCRIPTION
Allows modals to scroll when their content goes offscreen.

Removed the `display: flex` from `Label` which I think was a holdover from our earlier iteration as it doesn't seem to affect anything.

Fixed an issue where popover links within labels were not activating in Safari.