### PR TITLE
Fix: pass checked attributed to input element

### DIFF
--- a/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
@@ -90,9 +90,14 @@ export function RadioButton({ children, ...radioProps }) {
     checked: isChecked
   };
 
+  const inputProps = {
+    ...radioProps,
+    checked: isChecked
+  };
+
   return (
     <RadioLabel {...labelProps}>
-      <RadioInput type="radio" id={id} {...radioProps} />
+      <RadioInput type="radio" id={id} {...inputProps} />
       <RadioDisplay
         className="es-radio__fill"
         borderColor={fill}


### PR DESCRIPTION
Fix for bug with the radio button inputs when using the selectedValue in the RadioGroup component, when having an external function set the value of the of the selected element, trying to click the previously selected element won't work