### PR TITLE
Update: restrict resize event firing

### DIFF
--- a/packages/es-components/src/components/util/withWindowSize.js
+++ b/packages/es-components/src/components/util/withWindowSize.js
@@ -30,7 +30,14 @@ export default function withWindowSize(ComponentClass) {
       window.removeEventListener('resize', this.handleResize);
     }
 
-    handleResize = () => this.setState(getWindowSize());
+    handleResize = () => {
+      const activeTag = document.activeElement.tagName.toLocaleLowerCase();
+      if (activeTag === 'input' || activeTag === 'select') {
+        return;
+      }
+
+      this.setState(getWindowSize());
+    };
 
     render() {
       return (


### PR DESCRIPTION
- Adds check in the resize event of withWindowSize that will cause the
new window size to be set on the state when thie active element is
an input or select tag.

- This was added to get around how android browsers resize the viewport
when the 'soft' keyboard is opening, which would cause a rerender and
posibly break things in downstream responsive apps.