### PR TITLE
Build: removed browser field in package.json

### DIFF
--- a/packages/es-components/package-lock.json
+++ b/packages/es-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components",
-  "version": "19.0.76",
+  "version": "19.0.85",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6182,10 +6182,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -5,7 +5,6 @@
   "repository": "https://github.com/wtw-im/es-components",
   "module": "lib/index.js",
   "main": "cjs/index.js",
-  "browser": "bundle/main.min.js",
   "sideEffects": false,
   "scripts": {
     "build": "npm run rollup",

--- a/packages/es-components/rollup.config.js
+++ b/packages/es-components/rollup.config.js
@@ -46,7 +46,7 @@ export default [
   {
     input: 'src/index.js',
     output: {
-      file: pkg.browser,
+      file: 'bundle/main.min.js',
       format: 'umd',
       name: 'es-components',
       globals: {


### PR DESCRIPTION
During the switch to rollup, the `browser` field was added to the package.json, pointing to the UMD build (which existed before). Due to the issues caused by webpack preferring this build by default, this simply removes that field from the package.json, while still leaving the UMD build in place as it was before.

Question: Do we still need to have a UMD build?