### PR TITLE
pass additional props to Notification components

### DIFF
--- a/packages/es-components/src/components/containers/notification/useNotification.js
+++ b/packages/es-components/src/components/containers/notification/useNotification.js
@@ -42,7 +42,8 @@ function NotificationContent(props) {
     iconName,
     iconColor,
     color,
-    dismissNotification
+    dismissNotification,
+    ...rest
   } = props;
 
   function dismiss() {
@@ -55,7 +56,7 @@ function NotificationContent(props) {
       {includeIcon && (
         <NotificationIcon name={iconName} iconColor={iconColor} size={28} />
       )}
-      <ContentWrapper>{children}</ContentWrapper>
+      <ContentWrapper {...rest}>{children}</ContentWrapper>
       {isDismissable && <Dismiss onClick={dismiss} color={color} />}
     </>
   );
@@ -91,7 +92,13 @@ export function useNotification(styleType = 'base') {
     const iconName = theme.validationIconName[type];
     const iconColor =
       styleType === 'light' ? theme.colors[type] : theme.colors.white;
-    const notificationContentProps = { color, iconName, iconColor, ...rest };
+    const notificationContentProps = {
+      color,
+      iconName,
+      iconColor,
+      role,
+      ...rest
+    };
     const [isDismissed, setIsDismissed] = useState(false);
 
     function dismissNotification() {
@@ -100,7 +107,7 @@ export function useNotification(styleType = 'base') {
 
     return (
       !isDismissed && (
-        <Notification role={role} variant={color}>
+        <Notification variant={color}>
           <NotificationContent
             dismissNotification={dismissNotification}
             {...notificationContentProps}


### PR DESCRIPTION
We are trying to pass `aria` attributes to a `LightNotification` component.  `Notification` is assigned a `role` attribute, which means that it should also get any passed-in `aria` attributes, but in `useNotification`, any additional props are instead passed on to `NotificationContent`, which is a separate element.  `NotificationContent` also ignores any additional props, so there are really two problems here.  

This PR moves `role` and any additional props to `ContentWrapper` inside of `NotificationContent`. 