### PR TITLE
New: add inherited button style type

### DIFF
--- a/packages/es-components-via-theme/index.js
+++ b/packages/es-components-via-theme/index.js
@@ -265,6 +265,15 @@ const theme = {
           activeBgColor: dangerHover,
           activeTextColor: white,
           boxShadowColor: dangerHover
+        },
+        inherited: {
+          bgColor: 'inherit',
+          textColor: 'inherit',
+          hoverBgColor: 'inherit',
+          hoverTextColor: 'inherit',
+          activeBgColor: 'inherit',
+          activeTextColor: 'inherit',
+          boxShadowColor: 'inherit'
         }
       },
       // size should always have default, lg, sm, xs
@@ -388,6 +397,15 @@ const theme = {
           activeBgColor: '#4d1659',
           activeTextColor: white,
           borderColor: '#702082'
+        },
+        inherited: {
+          bgColor: 'inherit',
+          textColor: 'inherit',
+          hoverBgColor: 'inherit',
+          hoverTextColor: 'inherit',
+          activeBgColor: 'inherit',
+          activeTextColor: 'inherit',
+          boxShadowColor: 'inherit'
         }
       },
       size: {

--- a/packages/es-components-wtw-theme/index.js
+++ b/packages/es-components-wtw-theme/index.js
@@ -263,6 +263,15 @@ const theme = {
           activeBgColor: dangerHover,
           activeTextColor: white,
           boxShadowColor: dangerHover
+        },
+        inherited: {
+          bgColor: 'inherit',
+          textColor: 'inherit',
+          hoverBgColor: 'inherit',
+          hoverTextColor: 'inherit',
+          activeBgColor: 'inherit',
+          activeTextColor: 'inherit',
+          boxShadowColor: 'inherit'
         }
       },
       // size should always have default, lg, sm, xs
@@ -358,6 +367,15 @@ const theme = {
           activeBgColor: dangerHover,
           activeTextColor: white,
           borderColor: danger
+        },
+        inherited: {
+          bgColor: 'inherit',
+          textColor: 'inherit',
+          hoverBgColor: 'inherit',
+          hoverTextColor: 'inherit',
+          activeBgColor: 'inherit',
+          activeTextColor: 'inherit',
+          boxShadowColor: 'inherit'
         }
       },
       size: {

--- a/packages/es-components/src/components/controls/buttons/LinkButton.md
+++ b/packages/es-components/src/components/controls/buttons/LinkButton.md
@@ -5,3 +5,11 @@ Additional props supplied to the LinkButton component will be passed to the unde
 ```
 <LinkButton styleType="primary">Link Button Example</LinkButton>
 ```
+
+Use the `inherited` styleType in order to inherit colors from the parent.
+
+```
+<div style={{ color: "red" }}>
+  <LinkButton styleType="inherited">I am red because of my parent!</LinkButton>
+</div>
+```


### PR DESCRIPTION
Add new inherited button style type. This will allow buttons to inherit colors from its closest parent. This is typically only going to be useful for link buttons.