### PR TITLE
Fix: modal close button in Safari

### DIFF
--- a/packages/es-components/src/components/containers/modal/ModalFooter.js
+++ b/packages/es-components/src/components/containers/modal/ModalFooter.js
@@ -2,12 +2,17 @@ import styled from 'styled-components';
 
 // Note: ModalFooter relies on a parent (Modal) with ThemeProvider wrapping it
 const ModalFooter = styled.div`
+  align-items: baseline;
   display: flex;
-  padding: 15px;
+  padding: 15px 15px 45px;
   text-align: right;
 
   button {
     width: auto;
+  }
+
+  @media (min-width: ${props => props.theme.screenSize.tablet}) {
+    padding: 15px 15px 19px;
   }
 `;
 

--- a/packages/es-components/src/components/containers/modal/ModalHeader.js
+++ b/packages/es-components/src/components/containers/modal/ModalHeader.js
@@ -7,6 +7,7 @@ import Heading from '../heading/Heading';
 
 // Note: ModalHeader relies on a parent (Modal) with ThemeProvider wrapping it
 const Header = styled.div`
+  align-items: baseline;
   border-bottom: 2px solid ${props => props.theme.brandColors.vbMagenta};
   color: ${props => props.theme.colors.gray9};
   display: flex;

--- a/packages/es-components/src/components/containers/modal/__snapshots__/Modal.specs.js.snap
+++ b/packages/es-components/src/components/containers/modal/__snapshots__/Modal.specs.js.snap
@@ -19,7 +19,7 @@ exports[`renders different modal sections 2`] = `
 
 exports[`renders different modal sections 3`] = `
 <div
-  class="sc-gzVnrw ilnIUq"
+  class="sc-gzVnrw hAeTVX"
 >
   Footer
 </div>


### PR DESCRIPTION
Another small tweak that adds some padding to the bottom of the mobile full-screen modal to accommodate the Safari toolbar. 