### PR TITLE
Fix: set text-decoration on Button

### DIFF
--- a/packages/es-components/src/components/controls/buttons/Button.js
+++ b/packages/es-components/src/components/controls/buttons/Button.js
@@ -12,6 +12,7 @@ const StyledButton = styled.button`
   display: block;
   overflow: visible;
   padding: 0;
+  text-decoration: none;
   width: 100%;
 
   @media (min-width: ${props => props.theme.screenSize.tablet}) {

--- a/packages/es-components/src/components/controls/buttons/OutlineButton.js
+++ b/packages/es-components/src/components/controls/buttons/OutlineButton.js
@@ -23,6 +23,7 @@ const StyledButton = styled.button`
   padding-right: ${props => props.buttonSize.paddingSides};
   padding-top: ${props => props.buttonSize.paddingTop};
   text-align: center;
+  text-decoration: none;
   text-transform: ${props =>
     props.buttonSize.textTransform ? props.buttonSize.textTransform : 'none'};
   transition: background-color 150ms linear, color 150ms linear;


### PR DESCRIPTION
Explicitly set text-decoration to none so that a Button can be used as a link without it receiving the default browser link treatment.

This will have no outward effects on any existing button styles since text inside them don't get underlined by browsers.