### PR TITLE
Update: added selectOptionText prop to DateInput

### DIFF
--- a/packages/es-components/src/components/patterns/dateInput/DateInput.js
+++ b/packages/es-components/src/components/patterns/dateInput/DateInput.js
@@ -1,4 +1,4 @@
-import React, { useReducer } from 'react';
+import React, { useEffect, useReducer } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { isBefore, isAfter } from 'date-fns';
@@ -57,10 +57,21 @@ function DateInput({
     year: defaultValue ? defaultValue.getFullYear().toString() : ''
   });
 
+  useEffect(() => {
+    React.Children.forEach(children, child => {
+      if (child.type.name === 'Month') {
+        if (child.props.selectOptionText) {
+          dispatch({ type: 'month_updated', value: 'none' });
+        }
+      }
+    });
+  }, []);
+
   function createDate(year, month, day) {
     const cleanDay = day ? cleanZeroes(day.toString()) : day;
     const date = new Date(`${year}/${month}/${cleanDay}`);
     const dateIsValid =
+      month !== 'none' &&
       year.length === 4 &&
       (day ? date.getDate().toString() === cleanDay : true) &&
       (month ? (date.getMonth() + 1).toString() === month.toString() : true) &&

--- a/packages/es-components/src/components/patterns/dateInput/DateInput.md
+++ b/packages/es-components/src/components/patterns/dateInput/DateInput.md
@@ -10,7 +10,8 @@ Using the `onChange` callback returns an object:
 The `value` is a Date created from the combined inputs. The `value` is `undefined` when the date is invalid.
 `isInRange` is provided for validation help.
 
-`DateInput.Month` also accepts an array of month names (`monthName` prop) for localization support.
+`DateInput.Month` also accepts an array of month names (`monthName` prop) for localization support. You may also
+provide `selectOptionText` to define a default "Please select a Month"-style option.
 
 ```
 const Control = require('../../controls/Control').default;
@@ -19,11 +20,12 @@ const AdditionalHelp = require('../../controls/AdditionalHelp').default;
 function DateInputExample() {
   const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
   const [myDate, setMyDate] = React.useState();
-  const [validation, setValidation] = React.useState();
+  const [validation, setValidation] = React.useState('default');
 
   function handleChange(date) {
     console.log(date);
     setMyDate(date.value);
+    setValidation('default');
   }
 
   function handleOnBlur() {
@@ -34,7 +36,7 @@ function DateInputExample() {
     <Control validationState={validation}>
       <Label htmlFor="someDate">Enter a Date</Label>
       <DateInput id="someDate" name="someDate" onChange={handleChange} onBlur={handleOnBlur}>
-        <DateInput.Month monthNames={['01 - Jan', '02 - Feb', '03 - Mar']} />
+        <DateInput.Month monthNames={['01 - Jan', '02 - Feb', '03 - Mar']} selectOptionText="Select a month" />
         <DateInput.Day />
         <DateInput.Year />
       </DateInput>

--- a/packages/es-components/src/components/patterns/dateInput/Month.js
+++ b/packages/es-components/src/components/patterns/dateInput/Month.js
@@ -10,7 +10,7 @@ const MonthDropdown = styled(Dropdown)`
   flex: 3 1 100px;
 `;
 
-function Month({ onChange, monthNames, date, ...props }) {
+function Month({ onChange, monthNames, selectOptionText, date, ...props }) {
   const theme = useTheme();
   const validationState = React.useContext(ValidationContext);
   const [month, setMonth] = React.useState(date ? date.getMonth() + 1 : '');
@@ -27,6 +27,7 @@ function Month({ onChange, monthNames, date, ...props }) {
       value={month}
       {...props}
     >
+      {selectOptionText && <option value="none">{selectOptionText}</option>}
       {monthNames.map((value, index) => (
         <option value={index + 1} key={value}>
           {value}
@@ -38,7 +39,9 @@ function Month({ onChange, monthNames, date, ...props }) {
 
 Month.propTypes = {
   /** array of month names */
-  monthNames: PropTypes.array
+  monthNames: PropTypes.array,
+  /** adds an unselected option at the top */
+  selectOptionText: PropTypes.string
 };
 
 Month.defaultProps = {
@@ -55,7 +58,8 @@ Month.defaultProps = {
     'October',
     'November',
     'December'
-  ]
+  ],
+  selectOptionText: undefined
 };
 
 export default Month;


### PR DESCRIPTION
Adds a new prop to Month to insert a "select a month" option into the dropdown. This forces the user to actually select an option rather than skipping it and leaving it on the default January option.

Addresses WE-5091