### PR TITLE
Fix: stop default month from being set in DateInput

### DIFF
--- a/packages/es-components/package-lock.json
+++ b/packages/es-components/package-lock.json
@@ -4249,7 +4249,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "pify": {
@@ -5504,7 +5505,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
       }
@@ -8169,6 +8171,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
               "dev": true,
               "optional": true
             }
@@ -11032,7 +11036,8 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "resolved": "",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                   "dev": true,
                   "optional": true
                 }
@@ -15297,7 +15302,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "source-map": {
@@ -18193,7 +18199,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
       }

--- a/packages/es-components/src/components/patterns/dateInput/DateInput.js
+++ b/packages/es-components/src/components/patterns/dateInput/DateInput.js
@@ -42,18 +42,18 @@ function reducer(state, action) {
 }
 
 function DateInput({
-  children,
-  defaultValue,
-  id,
-  maxDate,
-  minDate,
-  onBlur,
-  onChange,
-  ...props
-}) {
+                     children,
+                     defaultValue,
+                     id,
+                     maxDate,
+                     minDate,
+                     onBlur,
+                     onChange,
+                     ...props
+                   }) {
   const [state, dispatch] = useReducer(reducer, {
     day: defaultValue ? defaultValue.getDate() : '',
-    month: defaultValue ? defaultValue.getMonth() + 1 : 1,
+    month: defaultValue ? defaultValue.getMonth() + 1 : '',
     year: defaultValue ? defaultValue.getFullYear().toString() : ''
   });
 
@@ -76,16 +76,16 @@ function DateInput({
     const cleanDay = day ? cleanZeroes(day.toString()) : day;
     const date = new Date(`${year}/${month}/${cleanDay}`);
     const dateIsValid =
-      month !== 'none' &&
-      year.length === 4 &&
-      (hasDayElement.current ? date.getDate().toString() === cleanDay : true) &&
-      (month ? (date.getMonth() + 1).toString() === month.toString() : true) &&
-      date.getFullYear().toString() === year.toString();
+        month !== 'none' &&
+        year.length === 4 &&
+        (hasDayElement.current ? date.getDate().toString() === cleanDay : true) &&
+        (month ? (date.getMonth() + 1).toString() === month.toString() : true) &&
+        date.getFullYear().toString() === year.toString();
 
     const isInRange =
-      dateIsValid &&
-      (minDate ? isAfter(date, minDate) : true) &&
-      (maxDate ? isBefore(date, maxDate) : true);
+        dateIsValid &&
+        (minDate ? isAfter(date, minDate) : true) &&
+        (maxDate ? isBefore(date, maxDate) : true);
     return {
       value: dateIsValid ? date : undefined,
       isInRange
@@ -129,18 +129,18 @@ function DateInput({
   return (
     <Wrapper tabIndex="-1" {...props} onBlur={onBlurComponent}>
       {React.Children.map(
-        children,
-        (child, index) =>
-          index === 0
-            ? React.cloneElement(child, {
-                id,
-                onChange: onChangeDatePart,
-                date: createDate(state.year, state.month, state.day).value
-              })
-            : React.cloneElement(child, {
-                onChange: onChangeDatePart,
-                date: createDate(state.year, state.month, state.day).value
-              })
+          children,
+          (child, index) =>
+              index === 0
+                  ? React.cloneElement(child, {
+                    id,
+                    onChange: onChangeDatePart,
+                    date: createDate(state.year, state.month, state.day).value
+                  })
+                  : React.cloneElement(child, {
+                    onChange: onChangeDatePart,
+                    date: createDate(state.year, state.month, state.day).value
+                  })
       )}
     </Wrapper>
   );

--- a/packages/es-components/src/components/patterns/dateInput/DateInput.md
+++ b/packages/es-components/src/components/patterns/dateInput/DateInput.md
@@ -112,13 +112,57 @@ function DateInputExample() {
 
 ### Display
 
-You may omit Month and/or Day, but Year is required.
+You may omit Day, but Month and Year is required.
 
 ```
 <DateInput id="anotherDate" onChange={()=>{}}>
   <DateInput.Month />
   <DateInput.Year />
 </DateInput>
+```
+
+Month and Year validated with no default selected.
+
+```
+import Control from '../../controls/Control';
+import Label from '../../controls/label/Label';
+import AdditionalHelp from '../../controls/AdditionalHelp';
+
+function DateInputExample() {
+  const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+  const [myDate, setMyDate] = React.useState();
+  const [validation, setValidation] = React.useState('default');
+
+  function handleChange(date) {
+    console.log(date);
+    setMyDate(date);
+    setValidation('default');
+  }
+
+  function handleOnBlur() {
+    setValidation(myDate && myDate.value ? 'success' : 'danger');
+  }
+
+  return (
+    <Control validationState={validation}>
+      <DateInput id="demoDate"
+        onChange={handleChange}
+        onBlur={handleOnBlur}
+        minDate={new Date('2000/1/1')}
+        maxDate={new Date('2040/1/1')}
+      >
+        <DateInput.Month selectOptionText="Select a month" />
+        <DateInput.Year />
+      </DateInput>
+      <AdditionalHelp>
+        <span>{myDate && myDate.isInRange
+                  ? `You entered: ${myDate.value.toLocaleDateString("en-US", options)}`
+                  : validation !== 'default' && 'Please enter a valid date.'}</span>
+      </AdditionalHelp>
+    </Control>
+  );
+}
+<DateInputExample />
 ```
 
 Year, Month, and Day will display in the order you provide them.
@@ -136,3 +180,4 @@ import Label from '../../controls/label/Label';
   </DateInput>
 </Control>
 ```
+

--- a/packages/es-components/src/components/patterns/dateInput/DateInput.specs.js
+++ b/packages/es-components/src/components/patterns/dateInput/DateInput.specs.js
@@ -10,10 +10,10 @@ import DateInput from './DateInput';
 beforeEach(cleanup);
 
 const buildDateInput = props => (
-    <Control>
-      <Label htmlFor="test">Text</Label>
-      <DateInput id="test" {...props} data-testid="dateinput" />
-    </Control>
+  <Control>
+    <Label htmlFor="test">Text</Label>
+    <DateInput id="test" {...props} data-testid="dateinput" />
+  </Control>
 );
 
 it('executes the onChange function when text is changed', () => {

--- a/packages/es-components/src/components/patterns/dateInput/DateInput.specs.js
+++ b/packages/es-components/src/components/patterns/dateInput/DateInput.specs.js
@@ -178,6 +178,7 @@ it('returns undefined when Day is present but not defined', () => {
     onChange: jest.fn(),
     children: [<DateInput.Month />, <DateInput.Day />, <DateInput.Year />]
   };
+
   const { getByPlaceholderText } = renderWithTheme(buildDateInput(props));
 
   fireEvent.change(getByPlaceholderText('Year'), {
@@ -185,6 +186,7 @@ it('returns undefined when Day is present but not defined', () => {
       value: '1983'
     }
   });
+
   expect(props.onChange).toHaveBeenCalledWith({
     isInRange: false,
     value: undefined
@@ -194,6 +196,7 @@ it('returns undefined when Day is present but not defined', () => {
 it('returns date when Day is padded with 0', () => {
   const props = {
     onChange: jest.fn(),
+    defaultValue: new Date(2019, 0, 1),
     children: [<DateInput.Month />, <DateInput.Day />, <DateInput.Year />]
   };
   const { getByPlaceholderText } = renderWithTheme(buildDateInput(props));


### PR DESCRIPTION
When specifying selectOptionText for DateInput.Month we should get a none value, but currently we default the month to a value of 1. This allows validation to be successful even when not changing month value.