### PR TITLE
Fix: ensuring all layout spacing takes effect for labels

### DIFF
--- a/packages/es-components/src/components/controls/label/Label.js
+++ b/packages/es-components/src/components/controls/label/Label.js
@@ -6,6 +6,7 @@ const Label = styled.label`
   font-size: ${props => props.theme.sizes.baseFontSize};
   font-weight: 700;
   margin-bottom: 5px;
+  display: inline-block;
 
   &[disabled] {
     cursor: not-allowed;


### PR DESCRIPTION
This conforms to the styles from the [BDA Style Guide](http://prototypes-wtw.net/controls/#forms-example).