### PR TITLE
Fix: utilizing upstream styles and classes in Notifications

### DIFF
--- a/packages/es-components/src/components/containers/notification/Notification.specs.js
+++ b/packages/es-components/src/components/containers/notification/Notification.specs.js
@@ -26,6 +26,22 @@ it('notification prepends icon when includeIcon is true', () => {
   expect(container.querySelector('i')).not.toBeNull();
 });
 
+it('can take an extra className', () => {
+  const { container } = renderWithTheme(
+    <Notification type="success" className="my-success" />
+  );
+  expect(container.querySelector('.my-success')).not.toBeNull();
+});
+
+it('can take styles', () => {
+  const { container } = renderWithTheme(
+    <Notification type="success" style={{ color: 'blue' }} />
+  );
+  const notificationDiv = container.querySelector('div');
+  const styles = window.getComputedStyle(notificationDiv);
+  expect(styles.color).toEqual('blue');
+});
+
 describe('dismissable notifications', () => {
   it('removes notification when dismiss button is clicked', () => {
     const { container, getByText } = renderWithTheme(

--- a/packages/es-components/src/components/containers/notification/useNotification.js
+++ b/packages/es-components/src/components/containers/notification/useNotification.js
@@ -86,7 +86,14 @@ const Notification = styled.div`
 `;
 
 export function useNotification(styleType = 'base') {
-  return function BaseNotification({ role, type, children, ...rest }) {
+  return function BaseNotification({
+    role,
+    type,
+    children,
+    className,
+    style,
+    ...rest
+  }) {
     const theme = useTheme();
     const color = theme.notificationStyles[type][styleType];
     const iconName = theme.validationIconName[type];
@@ -107,7 +114,7 @@ export function useNotification(styleType = 'base') {
 
     return (
       !isDismissed && (
-        <Notification variant={color}>
+        <Notification variant={color} className={className} style={style}>
           <NotificationContent
             dismissNotification={dismissNotification}
             {...notificationContentProps}


### PR DESCRIPTION
This should allow us to use `<Notification style={...}>` and `styled(Notification)` without issues. 