### PR TITLE
Update: Textbox addons focus on click, MaskedTextbox cleanup

### DIFF
--- a/packages/es-components/src/components/containers/notification/useNotification.js
+++ b/packages/es-components/src/components/containers/notification/useNotification.js
@@ -29,7 +29,10 @@ const ContentWrapper = styled.div`
   flex-grow: 1;
 `;
 
-const NotificationContent = React.forwardRef((props, ref) => {
+const NotificationContent = React.forwardRef(function NotificationContent(
+  props,
+  ref
+) {
   const {
     includeIcon,
     isDismissable,

--- a/packages/es-components/src/components/controls/buttons/Button.js
+++ b/packages/es-components/src/components/controls/buttons/Button.js
@@ -74,7 +74,7 @@ const StyledButton = styled.button`
   }
 `;
 
-const Button = React.forwardRef((props, ref) => {
+const Button = React.forwardRef(function Button(props, ref) {
   const { children, styleType, size, block, ...other } = props;
   const theme = useTheme();
   const buttonSize = theme.buttonStyles.button.size[size];

--- a/packages/es-components/src/components/controls/buttons/LinkButton.js
+++ b/packages/es-components/src/components/controls/buttons/LinkButton.js
@@ -31,7 +31,7 @@ const StyledButton = styled.button`
   }
 `;
 
-const LinkButton = React.forwardRef((props, ref) => {
+const LinkButton = React.forwardRef(function LinkButton(props, ref) {
   const { children, styleType, ...other } = props;
   const theme = useTheme();
   const variant = theme.buttonStyles.button.variant[styleType];

--- a/packages/es-components/src/components/controls/buttons/OutlineButton.js
+++ b/packages/es-components/src/components/controls/buttons/OutlineButton.js
@@ -59,7 +59,7 @@ const StyledButton = styled.button`
   }
 `;
 
-const OutlineButton = React.forwardRef((props, ref) => {
+const OutlineButton = React.forwardRef(function OutlineButton(props, ref) {
   const { children, styleType, size, block, ...other } = props;
   const theme = useTheme();
   const buttonSize = theme.buttonStyles.outlineButton.size[size];

--- a/packages/es-components/src/components/controls/buttons/PopoverLink.js
+++ b/packages/es-components/src/components/controls/buttons/PopoverLink.js
@@ -16,7 +16,7 @@ const StyledButton = styled(LinkButton)`
   }
 `;
 
-const PopoverLink = React.forwardRef((props, ref) => {
+const PopoverLink = React.forwardRef(function PopoverLink(props, ref) {
   const { children, styleType, suppressUnderline, ...other } = props;
   const theme = useTheme();
   const variant = theme.buttonStyles.button.variant[styleType];

--- a/packages/es-components/src/components/controls/textbox/MaskedTextbox.js
+++ b/packages/es-components/src/components/controls/textbox/MaskedTextbox.js
@@ -1,110 +1,35 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
-import { omit, noop } from 'lodash';
 import MaskedInput from 'react-text-mask';
 
-import Icon from '../../base/icons/Icon';
 import inputMaskType from './inputMaskType';
-import {
-  ValidationIconWrapper,
-  ValidationIcon,
-  Prepend,
-  Append,
-  InputWrapper,
-  TextboxBase
-} from './TextAddons';
-import { useTheme } from '../../util/useTheme';
-import ValidationContext from '../ValidationContext';
+import Textbox from './Textbox';
 
-// apply styles to masked input, but remove props it doesn't use
-const StyledMask = styled(props => (
-  <MaskedInput
-    {...omit(props, [
-      'borderColor',
-      'boxShadow',
-      'focusBorderColor',
-      'focusBoxShadow',
-      'hasAppend',
-      'hasPrepend',
-      'initialValue'
-    ])}
-  />
-))``;
+const MaskedTextbox = React.forwardRef(function MaskedTextbox(props, ref) {
+  const { maskType, customMask, ...additionalTextProps } = props;
+  const inputRef = React.useRef();
+  React.useImperativeHandle(ref, () => inputRef.current);
 
-function MaskedTextbox(props) {
-  const {
-    prependIconName,
-    appendIconName,
-    maskType,
-    customMask,
-    inputRef,
-    ...additionalTextProps
-  } = props;
-  const theme = useTheme();
-
-  const validationState = React.useContext(ValidationContext);
-
-  const hasPrepend = !!prependIconName;
-  const hasAppend = !!appendIconName;
-  const hasValidationIcon = validationState !== 'default';
   const maskArgs =
     maskType === 'custom' && customMask ? customMask : inputMaskType[maskType];
 
-  maskArgs.render = (maskRef, maskProps) => {
-    const setRef = inputElement => {
-      maskRef(inputElement);
-      inputRef(inputElement);
-    };
-    return <input ref={setRef} {...maskProps} />;
-  };
-
-  const addOnTextColor = hasValidationIcon
-    ? theme.colors.white
-    : theme.colors.gray8;
-  const addOnBgColor = hasValidationIcon
-    ? theme.validationTextColor[validationState]
-    : theme.colors.gray3;
-
   return (
-    <InputWrapper>
-      {hasPrepend && (
-        <Prepend addOnTextColor={addOnTextColor} addOnBgColor={addOnBgColor}>
-          <Icon aria-hidden="true" name={prependIconName} size={18} />
-        </Prepend>
-      )}
-      <TextboxBase
-        as={StyledMask}
-        hasAppend={hasAppend}
-        hasPrepend={hasPrepend}
-        type="text"
-        {...maskArgs}
-        {...additionalTextProps}
-        {...theme.validationInputColor[validationState]}
-      />
-      {hasValidationIcon && (
-        <ValidationIconWrapper>
-          <ValidationIcon
-            aria-hidden="true"
-            name={theme.validationIconName[validationState]}
-            size={18}
-          />
-        </ValidationIconWrapper>
-      )}
-      {hasAppend && (
-        <Append addOnTextColor={addOnTextColor} addOnBgColor={addOnBgColor}>
-          <Icon aria-hidden="true" name={appendIconName} size={18} />
-        </Append>
-      )}
-    </InputWrapper>
+    <MaskedInput
+      render={(maskRef, textboxProps) => {
+        const setRef = inputElement => {
+          // we need to set both the mask ref and the passed in ref
+          maskRef(inputElement);
+          inputRef.current = inputElement;
+        };
+        return <Textbox ref={setRef} {...textboxProps} type="text" />;
+      }}
+      {...maskArgs}
+      {...additionalTextProps}
+    />
   );
-}
+});
 
 MaskedTextbox.propTypes = {
-  /** Content to prepend input box with */
-  prependIconName: PropTypes.string,
-  /** Content to append to input box */
-  appendIconName: PropTypes.string,
   /** Sets a mask type on the input */
   maskType: PropTypes.oneOf([
     'date',
@@ -122,16 +47,11 @@ MaskedTextbox.propTypes = {
     keepCharPositions: PropTypes.bool,
     pipe: PropTypes.func,
     showMask: PropTypes.bool
-  }),
-  /** Callback function to get inner mask ref */
-  inputRef: PropTypes.func
+  })
 };
 
 MaskedTextbox.defaultProps = {
-  prependIconName: undefined,
-  appendIconName: undefined,
-  customMask: undefined,
-  inputRef: noop
+  customMask: undefined
 };
 
 export default MaskedTextbox;

--- a/packages/es-components/src/components/controls/textbox/TextAddons.js
+++ b/packages/es-components/src/components/controls/textbox/TextAddons.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import Icon from '../../base/icons/Icon';
 import InputBase from './InputText';
 
@@ -35,7 +35,7 @@ const ValidationIcon = styled(Icon)`
   top: 11px;
 `;
 
-const AddOn = css`
+const AddOn = styled.button`
   background-color: ${props => props.addOnBgColor};
   border: 1px solid
     ${props =>
@@ -48,6 +48,7 @@ const AddOn = css`
   display: table-cell;
   height: 39px;
   line-height: 1.2;
+  outline: 0;
   padding: 6px 11px;
 
   i {
@@ -56,14 +57,14 @@ const AddOn = css`
   }
 `;
 
-const Prepend = styled.span`
-  ${AddOn} border-bottom-right-radius: 0;
+const Prepend = styled(AddOn)`
+  border-bottom-right-radius: 0;
   border-right: none;
   border-top-right-radius: 0;
 `;
 
-const Append = styled.span`
-  ${AddOn} border-bottom-left-radius: 0;
+const Append = styled(AddOn)`
+  border-bottom-left-radius: 0;
   border-left: none;
   border-top-left-radius: 0;
 `;

--- a/packages/es-components/src/components/controls/textbox/Textbox.js
+++ b/packages/es-components/src/components/controls/textbox/Textbox.js
@@ -13,11 +13,13 @@ import {
 import { useTheme } from '../../util/useTheme';
 import ValidationContext from '../ValidationContext';
 
-const Textbox = React.forwardRef((props, ref) => {
+const Textbox = React.forwardRef(function Textbox(props, ref) {
   const { prependIconName, appendIconName, ...additionalTextProps } = props;
   const theme = useTheme();
-
   const validationState = React.useContext(ValidationContext);
+
+  const inputRef = React.useRef();
+  React.useImperativeHandle(ref, () => inputRef.current);
 
   const hasPrepend = !!prependIconName;
   const hasAppend = !!appendIconName;
@@ -30,17 +32,26 @@ const Textbox = React.forwardRef((props, ref) => {
     ? theme.validationTextColor[validationState]
     : theme.colors.gray3;
 
+  function focusInput() {
+    inputRef.current.focus();
+  }
+
   return (
     <InputWrapper>
       {hasPrepend && (
-        <Prepend addOnTextColor={addOnTextColor} addOnBgColor={addOnBgColor}>
+        <Prepend
+          addOnTextColor={addOnTextColor}
+          addOnBgColor={addOnBgColor}
+          aria-hidden="true"
+          onClick={focusInput}
+        >
           <Icon aria-hidden="true" name={prependIconName} size={18} />
         </Prepend>
       )}
       <TextboxBase
         hasAppend={hasAppend}
         hasPrepend={hasPrepend}
-        ref={ref}
+        ref={inputRef}
         {...additionalTextProps}
         {...theme.validationInputColor[validationState]}
       />
@@ -54,7 +65,12 @@ const Textbox = React.forwardRef((props, ref) => {
         </ValidationIconWrapper>
       )}
       {hasAppend && (
-        <Append addOnTextColor={addOnTextColor} addOnBgColor={addOnBgColor}>
+        <Append
+          addOnTextColor={addOnTextColor}
+          addOnBgColor={addOnBgColor}
+          aria-hidden="true"
+          onClick={focusInput}
+        >
           <Icon aria-hidden="true" name={appendIconName} size={18} />
         </Append>
       )}

--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.js
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.js
@@ -32,19 +32,16 @@ const getVerifiedDate = selectedDate => {
 };
 
 // required for react-datepicker 2.0.0 to properly set focus
-class DateTextbox extends React.Component {
-  setRef = ref => {
-    this.inputElement = ref;
-  };
+const DateTextbox = React.forwardRef(function DateTextbox(props, ref) {
+  const inputRef = React.useRef();
+  React.useImperativeHandle(ref, () => ({
+    focus: () => {
+      inputRef.current.focus();
+    }
+  }));
 
-  focus() {
-    this.inputElement.focus();
-  }
-
-  render() {
-    return <MaskedTextbox inputRef={this.setRef} {...this.props} />;
-  }
-}
+  return <MaskedTextbox ref={inputRef} {...props} />;
+});
 
 function NativeDatePicker({ selectedDate, name, onChange, ...props }) {
   const onChangeIntercept = event => {


### PR DESCRIPTION
- UX wanted the Textbox append/prepends to be clickable so they focus on the input

- Significantly cleaned up MaskedTextbox code (backwards compatible)

- Changed usage of forwardRef to named functions for better debugging messages. If you forgot to supply a required prop, for example
  - before: "The prop 'x' is marked as required in ForwardRef, but its value is undefined."
  - after: "The prop 'x' is marked as required in ForwardRef(ComponentName), but its value is undefined."