### PR TITLE
Update: heading styles, added knockout and underlineColor props

### DIFF
--- a/packages/es-components/src/components/containers/heading/Heading.js
+++ b/packages/es-components/src/components/containers/heading/Heading.js
@@ -3,24 +3,51 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 const HeadingBase = styled.h1`
-  color: inherit;
-  font-size: ${props => props.theme.headingSize[props.adjustedSize]};
+  background-color: ${props =>
+    props.isKnockoutStyle && props.theme.colors.softwareBlue};
+  border-bottom: ${props =>
+    props.underlineColor && `2px solid ${props.underlineColor};`};
+  color: ${props => (props.isKnockoutStyle ? 'white' : 'inherit')};
+  font-size: ${props =>
+    props.adjustedSize > 2
+      ? props.theme.headingSize[props.adjustedSize]
+      : `calc(${props.theme.headingSize[props.adjustedSize]} - 6px);`};
   font-weight: 300;
   line-height: 1.1;
-  margin-bottom: 12.5px;
-  margin-top: 25px;
+  margin-bottom: 0.45em;
+  margin-top: 0;
+  padding-bottom: ${props => props.underlineColor && '0.22em'};
+  padding: ${props => props.isKnockoutStyle && '20px 15px'};
 
   small {
     font-size: ${props => (props.adjustedSize > 3 ? '75%' : '65%')};
     line-height: 1;
   }
+
+  @media (min-width: ${props => props.theme.screenSize.tablet}) {
+    font-size: ${props => props.theme.headingSize[props.adjustedSize]};
+  }
 `;
 
-function Heading({ children, level, size, ...other }) {
+function Heading({
+  children,
+  level,
+  size,
+  isKnockoutStyle,
+  underlineColor,
+  ...other
+}) {
   const adjustedSize = size || level;
   const hLevel = `h${level}`;
+
   return (
-    <HeadingBase as={hLevel} adjustedSize={adjustedSize} {...other}>
+    <HeadingBase
+      as={hLevel}
+      adjustedSize={adjustedSize}
+      isKnockoutStyle={isKnockoutStyle}
+      underlineColor={underlineColor}
+      {...other}
+    >
       {children}
     </HeadingBase>
   );
@@ -31,12 +58,18 @@ Heading.propTypes = {
   /** Heading level element */
   level: PropTypes.oneOf([1, 2, 3, 4, 5, 6]).isRequired,
   /** Override the default font size with another level */
-  size: PropTypes.oneOf([1, 2, 3, 4, 5, 6])
+  size: PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
+  /** Alternate knockout-style header with a solid background */
+  isKnockoutStyle: PropTypes.bool,
+  /** Include an underline with the provided color */
+  underlineColor: PropTypes.string
 };
 
 Heading.defaultProps = {
   children: undefined,
-  size: undefined
+  size: undefined,
+  isKnockoutStyle: false,
+  underlineColor: null
 };
 
 export default Heading;

--- a/packages/es-components/src/components/containers/heading/Heading.md
+++ b/packages/es-components/src/components/containers/heading/Heading.md
@@ -1,17 +1,24 @@
-A `Heading` component can be used for various heading levels. Wrap secondary text in `<small>` tags.
+A `Heading` component can be used for various heading levels. Wrap secondary text in `<small>` tags. Provide an `underlineColor` to display a styled border.
+Larger headings will resize appropriately in mobile viewports.
 
 ```
 const StyleReset = require('../../util/StyleReset').default;
 
 <div>
   <StyleReset />
-  <Heading level={1}>h1. Heading <small>Secondary Text</small></Heading>
-  <Heading level={2}>h2. Heading <small>Secondary Text</small></Heading>
+  <Heading level={1} underlineColor="#00a0d2">h1. Heading <small>Secondary Text</small></Heading>
+  <Heading level={2} underlineColor="#979797">h2. Heading <small>Secondary Text</small></Heading>
   <Heading level={3}>h3. Heading <small>Secondary Text</small></Heading>
   <Heading level={4}>h4. Heading <small>Secondary Text</small></Heading>
   <Heading level={5}>h5. Heading <small>Secondary Text</small></Heading>
   <Heading level={6}>h6. Heading <small>Secondary Text</small></Heading>
 </div>
+```
+
+Use `isKnockoutStyle` to display a special page-level heading style.
+
+```
+<Heading level={1} isKnockoutStyle>Knockout Heading</Heading>
 ```
 
 The font size may be overridden by that of another level by providing the `size` prop.

--- a/packages/es-components/src/components/containers/heading/Heading.specs.js
+++ b/packages/es-components/src/components/containers/heading/Heading.specs.js
@@ -26,3 +26,16 @@ it('renders heading level with another size', () => {
 
   expect(container).toMatchSnapshot();
 });
+
+it('renders knockout heading with different class', () => {
+  const { container } = renderWithTheme(
+    <div>
+      <Heading level={1}>Heading level 1</Heading>
+      <Heading level={1} isKnockoutStyle>
+        Knockout Heading level 1
+      </Heading>
+    </div>
+  );
+
+  expect(container).toMatchSnapshot();
+});

--- a/packages/es-components/src/components/containers/heading/__snapshots__/Heading.specs.js.snap
+++ b/packages/es-components/src/components/containers/heading/__snapshots__/Heading.specs.js.snap
@@ -4,20 +4,37 @@ exports[`renders heading level with another size 1`] = `
 <div>
   <div>
     <h1
-      class="sc-bdVaJa gbxEJg"
+      class="sc-bdVaJa mpAKb"
     >
       Heading level 1
     </h1>
     <h3
-      class="sc-bdVaJa bbqOIv"
+      class="sc-bdVaJa dfMvbW"
     >
       Heading level 3
     </h3>
     <h3
-      class="sc-bdVaJa gbxEJg"
+      class="sc-bdVaJa mpAKb"
     >
       Heading level 3 size 1
     </h3>
+  </div>
+</div>
+`;
+
+exports[`renders knockout heading with different class 1`] = `
+<div>
+  <div>
+    <h1
+      class="sc-bdVaJa mpAKb"
+    >
+      Heading level 1
+    </h1>
+    <h1
+      class="sc-bdVaJa eJSayt"
+    >
+      Knockout Heading level 1
+    </h1>
   </div>
 </div>
 `;

--- a/packages/es-components/src/components/containers/modal/__snapshots__/Modal.specs.js.snap
+++ b/packages/es-components/src/components/containers/modal/__snapshots__/Modal.specs.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders different modal sections 1`] = `
 <h4
-  class="sc-ifAKCX fBKnDt sc-htpNat kauQMr"
+  class="sc-ifAKCX fBKnDt sc-htpNat eNzNll"
   id="abcdef"
 >
   Header

--- a/packages/es-components/src/components/controls/checkbox/Checkbox.js
+++ b/packages/es-components/src/components/controls/checkbox/Checkbox.js
@@ -17,7 +17,7 @@ const backgroundColorSelect = (checked, theme, validationState) => {
 const CheckboxLabel = styled(Label)`
   color: inherit;
   font-size: ${props => props.theme.sizes.baseFontSize};
-  font-weight: bold;
+  font-weight: normal;
   line-height: ${props => props.theme.sizes.baseLineHeight};
   margin-left: -10px;
   min-height: 25px;

--- a/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
@@ -27,7 +27,7 @@ const RadioLabel = styled(Label)`
   cursor: pointer;
   display: flex;
   font-size: ${props => props.theme.sizes.baseFontSize};
-  font-weight: bold;
+  font-weight: normal;
   line-height: ${props => props.theme.sizes.baseLineHeight};
   margin-right: 15px;
   margin-bottom: 10px;
@@ -60,7 +60,7 @@ const RadioDisplay = styled.span`
   box-sizing: border-box;
   height: 25px;
   margin-right: 8px;
-  width: 25px;
+  min-width: 25px;
 
   &:before {
     ${props => radioFill(props.fill)};

--- a/packages/es-components/src/components/util/StyleReset.js
+++ b/packages/es-components/src/components/util/StyleReset.js
@@ -3,7 +3,7 @@ import { createGlobalStyle } from 'styled-components';
 const StyleReset = createGlobalStyle`
   html, body, div, span, applet, object, iframe,
   a, big, cite, code, del, dfn, em, img, ins, kbd,
-  q, s, samp, strike, sub, sup, tt, var,
+  q, s, samp, strike, tt, var,
   b, u, i, center, dl, dt, dd, ol, ul, li,
   fieldset, form, label, legend
   table, caption, tbody, tfoot, thead, tr, th, td,
@@ -17,14 +17,6 @@ const StyleReset = createGlobalStyle`
     margin: 0;
     padding: 0;
     vertical-align: baseline;
-  }
-
-  sub {
-    vertical-align: sub;
-  }
-
-  sup {
-    vertical-align: super;
   }
 
   input, button {
@@ -45,7 +37,8 @@ const StyleReset = createGlobalStyle`
     font: inherit;
     font-weight: 300;
     line-height: 1.1;
-    margin: 25px 0 12.5px;
+    margin-bottom: 0.45em;
+    margin-top: 0;
   }
 
   h1 {


### PR DESCRIPTION
H1 & H2 will size down a bit on mobile now, so teams don't have to write their own media queries.
UX has reviewed and suggested the underlineColor prop to keep it somewhat open to customization.

Also updated Checkbox and Radio labels to use normal font-weight.

![Pasted_image_at_2019-04-15__1_54_PM](https://user-images.githubusercontent.com/797074/56168077-53ac1e00-5f97-11e9-808c-9f9bb8cd7b81.png)
