### PR TITLE
Update: CDN links, font references

### DIFF
--- a/packages/es-components/src/components/base/icons/Icon.js
+++ b/packages/es-components/src/components/base/icons/Icon.js
@@ -6,7 +6,7 @@ import { regular } from './icon-definitions';
 
 const StyledIcon = styled.i`
   display: inline-block;
-  font-family: ${props => props.fontFamily} !important;
+  font-family: indv-mkt-icons !important;
   font-size: ${props => props.fontSize};
   font-style: normal;
   font-weight: inherit;
@@ -29,7 +29,6 @@ function Icon({ name, size, ...other }) {
 
   const styledIconProps = {
     content: regular[iconName],
-    fontFamily: 'indv-mkt-icons',
     fontSize: size !== undefined ? `${size}px` : 'inherit'
   };
 

--- a/packages/es-components/src/components/base/icons/Icon.md
+++ b/packages/es-components/src/components/base/icons/Icon.md
@@ -1,4 +1,4 @@
-Icons will inherit their size unless otherwise specified. <a href="https://wtw-bdaim-cdn.azureedge.net/es-assets/es-assets-master/font-demo.html" target="blank">This page</a> displays all the available icons.
+Icons will inherit their size unless otherwise specified. <a href="https://bdaim-webexcdn-p.azureedge.net/es-assets/icon-demo.html" target="blank">This page</a> displays all the available icons.
 
 ```
 const containerStyle = {
@@ -17,8 +17,8 @@ const containerStyle = {
 </div>
 ```
 
-**Note:** Icons require the `indv-mkt-icons` font from [es-assets](https://github.com/WTW-IM/es-assets). You can use the following link to reference the required font styles in your project:
+**Note:** Icons require the `indv-mkt-icons` font. Use the following link to include the required font in your project:
 
 ```html
-  <link rel="stylesheet" href="https://wtw-bdaim-cdn.azureedge.net/es-assets/es-assets-master/font.css">
+<link rel="stylesheet" href="https://bdaim-webexcdn-p.azureedge.net/es-assets/icons.css" />
 ```

--- a/packages/es-components/src/components/containers/heading/Heading.js
+++ b/packages/es-components/src/components/containers/heading/Heading.js
@@ -8,11 +8,13 @@ const HeadingBase = styled.h1`
   border-bottom: ${props =>
     props.underlineColor && `2px solid ${props.underlineColor};`};
   color: ${props => (props.isKnockoutStyle ? 'white' : 'inherit')};
+  font-family: 'SourceSansPro-Light', 'Segoe UI', Segoe, Calibri, Tahoma,
+    sans-serif;
   font-size: ${props =>
     props.adjustedSize > 2
       ? props.theme.headingSize[props.adjustedSize]
       : `calc(${props.theme.headingSize[props.adjustedSize]} - 6px);`};
-  font-weight: 300;
+  font-weight: normal;
   line-height: 1.1;
   margin-bottom: 0.45em;
   margin-top: 0;

--- a/packages/es-components/src/components/containers/heading/__snapshots__/Heading.specs.js.snap
+++ b/packages/es-components/src/components/containers/heading/__snapshots__/Heading.specs.js.snap
@@ -4,17 +4,17 @@ exports[`renders heading level with another size 1`] = `
 <div>
   <div>
     <h1
-      class="sc-bdVaJa mpAKb"
+      class="sc-bdVaJa glmyfY"
     >
       Heading level 1
     </h1>
     <h3
-      class="sc-bdVaJa dfMvbW"
+      class="sc-bdVaJa hxFzhR"
     >
       Heading level 3
     </h3>
     <h3
-      class="sc-bdVaJa mpAKb"
+      class="sc-bdVaJa glmyfY"
     >
       Heading level 3 size 1
     </h3>
@@ -26,12 +26,12 @@ exports[`renders knockout heading with different class 1`] = `
 <div>
   <div>
     <h1
-      class="sc-bdVaJa mpAKb"
+      class="sc-bdVaJa glmyfY"
     >
       Heading level 1
     </h1>
     <h1
-      class="sc-bdVaJa eJSayt"
+      class="sc-bdVaJa elAebA"
     >
       Knockout Heading level 1
     </h1>

--- a/packages/es-components/src/components/containers/modal/Modal.js
+++ b/packages/es-components/src/components/containers/modal/Modal.js
@@ -68,7 +68,8 @@ const ModalContent = styled.div`
   background-color: ${props => props.theme.colors.white};
   border-radius: 3px;
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
-  font-family: 'Source Sans Pro', 'Segoe UI', Segoe, Calibri, Tahoma, sans-serif;
+  font-family: 'SourceSansPro-Regular', 'Segoe UI', Segoe, Calibri, Tahoma,
+    sans-serif;
   font-size: ${props => props.theme.sizes.baseFontSize};
   outline: 0;
   position: relative;

--- a/packages/es-components/src/components/containers/modal/ModalHeader.js
+++ b/packages/es-components/src/components/containers/modal/ModalHeader.js
@@ -13,7 +13,6 @@ const Header = styled.div`
   color: ${props => props.theme.colors.gray9};
   display: flex;
   font-size: 26px;
-  font-weight: 500;
   justify-content: space-between;
   padding: 15px;
 `;

--- a/packages/es-components/src/components/containers/modal/__snapshots__/Modal.specs.js.snap
+++ b/packages/es-components/src/components/containers/modal/__snapshots__/Modal.specs.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders different modal sections 1`] = `
 <h4
-  class="sc-EHOje cgkaxn sc-bxivhb jjQKmu"
+  class="sc-EHOje cgkaxn sc-bxivhb fKhwyl"
   id="abcdef"
 >
   Header

--- a/packages/es-components/src/components/containers/tooltip/Tooltip.js
+++ b/packages/es-components/src/components/containers/tooltip/Tooltip.js
@@ -17,7 +17,8 @@ const TooltipInner = styled.div`
   background-color: ${props => props.theme.colors.softwareBlue};
   border-radius: 2px;
   color: ${props => props.theme.colors.white};
-  font-family: 'Source Sans Pro', 'Segoe UI', Segoe, Calibri, Tahoma, sans-serif;
+  font-family: 'SourceSansPro-Regular', 'Segoe UI', Segoe, Calibri, Tahoma,
+    sans-serif;
   font-size: 15px;
   line-height: ${props => props.theme.sizes.baseLineHeight};
   max-width: 250px;

--- a/packages/es-components/src/components/controls/label/Label.js
+++ b/packages/es-components/src/components/controls/label/Label.js
@@ -3,8 +3,11 @@ import styled from 'styled-components';
 const Label = styled.label`
   color: ${props => props.theme.colors.gray9};
   cursor: pointer;
+  font-family: 'SourceSansPro-Bold', 'Segoe UI', Segoe, Calibri, Tahoma,
+    sans-serif;
   font-size: ${props => props.theme.sizes.baseFontSize};
-  font-weight: 700;
+  font-weight: bold;
+  line-height: ${props => props.theme.sizes.baseLineHeight};
   margin-bottom: 5px;
   display: inline-block;
 

--- a/packages/es-components/src/components/patterns/dateInput/__snapshots__/DateInput.specs.js.snap
+++ b/packages/es-components/src/components/patterns/dateInput/__snapshots__/DateInput.specs.js.snap
@@ -6,7 +6,7 @@ exports[`displays monthNames provided by the monthNames prop 1`] = `
     class="sc-bdVaJa cGXwXX"
   >
     <label
-      class="sc-bwzfXH erYDxf"
+      class="sc-bwzfXH izGnNm"
       for="test"
     >
       Text
@@ -64,7 +64,7 @@ exports[`hides the Day input when Day is excluded 1`] = `
     class="sc-bdVaJa cGXwXX"
   >
     <label
-      class="sc-bwzfXH erYDxf"
+      class="sc-bwzfXH izGnNm"
       for="test"
     >
       Text

--- a/packages/es-components/src/components/theme/Themes.md
+++ b/packages/es-components/src/components/theme/Themes.md
@@ -7,14 +7,15 @@ import { ThemeProvider } from 'styled-components';
 import viaTheme from 'es-components-via-theme';
 
 ...
+
 render(
-	<ThemeProvider theme={viaTheme}>
-		<MyComponentOrApp />
-	</ThemeProvider>
+  <ThemeProvider theme={viaTheme}>
+    <MyComponentOrApp />
+  </ThemeProvider>
 );
 ```
 
-The [via benefits theme](https://www.npmjs.com/package/es-components-via-theme) is applied to all the components in this styleguide. To create your own theme, [copy the theme here](https://github.com/WTW-IM/es-components/blob/a05ccfacd68da862413f4bf38a804aa4c607eb48/packages/es-components-via-theme/index.js), modify the values, and supply that object to the `ThemeProvider`.
+The [via benefits theme](https://www.npmjs.com/package/es-components-via-theme) is applied to all the components in this styleguide. To create your own theme, [copy the theme here](https://github.com/WTW-IM/es-components/blob/master/packages/es-components-via-theme/index.js), modify the values, and supply that object to the `ThemeProvider`.
 
 ### Theme colors
 
@@ -47,14 +48,10 @@ The [via benefits theme](https://www.npmjs.com/package/es-components-via-theme) 
 
 ### Fonts
 
-Apart from the icon set, this library does not have a specific typography and should work with whatever font you have defined in your project. Our UX team's font of choice for
-our applications is `Source Sans Pro`. You can use the font in your project either by getting it from the UX team, or linking to [google's CDN](https://fonts.google.com/specimen/Source+Sans+Pro):
+Our web app font of choice is *Source Sans Pro*. Import it by adding the following to your application:
 
 ```html
-<link
-	href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,200i,300,300i,400,400i,600,600i,700,700i,900,900i"
-	rel="stylesheet"
->
+<link rel="stylesheet" href="https://bdaim-webexcdn-p.azureedge.net/es-assets/source-sans-pro.css" />
 ```
 
 ### Styles
@@ -67,6 +64,7 @@ element anywhere in your app.
 import StyleReset from 'es-components';
 
 ...
+
 render(
   <>
     <StyleReset />

--- a/packages/es-components/src/components/util/StyleReset.js
+++ b/packages/es-components/src/components/util/StyleReset.js
@@ -11,7 +11,7 @@ const StyleReset = createGlobalStyle`
   menu, nav, output, ruby, section, summary,
   time, mark, audio, video {
     border: 0;
-    font: inherit;
+    font-family: 'SourceSansPro-Regular', 'Segoe UI', Segoe, Calibri, Tahoma, sans-serif;
     font-size: 100%;
     margin: 0;
     padding: 0;
@@ -37,10 +37,14 @@ const StyleReset = createGlobalStyle`
     font-size: 85%;
   }
 
+  strong, b {
+    font-family: 'SourceSansPro-Bold', 'Segoe UI', Segoe, Calibri, Tahoma, sans-serif;
+  }
+
   h1, h2, h3, h4, h5, h6 {
     color: inherit;
     font: inherit;
-    font-weight: 300;
+    font-family: 'SourceSansPro-Light', 'Segoe UI', Segoe, Calibri, Tahoma, sans-serif;
     line-height: 1.1;
     margin-bottom: 0.45em;
     margin-top: 0;

--- a/packages/es-components/styleguide.config.js
+++ b/packages/es-components/styleguide.config.js
@@ -31,8 +31,8 @@ module.exports = {
           word-break: break-word !important;
         }
       </style>
-      <link rel="stylesheet" href="https://wtw-bdaim-cdn.azureedge.net/es-assets/es-assets-master/font.css">
-      <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,200i,300,300i,400,400i,600,600i,700,700i,900,900i" rel="stylesheet">
+      <link rel="stylesheet" href="https://bdaim-webexcdn-p.azureedge.net/es-assets/icons.css">
+      <link rel="stylesheet" href="https://bdaim-webexcdn-p.azureedge.net/es-assets/source-sans-pro.css">
       <script src="https://unpkg.com/@babel/polyfill@7.0.0/dist/polyfill.min.js"></script>
     `
     }


### PR DESCRIPTION
Our asset CDN has been set up on a new Azure endpoint, so we need to update our references. I also added the Source Sans Pro font to our CDN so we can exactly match the BDA Toolkit, as the Google-hosted one was a little different (it used the regular variant for bold and light).

We'll need to update other projects with the new CDN URL as well.