### PR TITLE
Add `inputmode` and `pattern` to Day and Year input components

### DIFF
--- a/packages/es-components/src/components/patterns/dateInput/Day.js
+++ b/packages/es-components/src/components/patterns/dateInput/Day.js
@@ -32,6 +32,8 @@ function Day({ onChange, date, ...props }) {
   return (
     <DayInput
       type="number"
+      inputmode="numeric"
+      pattern="[0-9]*"
       min="1"
       max="31"
       onChange={onDayChange}

--- a/packages/es-components/src/components/patterns/dateInput/Year.js
+++ b/packages/es-components/src/components/patterns/dateInput/Year.js
@@ -32,6 +32,8 @@ function Year({ onChange, date, ...props }) {
   return (
     <YearInput
       type="number"
+      inputmode="numeric"
+      pattern="[0-9]*"
       onChange={onYearChange}
       placeholder="Year"
       value={value}

--- a/packages/es-components/src/components/patterns/dateInput/__snapshots__/DateInput.specs.js.snap
+++ b/packages/es-components/src/components/patterns/dateInput/__snapshots__/DateInput.specs.js.snap
@@ -42,6 +42,7 @@ exports[`displays monthNames provided by the monthNames prop 1`] = `
         max="31"
         min="1"
         name="day"
+        pattern="[0-9]*"
         placeholder="Day"
         type="number"
         value=""
@@ -49,6 +50,7 @@ exports[`displays monthNames provided by the monthNames prop 1`] = `
       <input
         class="sc-htpNat sc-bZQynM dkwEsv"
         name="year"
+        pattern="[0-9]*"
         placeholder="Year"
         type="number"
         value=""
@@ -141,6 +143,7 @@ exports[`hides the Day input when Day is excluded 1`] = `
       </select>
       <input
         class="sc-htpNat sc-bZQynM dkwEsv"
+        pattern="[0-9]*"
         placeholder="Year"
         type="number"
         value=""


### PR DESCRIPTION
Added `inputmode` and `pattern` attributes to set mobile keyboards to display numeric input when using components.