### PR TITLE
Unified Source Sans Pro fix

### DIFF
--- a/packages/es-components/src/components/containers/heading/Heading.js
+++ b/packages/es-components/src/components/containers/heading/Heading.js
@@ -8,13 +8,12 @@ const HeadingBase = styled.h1`
   border-bottom: ${props =>
     props.underlineColor && `2px solid ${props.underlineColor};`};
   color: ${props => (props.isKnockoutStyle ? 'white' : 'inherit')};
-  font-family: 'SourceSansPro-Light', 'Source Sans Pro', 'Segoe UI', Segoe,
-    Calibri, Tahoma, sans-serif;
+  font-family: 'Source Sans Pro', 'Segoe UI', Segoe, Calibri, Tahoma, sans-serif;
   font-size: ${props =>
     props.adjustedSize > 2
       ? props.theme.headingSize[props.adjustedSize]
       : `calc(${props.theme.headingSize[props.adjustedSize]} - 6px);`};
-  font-weight: normal;
+  font-weight: 300;
   line-height: 1.1;
   margin-bottom: 0.45em;
   margin-top: 0;

--- a/packages/es-components/src/components/containers/heading/__snapshots__/Heading.specs.js.snap
+++ b/packages/es-components/src/components/containers/heading/__snapshots__/Heading.specs.js.snap
@@ -4,17 +4,17 @@ exports[`renders heading level with another size 1`] = `
 <div>
   <div>
     <h1
-      class="sc-bdVaJa gPKHyT"
+      class="sc-bdVaJa fBcbFy"
     >
       Heading level 1
     </h1>
     <h3
-      class="sc-bdVaJa jlHEae"
+      class="sc-bdVaJa eINuct"
     >
       Heading level 3
     </h3>
     <h3
-      class="sc-bdVaJa gPKHyT"
+      class="sc-bdVaJa fBcbFy"
     >
       Heading level 3 size 1
     </h3>
@@ -26,12 +26,12 @@ exports[`renders knockout heading with different class 1`] = `
 <div>
   <div>
     <h1
-      class="sc-bdVaJa gPKHyT"
+      class="sc-bdVaJa fBcbFy"
     >
       Heading level 1
     </h1>
     <h1
-      class="sc-bdVaJa coQhuw"
+      class="sc-bdVaJa jEjnXU"
     >
       Knockout Heading level 1
     </h1>

--- a/packages/es-components/src/components/containers/modal/Modal.js
+++ b/packages/es-components/src/components/containers/modal/Modal.js
@@ -68,8 +68,7 @@ const ModalContent = styled.div`
   background-color: ${props => props.theme.colors.white};
   border-radius: 3px;
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
-  font-family: 'SourceSansPro-Regular', 'Source Sans Pro', 'Segoe UI', Segoe,
-    Calibri, Tahoma, sans-serif;
+  font-family: 'Source Sans Pro', 'Segoe UI', Segoe, Calibri, Tahoma, sans-serif;
   font-size: ${props => props.theme.sizes.baseFontSize};
   outline: 0;
   position: relative;

--- a/packages/es-components/src/components/containers/modal/__snapshots__/Modal.specs.js.snap
+++ b/packages/es-components/src/components/containers/modal/__snapshots__/Modal.specs.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders different modal sections 1`] = `
 <h4
-  class="sc-EHOje cgkaxn sc-bxivhb exNUJO"
+  class="sc-EHOje cgkaxn sc-bxivhb flpGBz"
   id="abcdef"
 >
   Header

--- a/packages/es-components/src/components/containers/table/ResponsiveTable.js
+++ b/packages/es-components/src/components/containers/table/ResponsiveTable.js
@@ -5,8 +5,8 @@ import Table from './Table';
 const TableBase = styled(Table)`
   tbody {
     th {
-      font-family: 'SourceSansPro-Regular', 'Source Sans Pro', 'Segoe UI', Segoe,
-        Calibri, Tahoma, sans-serif;
+      font-family: 'Source Sans Pro', 'Segoe UI', Segoe, Calibri, Tahoma,
+        sans-serif;
       font-weight: normal;
     }
   }
@@ -44,16 +44,12 @@ const TableBase = styled(Table)`
 
         &:before {
           content: attr(data-label);
-          font-family: 'SourceSansPro-Bold', 'Source Sans Pro', 'Segoe UI',
-            Segoe, Calibri, Tahoma, sans-serif;
+          font-family: 'Source Sans Pro', 'Segoe UI', Segoe, Calibri, Tahoma,
+            sans-serif;
           font-weight: bold;
           margin-right: 2em;
           max-width: 25%;
           text-align: left;
-
-          @-moz-document url-prefix() {
-            font-weight: lighter !important;
-          }
         }
 
         &:first-child {

--- a/packages/es-components/src/components/containers/table/Table.js
+++ b/packages/es-components/src/components/containers/table/Table.js
@@ -31,17 +31,13 @@ const TableBase = styled.table`
   }
 
   th {
-    font-family: 'SourceSansPro-Bold', 'Source Sans Pro', 'Segoe UI', Segoe,
-      Calibri, Tahoma, sans-serif;
+    font-family: 'Source Sans Pro', 'Segoe UI', Segoe, Calibri, Tahoma,
+      sans-serif;
     font-weight: bold;
     line-height: ${props => props.theme.sizes.baseLineHeight};
     padding: ${props => props.cellPadding};
     text-align: left;
     vertical-align: bottom;
-
-    @-moz-document url-prefix() {
-      font-weight: lighter !important;
-    }
   }
 
   td {

--- a/packages/es-components/src/components/containers/tooltip/Tooltip.js
+++ b/packages/es-components/src/components/containers/tooltip/Tooltip.js
@@ -17,8 +17,7 @@ const TooltipInner = styled.div`
   background-color: ${props => props.theme.colors.softwareBlue};
   border-radius: 2px;
   color: ${props => props.theme.colors.white};
-  font-family: 'SourceSansPro-Regular', 'Source Sans Pro', 'Segoe UI', Segoe,
-    Calibri, Tahoma, sans-serif;
+  font-family: 'Source Sans Pro', 'Segoe UI', Segoe, Calibri, Tahoma, sans-serif;
   font-size: 15px;
   line-height: ${props => props.theme.sizes.baseLineHeight};
   max-width: 250px;

--- a/packages/es-components/src/components/controls/checkbox/Checkbox.js
+++ b/packages/es-components/src/components/controls/checkbox/Checkbox.js
@@ -17,8 +17,7 @@ const backgroundColorSelect = (checked, theme, validationState) => {
 
 const CheckboxLabel = styled(Label)`
   font-size: ${props => props.theme.sizes.baseFontSize};
-  font-family: 'SourceSansPro-Regular', 'Source Sans Pro', 'Segoe UI', Segoe,
-    Calibri, Tahoma, sans-serif;
+  font-family: 'Source Sans Pro', 'Segoe UI', Segoe, Calibri, Tahoma, sans-serif;
   font-size: ${props => props.theme.sizes.baseFontSize};
   font-weight: normal;
   line-height: ${props => props.theme.sizes.baseLineHeight};

--- a/packages/es-components/src/components/controls/label/Label.js
+++ b/packages/es-components/src/components/controls/label/Label.js
@@ -3,17 +3,12 @@ import styled from 'styled-components';
 const Label = styled.label`
   color: ${props => props.theme.colors.gray9};
   cursor: pointer;
-  font-family: 'SourceSansPro-Bold', 'Source Sans Pro', 'Segoe UI', Segoe,
-    Calibri, Tahoma, sans-serif;
+  font-family: 'Source Sans Pro', 'Segoe UI', Segoe, Calibri, Tahoma, sans-serif;
   font-size: ${props => props.theme.sizes.baseFontSize};
   font-weight: bold;
   line-height: ${props => props.theme.sizes.baseLineHeight};
   margin-bottom: 5px;
   display: inline-block;
-
-  @-moz-document url-prefix() {
-    font-weight: lighter !important;
-  }
 
   &[disabled] {
     cursor: not-allowed;

--- a/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
@@ -27,8 +27,7 @@ const RadioLabel = styled(Label)`
   align-self: flex-start;
   cursor: pointer;
   display: flex;
-  font-family: 'SourceSansPro-Regular', 'Source Sans Pro', 'Segoe UI', Segoe,
-    Calibri, Tahoma, sans-serif;
+  font-family: 'Source Sans Pro', 'Segoe UI', Segoe, Calibri, Tahoma, sans-serif;
   font-size: ${props => props.theme.sizes.baseFontSize};
   font-weight: normal;
   line-height: ${props => props.theme.sizes.baseLineHeight};

--- a/packages/es-components/src/components/patterns/dateInput/__snapshots__/DateInput.specs.js.snap
+++ b/packages/es-components/src/components/patterns/dateInput/__snapshots__/DateInput.specs.js.snap
@@ -6,7 +6,7 @@ exports[`displays monthNames provided by the monthNames prop 1`] = `
     class="sc-bdVaJa cGXwXX"
   >
     <label
-      class="sc-bwzfXH cCHUKk"
+      class="sc-bwzfXH kAShKy"
       for="test"
     >
       Text
@@ -64,7 +64,7 @@ exports[`hides the Day input when Day is excluded 1`] = `
     class="sc-bdVaJa cGXwXX"
   >
     <label
-      class="sc-bwzfXH cCHUKk"
+      class="sc-bwzfXH kAShKy"
       for="test"
     >
       Text

--- a/packages/es-components/src/components/util/StyleReset.js
+++ b/packages/es-components/src/components/util/StyleReset.js
@@ -11,7 +11,7 @@ const StyleReset = createGlobalStyle`
   menu, nav, output, ruby, section, summary,
   time, mark, audio, video {
     border: 0;
-    font-family: 'SourceSansPro-Regular', 'Source Sans Pro', 'Segoe UI', Segoe, Calibri, Tahoma, sans-serif;
+    font-family: 'Source Sans Pro', 'Segoe UI', Segoe, Calibri, Tahoma, sans-serif;
     font-size: 100%;
     margin: 0;
     padding: 0;
@@ -38,19 +38,15 @@ const StyleReset = createGlobalStyle`
   }
 
   strong, b {
-    font-family: 'SourceSansPro-Bold', 'Source Sans Pro', 'Segoe UI', Segoe, Calibri, Tahoma, sans-serif;
-  }
-
-  @-moz-document url-prefix() {
-    strong, b {
-      font-weight: lighter !important;
-    }
+    font-family: 'Source Sans Pro', 'Segoe UI', Segoe, Calibri, Tahoma, sans-serif;
+    font-weight: bold;
   }
 
   h1, h2, h3, h4, h5, h6 {
     color: inherit;
     font: inherit;
-    font-family: 'SourceSansPro-Light', 'Source Sans Pro', 'Segoe UI', Segoe, Calibri, Tahoma, sans-serif;
+    font-family: 'Source Sans Pro', 'Segoe UI', Segoe, Calibri, Tahoma, sans-serif;
+    font-weight: 300;
     line-height: 1.1;
     margin-bottom: 0.45em;
     margin-top: 0;


### PR DESCRIPTION
The previous issues with bold rendering in Firefox came from the CDN font source being split into 3 different families (one for regular, light, and bold). That has been fixed and the specific overrides are no longer necessary. Everything just uses 'Source Sans Pro' now and it works as it should. This should also be fully backward compatible with the google Source Sans Pro.