### PR TITLE
Fix: nest styles to prevent css collisions

### DIFF
--- a/packages/es-components/package-lock.json
+++ b/packages/es-components/package-lock.json
@@ -14581,9 +14581,9 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-modal": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.10.1.tgz",
-      "integrity": "sha512-2DKIfdOc8+WY+SYJ/xf/WBwOYMmNAYAyGkYlc4e1TCs9rk1xY4QBz04hB3UHGcrLChh7ce77rHAe6VPNmuLYsQ==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.11.2.tgz",
+      "integrity": "sha512-o8gvvCOFaG1T7W6JUvsYjRjMVToLZgLIsi5kdhFIQCtHxDkA47LznX62j+l6YQkpXDbvQegsDyxe/+JJsFQN7w==",
       "requires": {
         "exenv": "^1.2.0",
         "prop-types": "^15.5.10",

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -93,7 +93,7 @@
     "react-animate-height": "^2.0.15",
     "react-datepicker": "^2.9.6",
     "react-dom": "^16.8.6",
-    "react-modal": "^3.10.1",
+    "react-modal": "^3.11.2",
     "react-overlays": "^2.1.0",
     "react-popper": "^1.3.3",
     "react-text-mask": "^5.4.3",

--- a/packages/es-components/src/components/containers/modal/Modal.js
+++ b/packages/es-components/src/components/containers/modal/Modal.js
@@ -26,20 +26,20 @@ const ModalStyles = createGlobalStyle`
     top: 0;
     z-index: 1030;
     transition: background-color 150ms linear;
-
-    &.ReactModal__Overlay--after-open {
-        background-color: ${props => {
-          if (props.showBackdrop) {
-            const color = tinycolor(props.theme.colors.black);
-            color.setAlpha(0.5);
-            return color.toRgbString();
-          }
-          return 'transparent';
-        }} !important;
-    }
   }
 
-  .ReactModal__Content {
+  .background-overlay--after-open {
+      background-color: ${props => {
+        if (props.showBackdrop) {
+          const color = tinycolor(props.theme.colors.black);
+          color.setAlpha(0.5);
+          return color.toRgbString();
+        }
+        return 'transparent';
+      }} !important;
+  }
+
+  .modal-content {
     background-clip: padding-box;
     background-color: ${props => props.theme.colors.white};
     border-radius: 3px;
@@ -60,7 +60,7 @@ const ModalStyles = createGlobalStyle`
         : ''};
   }
 
-  .ReactModal__Content--after-open {
+  .modal-content--after-open {
     ${props =>
       props.showAnimation
         ? `
@@ -70,7 +70,7 @@ const ModalStyles = createGlobalStyle`
         : ''};
   }
 
-  .ReactModal__Content--before-close {
+  .modal-content--before-close {
     ${props =>
       props.showAnimation
         ? `
@@ -125,7 +125,16 @@ function Modal(props) {
       <ModalStyles showAnimation={animation} showBackdrop={backdrop} />
       <ModalContext.Provider value={{ onHide, ariaId }}>
         <ReactModal
-          overlayClassName="background-overlay"
+          className={{
+            base: `modal-content  ${size}`,
+            afterOpen: 'modal-content--after-open',
+            beforeClose: 'modal-content--before-close'
+          }}
+          overlayClassName={{
+            base: 'background-overlay',
+            afterOpen: 'background-overlay--after-open',
+            beforeClose: 'background-overlay--before-close'
+          }}
           closeTimeoutMS={animation ? 150 : null}
           isOpen={show}
           aria={{
@@ -135,7 +144,6 @@ function Modal(props) {
           onRequestClose={onHide}
           onAfterOpen={onEnter}
           onAfterClose={onExit}
-          className={size}
           shouldCloseOnEsc={escapeExits}
           {...other}
         >

--- a/packages/es-components/src/components/containers/sliding-pane/SlidingPane.js
+++ b/packages/es-components/src/components/containers/sliding-pane/SlidingPane.js
@@ -133,7 +133,7 @@ const GlobalPaneStyles = createGlobalStyle`
   }
 
   .ReactModal__Overlay--after-open {
-    background-color: rgba(0,0,0,0.3) !important;
+    background-color: rgba(0,0,0,0.5) !important;
   }
 
   .ReactModal__Overlay--before-close {


### PR DESCRIPTION
Make sure that the modal classes are nested so that it should prevent collisions with the sliding pane.