### PR TITLE
New: create a new button style object for link buttons

### DIFF
--- a/packages/es-components-via-theme/index.js
+++ b/packages/es-components-via-theme/index.js
@@ -443,6 +443,38 @@ const theme = {
           textTransform: 'uppercase'
         }
       }
+    },
+    linkButton: {
+      variant: {
+        default: {
+          textColor: defaultColor,
+          hoverTextColor: defaultHover
+        },
+        primary: {
+          textColor: primary,
+          hoverTextColor: primaryHover
+        },
+        success: {
+          textColor: success,
+          hoverTextColor: successHover
+        },
+        information: {
+          textColor: info,
+          hoverTextColor: infoHover,
+        },
+        danger: {
+          textColor: danger,
+          hoverTextColor: dangerHover
+        },
+        warning: {
+          textColor: warning,
+          hoverTextColor: warningHover
+        },
+        inherited: {
+          textColor: 'inherit',
+          hoverTextColor: 'inherit'
+        }
+      }
     }
   },
   validationIconName: {

--- a/packages/es-components-wtw-theme/index.js
+++ b/packages/es-components-wtw-theme/index.js
@@ -413,6 +413,38 @@ const theme = {
           textTransform: 'uppercase'
         }
       }
+    },
+    linkButton: {
+      variant: {
+        default: {
+          textColor: defaultColor,
+          hoverTextColor: defaultHover
+        },
+        primary: {
+          textColor: primary,
+          hoverTextColor: primaryHover
+        },
+        success: {
+          textColor: success,
+          hoverTextColor: successHover
+        },
+        information: {
+          textColor: info,
+          hoverTextColor: infoHover,
+        },
+        danger: {
+          textColor: danger,
+          hoverTextColor: dangerHover
+        },
+        warning: {
+          textColor: warning,
+          hoverTextColor: warningHover
+        },
+        inherited: {
+          textColor: 'inherit',
+          hoverTextColor: 'inherit'
+        }
+      }
     }
   },
   validationIconName: {

--- a/packages/es-components/src/components/controls/buttons/LinkButton.js
+++ b/packages/es-components/src/components/controls/buttons/LinkButton.js
@@ -8,7 +8,7 @@ const StyledButton = styled.button`
   border: none;
   box-shadow: none;
   cursor: pointer;
-  color: ${props => props.variant.bgColor};
+  color: ${props => props.variant.textColor};
   font-size: inherit;
   line-height: ${props => props.theme.sizes.baseLineHeight};
   padding: 0;
@@ -17,7 +17,7 @@ const StyledButton = styled.button`
   &:hover,
   &:focus,
   &:active {
-    color: ${props => props.variant.hoverBgColor};
+    color: ${props => props.variant.hoverTextColor};
     text-decoration: none;
   }
 
@@ -26,7 +26,7 @@ const StyledButton = styled.button`
   }
 
   &[disabled]:hover {
-    color: ${props => props.variant.bgColor};
+    color: ${props => props.variant.textColor};
     text-decoration: underline;
   }
 `;
@@ -34,7 +34,7 @@ const StyledButton = styled.button`
 const LinkButton = React.forwardRef(function LinkButton(props, ref) {
   const { children, styleType, ...other } = props;
   const theme = useTheme();
-  const variant = theme.buttonStyles.button.variant[styleType];
+  const variant = theme.buttonStyles.linkButton.variant[styleType];
 
   return (
     <StyledButton ref={ref} variant={variant} type="button" {...other}>

--- a/packages/es-components/src/components/controls/buttons/LinkButton.md
+++ b/packages/es-components/src/components/controls/buttons/LinkButton.md
@@ -3,8 +3,17 @@ Additional props supplied to the LinkButton component will be passed to the unde
 ## LinkButton Style Types
 
 ```
-<LinkButton styleType="primary">Link Button Example</LinkButton>
+<p>
+  <LinkButton styleType="primary">Primary</LinkButton><br />
+  <LinkButton styleType="success">Success</LinkButton><br />
+  <LinkButton styleType="information">Info</LinkButton><br />
+  <LinkButton styleType="warning">Warning</LinkButton><br />
+  <LinkButton styleType="danger">Danger</LinkButton><br />
+</p>
 ```
+
+
+
 
 Use the `inherited` styleType in order to inherit colors from the parent.
 

--- a/packages/es-components/src/components/controls/buttons/PopoverLink.js
+++ b/packages/es-components/src/components/controls/buttons/PopoverLink.js
@@ -22,7 +22,7 @@ const StyledButton = styled(LinkButton)`
 const PopoverLink = React.forwardRef(function PopoverLink(props, ref) {
   const { children, styleType, suppressUnderline, ...other } = props;
   const theme = useTheme();
-  const variant = theme.buttonStyles.button.variant[styleType];
+  const variant = theme.buttonStyles.linkButton.variant[styleType];
 
   return (
     <StyledButton


### PR DESCRIPTION
Trying to manage use the button styles for both links and button links has caused headaches downstream. Make the button link styles a first class citizen.