### PR TITLE
Update: Popover title not required, DismissButton consistent styles 

### DIFF
--- a/packages/es-components/src/components/containers/menu/MenuPanel.js
+++ b/packages/es-components/src/components/containers/menu/MenuPanel.js
@@ -13,6 +13,7 @@ const StyledPanel = styled.div`
 
 const StyledDismissButton = styled(DismissButton)`
   margin-left: auto;
+  margin-right: 4px;
 `;
 
 const Header = styled.header`

--- a/packages/es-components/src/components/containers/modal/Modal.md
+++ b/packages/es-components/src/components/containers/modal/Modal.md
@@ -18,7 +18,7 @@ the level passed in.
     show={state.show}
     onHide={() => setState({show: false})}
   >
-    <Modal.Header level={2} hideCloseButton={state.hideCloseButton}>This is the header.</Modal.Header>
+    <Modal.Header level={4} hideCloseButton={state.hideCloseButton}>This is the header.</Modal.Header>
     <Modal.Body>Body Content. Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch.This is the popover's content. Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid.</Modal.Body>
     <Modal.Footer>
       <span style={{ flexGrow: 1, marginRight: '10px' }}>

--- a/packages/es-components/src/components/containers/modal/ModalHeader.js
+++ b/packages/es-components/src/components/containers/modal/ModalHeader.js
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+
 import DismissButton from '../../controls/DismissButton';
 import { ModalContext } from './ModalContext';
 import Heading from '../heading/Heading';
@@ -18,20 +19,13 @@ const Header = styled.div`
 `;
 
 const Title = styled(Heading)`
-  font-size: 24px;
-  font-weight: 500;
   margin: 0;
 `;
 
 const DismissModal = styled(DismissButton)`
+  align-self: center;
   color: ${props => props.theme.colors.black};
-  line-height: 1;
-  opacity: 0.2;
-  text-shadow: 0 1px 0 ${props => props.theme.colors.white};
-
-  &:hover {
-    opacity: 0.5;
-  }
+  font-size: 18px;
 `;
 
 function ModalHeader(props) {

--- a/packages/es-components/src/components/containers/modal/__snapshots__/Modal.specs.js.snap
+++ b/packages/es-components/src/components/containers/modal/__snapshots__/Modal.specs.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders different modal sections 1`] = `
 <h4
-  class="sc-ifAKCX fBKnDt sc-htpNat eNzNll"
+  class="sc-EHOje cgkaxn sc-bxivhb jjQKmu"
   id="abcdef"
 >
   Header
@@ -11,7 +11,7 @@ exports[`renders different modal sections 1`] = `
 
 exports[`renders different modal sections 2`] = `
 <div
-  class="sc-bZQynM eVbtnu"
+  class="sc-gzVnrw NNeXF"
 >
   Body
 </div>
@@ -19,7 +19,7 @@ exports[`renders different modal sections 2`] = `
 
 exports[`renders different modal sections 3`] = `
 <div
-  class="sc-gzVnrw iNjHaI"
+  class="sc-htoDjs hiiqld"
 >
   Footer
 </div>

--- a/packages/es-components/src/components/containers/notification/useNotification.js
+++ b/packages/es-components/src/components/containers/notification/useNotification.js
@@ -2,6 +2,7 @@ import React, { useRef, useState, useEffect } from 'react';
 import styled from 'styled-components';
 import Icon from '../../base/icons/Icon';
 import { useTheme } from '../../util/useTheme';
+import DismissButton from '../../controls/DismissButton';
 
 const NotificationIcon = styled(Icon)`
   align-self: start;
@@ -14,14 +15,15 @@ const NotificationIcon = styled(Icon)`
   }
 `;
 
-const DismissButton = styled.button`
+const Dismiss = styled(DismissButton)`
   align-self: start;
-  background-color: transparent;
-  border: 0;
   color: ${props => props.color.textColor};
-  cursor: pointer;
+  font-weight: normal;
   opacity: 0.8;
-  padding: 0;
+
+  i {
+    font-size: 27px;
+  }
 `;
 
 const ContentWrapper = styled.div`
@@ -64,11 +66,7 @@ const NotificationContent = React.forwardRef(function NotificationContent(
         <NotificationIcon name={iconName} iconColor={iconColor} size={28} />
       )}
       <ContentWrapper>{children}</ContentWrapper>
-      {isDismissable && (
-        <DismissButton onClick={dismissNotification} color={color}>
-          <Icon name="remove" size={27} />
-        </DismissButton>
-      )}
+      {isDismissable && <Dismiss onClick={dismissNotification} color={color} />}
     </>
   );
 });

--- a/packages/es-components/src/components/containers/popover/Popover.js
+++ b/packages/es-components/src/components/containers/popover/Popover.js
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-import Icon from '../../base/icons/Icon';
+import DismissButton from '../../controls/DismissButton';
 import Button from '../../controls/buttons/Button';
 import Popup from './Popup';
 
@@ -29,13 +29,14 @@ const PopoverHeader = styled.div`
 `;
 
 const TitleBar = styled.h3`
+  flex: 1 1;
   font-size: 18px;
   margin: 0;
   padding: 8px 14px;
 `;
 
 const PopoverBody = styled.div`
-  color: ${props => props.theme.colors.gray8};
+  color: ${props => props.theme.colors.gray9};
   font-size: 18px;
   font-weight: normal;
   line-height: ${props => props.theme.sizes.baseLineHeight};
@@ -54,23 +55,18 @@ const PopoverCloseButton = styled(Button)`
   width: auto;
 `;
 
-const AlternateCloseButton = styled(PopoverCloseButton)`
-  background: transparent;
-  border: none;
-  box-shadow: none;
+const AltCloseButton = styled(DismissButton)`
   color: ${props =>
-    props.hasTitle ? props.theme.colors.white : props.theme.colors.grayDark};
-  margin: 0;
-  margin-left: auto;
-  padding: 0 8px;
+    props.hasTitle ? props.theme.colors.white : props.theme.colors.black};
 
-  &:hover {
-    background: transparent;
-  }
+  flex: 0 1;
+  margin-left: auto;
+  padding: 8px;
 `;
 
 const CloseHelpText = styled.span`
   color: transparent;
+  flex: none;
   height: 1px;
   outline: 0;
   width: 1px;
@@ -138,14 +134,12 @@ function Popover(props) {
   );
 
   const altCloseButton = (
-    <AlternateCloseButton
+    <AltCloseButton
       aria-label="Close"
       hasTitle={hasTitle}
       onClick={toggleShow}
       ref={closeBtnRef}
-    >
-      <Icon name="remove" />
-    </AlternateCloseButton>
+    />
   );
 
   function hidePopOnScroll() {
@@ -222,7 +216,7 @@ Popover.propTypes = {
   /** The name of the popover. Used for differentiating popovers */
   name: PropTypes.string.isRequired,
   /** The text displayed in the popover title section */
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   /** The content displayed in the popover body */
   content: PropTypes.node.isRequired,
   /** The placement of the popover in relation to the link */
@@ -247,7 +241,8 @@ Popover.defaultProps = {
   disableRootClose: false,
   hasCloseButton: false,
   hasAltCloseButton: false,
-  disableFlipping: false
+  disableFlipping: false,
+  title: undefined
 };
 
 export default Popover;

--- a/packages/es-components/src/components/containers/popover/Popover.md
+++ b/packages/es-components/src/components/containers/popover/Popover.md
@@ -91,9 +91,8 @@ const styles = {
 Here's an example of a
 <Popover
     name="popEx"
-    title="Popover"
     content="This is the popover's content. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch."
-    hasCloseButton
+    hasAltCloseButton
     renderTrigger={({ ref, toggleShow, isOpen }) => (
       <PopoverLink
         onClick={toggleShow}

--- a/packages/es-components/src/components/controls/DismissButton.js
+++ b/packages/es-components/src/components/controls/DismissButton.js
@@ -1,22 +1,32 @@
 import React from 'react';
 import styled from 'styled-components';
 import screenReaderOnly from '../patterns/screenReaderOnly/screenReaderOnly';
+import Icon from '../base/icons/Icon';
 
 const DismissButtonBase = styled.button`
-  background: transparent;
+  background-color: transparent;
   border: 0;
   cursor: pointer;
-  font-size: 27px;
+  display: flex;
   font-weight: bold;
+  opacity: 0.2;
+  padding: 0;
+
+  &:hover,
+  &:focus {
+    opacity: 0.5;
+  }
 `;
 
 const ScreenReaderText = screenReaderOnly('span');
 
-const DismissButton = props => (
-  <DismissButtonBase aria-label="Close" type="button" {...props}>
-    <span aria-hidden="true">×</span>
-    <ScreenReaderText>Close</ScreenReaderText>
-  </DismissButtonBase>
-);
+const DismissButton = React.forwardRef(function DismissButton(props, ref) {
+  return (
+    <DismissButtonBase aria-label="Close" type="button" {...props}>
+      <Icon name="remove" />
+      <ScreenReaderText>Close</ScreenReaderText>
+    </DismissButtonBase>
+  );
+});
 
 export default DismissButton;

--- a/packages/es-components/src/components/controls/buttons/OutlineButton.js
+++ b/packages/es-components/src/components/controls/buttons/OutlineButton.js
@@ -31,7 +31,7 @@ const StyledButton = styled.button`
 
   @media (min-width: ${props => props.theme.screenSize.tablet}) {
     display: ${props => (props.block ? 'block' : 'inline-block')};
-    width: ${props => (props.block ? '100%' : 'initial')};
+    width: ${props => (props.block ? '100%' : 'auto')};
   }
 
   &:hover {

--- a/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
@@ -35,6 +35,10 @@ const RadioLabel = styled(Label)`
   padding: 10px 0 10px 10px;
   text-transform: none;
 
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+
   &:hover .es-radio__fill:before {
     ${props => !props.checked && radioFill(props.hoverFillColor)};
   }

--- a/packages/es-components/src/components/patterns/dateInput/DateInput.md
+++ b/packages/es-components/src/components/patterns/dateInput/DateInput.md
@@ -10,7 +10,7 @@ Using the `onChange` callback returns an object:
 The `value` is a Date created from the combined inputs. The `value` is `undefined` when the date is invalid.
 `isInRange` is provided for validation help.
 
-`DateInput.Month` also accepts an array of month names for localization support.
+`DateInput.Month` also accepts an array of month names (`monthName` prop) for localization support.
 
 ```
 const Control = require('../../controls/Control').default;
@@ -34,7 +34,7 @@ function DateInputExample() {
     <Control validationState={validation}>
       <Label htmlFor="someDate">Enter a Date</Label>
       <DateInput id="someDate" name="someDate" onChange={handleChange} onBlur={handleOnBlur}>
-        <DateInput.Month />
+        <DateInput.Month monthNames={['01 - Jan', '02 - Feb', '03 - Mar']} />
         <DateInput.Day />
         <DateInput.Year />
       </DateInput>


### PR DESCRIPTION
1. Made `Popover` `title` not required. 
2. Consistent use of `DismissButton` across `Popover`, `ModalHeader`, `Menu`, and `Notification`.
3. Small style changes to `Popover` text color, `RadioButton` (no bottom margin on last button).
4. Added `DateInput` example with `monthNames`.
5. Fixed OutlineButton width: initial issue. Changed to width: auto. #339 