### PR TITLE
Fix: Stop DateInput from setting default month

### DIFF
--- a/packages/es-components/src/components/patterns/dateInput/DateInput.js
+++ b/packages/es-components/src/components/patterns/dateInput/DateInput.js
@@ -53,7 +53,7 @@ function DateInput({
 }) {
   const [state, dispatch] = useReducer(reducer, {
     day: defaultValue ? defaultValue.getDate() : '',
-    month: defaultValue ? defaultValue.getMonth() + 1 : 1,
+    month: defaultValue ? defaultValue.getMonth() + 1 : '',
     year: defaultValue ? defaultValue.getFullYear().toString() : ''
   });
 

--- a/packages/es-components/src/components/patterns/dateInput/DateInput.md
+++ b/packages/es-components/src/components/patterns/dateInput/DateInput.md
@@ -121,6 +121,50 @@ You may omit Month and/or Day, but Year is required.
 </DateInput>
 ```
 
+Month and Year validated with no default selected.
+
+```
+import Control from '../../controls/Control';
+import Label from '../../controls/label/Label';
+import AdditionalHelp from '../../controls/AdditionalHelp';
+
+function DateInputExample() {
+  const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+  const [myDate, setMyDate] = React.useState();
+  const [validation, setValidation] = React.useState('default');
+
+  function handleChange(date) {
+    console.log(date);
+    setMyDate(date);
+    setValidation('default');
+  }
+
+  function handleOnBlur() {
+    setValidation(myDate && myDate.value ? 'success' : 'danger');
+  }
+
+  return (
+    <Control validationState={validation}>
+      <DateInput id="demoDate"
+        onChange={handleChange}
+        onBlur={handleOnBlur}
+        minDate={new Date('2000/1/1')}
+        maxDate={new Date('2040/1/1')}
+      >
+        <DateInput.Month selectOptionText="Select a month" />
+        <DateInput.Year />
+      </DateInput>
+      <AdditionalHelp>
+        <span>{myDate && myDate.isInRange
+                  ? `You entered: ${myDate.value.toLocaleDateString("en-US", options)}`
+                  : validation !== 'default' && 'Please enter a valid date.'}</span>
+      </AdditionalHelp>
+    </Control>
+  );
+}
+<DateInputExample />
+```
+
 Year, Month, and Day will display in the order you provide them.
 
 ```
@@ -136,3 +180,4 @@ import Label from '../../controls/label/Label';
   </DateInput>
 </Control>
 ```
+


### PR DESCRIPTION
When specifying `selectOptionText` for `DateInput.Month` we should get a `none` value, but currently we default the month to a value of `1`. This allows validation to be successful even when not changing month value.