### PR TITLE
Fix: moves RootCloseWrapper in Popover

### DIFF
--- a/packages/es-components/src/components/containers/popover/Popover.js
+++ b/packages/es-components/src/components/containers/popover/Popover.js
@@ -180,19 +180,19 @@ function Popover(props) {
 
   return (
     <Container>
-      <RootCloseWrapper onRootClose={hidePopover} disabled={disableRootClose}>
-        <Popup
-          name={name}
-          trigger={renderTrigger({ ref: triggerBtnRef, toggleShow, isOpen })}
-          position={placement}
-          arrowSize={arrowSize}
-          transitionIn={isOpen}
-          hasTitle={hasTitle}
-          disableFlipping={disableFlipping}
-          popperRef={elem => {
-            popperRef.current = elem;
-          }}
-        >
+      <Popup
+        name={name}
+        trigger={renderTrigger({ ref: triggerBtnRef, toggleShow, isOpen })}
+        position={placement}
+        arrowSize={arrowSize}
+        transitionIn={isOpen}
+        hasTitle={hasTitle}
+        disableFlipping={disableFlipping}
+        popperRef={elem => {
+          popperRef.current = elem;
+        }}
+      >
+        <RootCloseWrapper onRootClose={hidePopover} disabled={disableRootClose}>
           <div role="dialog" ref={contentRef}>
             <PopoverHeader hasTitle={hasTitle}>
               {hasTitle && <TitleBar>{title}</TitleBar>}
@@ -211,8 +211,8 @@ function Popover(props) {
               {showCloseButton && closeButton}
             </PopoverBody>
           </div>
-        </Popup>
-      </RootCloseWrapper>
+        </RootCloseWrapper>
+      </Popup>
     </Container>
   );
 }


### PR DESCRIPTION
- Because the RootCloseWrapper was around the Popup element instead of
the content of the Popover the onClose would trigger even when clicking
inside of the Popover which is not correct behavior for this type of
element. Moving the wrapper down around the content ensure the close
trigger is fired at the appropriate time.