### PR TITLE
Fix: Button box shadows cut off in IE11

### DIFF
--- a/packages/es-components/src/components/controls/buttons/Button.js
+++ b/packages/es-components/src/components/controls/buttons/Button.js
@@ -10,6 +10,7 @@ const StyledButton = styled.button`
   box-sizing: border-box;
   cursor: pointer;
   display: block;
+  overflow: visible;
   padding: 0;
   width: 100%;
 


### PR DESCRIPTION
In IE11 the Button component's box shadow was being cut off by the parent element. Here's what it looked like:
![Bad_button](https://user-images.githubusercontent.com/6923910/55754023-f8af7f80-5a08-11e9-9bca-5d1090ec762b.png)
Convenient arrow in case you couldn't spot the button... 😄 

The fix is to allow `overflow` to be visible on the parent element of the box shadow'd element.