### PR TITLE
Upgrade: use date-fns@next in DatePicker

### DIFF
--- a/packages/es-components/package-lock.json
+++ b/packages/es-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components",
-  "version": "19.0.43",
+  "version": "19.0.50",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4448,9 +4448,9 @@
       }
     },
     "date-fns": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
-      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw=="
+      "version": "2.0.0-alpha.31",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.0-alpha.31.tgz",
+      "integrity": "sha512-S19PwMqnbYsqcbCg02Yj9gv4veVNZ0OX7v2+zcd+Mq0RI7LoDKJipJjnMrTZ3Cc6blDuTce5G/pHXcVIGRwJWQ=="
     },
     "date-now": {
       "version": "0.1.4",
@@ -15414,7 +15414,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -85,7 +85,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.3.4",
-    "date-fns": "^1.29.0",
+    "date-fns": "^2.0.0-alpha.31",
     "lodash": "^4.17.11",
     "prop-types": "^15.7.2",
     "react-animate-height": "^2.0.9",

--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.md
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.md
@@ -1,6 +1,6 @@
 Based on <a href="https://hacker0x01.github.io/react-datepicker" target="blank">React-Datepicker</a> and supports most of the props documented there.
 
-Passes props through to the TextBox component for additional functionality (for example: validationState).
+Props are passed props through to the TextBox component unless they belong to the set of React Datepicker props.
 
 **Keyboard support**
 
@@ -13,11 +13,6 @@ Passes props through to the TextBox component for additional functionality (for 
 - Home: Move to the previous year
 - End: Move to the next year
 - Enter/Esc/Tab: Close the calendar
-
-### Events
-
-The `DatePicker` component supports event handlers for `onChange`, `onBlur`, and `onChangeRaw`. The `onChange` event will return a Date object representing the selected date, and only fires when a valid date is selected. The `onBlur` and `onChangeRaw` events will return an event with the raw value of the input.
-
 ```
 const Control = require('../../controls/Control').default;
 const AdditionalHelp = require('../../controls/AdditionalHelp').default;
@@ -63,8 +58,8 @@ function DatePickerExample() {
 ### Date Ranges
 
 ```
-const addDays = require('date-fns/add_days');
-const isAfter = require('date-fns/is_after');
+const addDays = require('date-fns').addDays;
+const isAfter = require('date-fns').isAfter;
 
 const Control = require('../../controls/Control').default;
 
@@ -160,12 +155,13 @@ function DatePickerExample() {
 <DatePickerExample />
 ```
 
+
 ### Filter Dates
 
 The `filterDate` prop accepts a function used to filter the available dates.
 
 ```
-const getDay = require('date-fns/get_day');
+const getDay = require('date-fns').getDay;
 const Control = require('../../controls/Control').default;
 
 function DatePickerExample() {
@@ -200,7 +196,7 @@ function DatePickerExample() {
 ### Include Dates (whitelist)
 
 ```
-const addDays = require('date-fns/add_days');
+const addDays = require('date-fns').addDays;
 const Control = require('../../controls/Control').default;
 
 function DatePickerExample() {
@@ -230,7 +226,7 @@ function DatePickerExample() {
 ### Exclude Dates (blacklist)
 
 ```
-const addDays = require('date-fns/add_days');
+const addDays = require('date-fns').addDays;
 const Control = require('../../controls/Control').default;
 
 function DatePickerExample() {


### PR DESCRIPTION
Use the alpha version of date-fns in the DatePicker. There were some confusing bits in the datepicker code that I hope I made a bit more clear. I also got rid of all the props that are only pass throughs to ReactDatePicker.