### PR TITLE
Enable events prop

### DIFF
--- a/packages/es-components/src/components/containers/popover/Popover.js
+++ b/packages/es-components/src/components/containers/popover/Popover.js
@@ -80,7 +80,8 @@ function Popover(props) {
     hasAltCloseButton,
     disableRootClose,
     disableFlipping,
-    enableEvents
+    enableEvents,
+    strategy
   } = props;
 
   const hasTitle = title !== undefined;
@@ -185,6 +186,7 @@ function Popover(props) {
           popperRef.current = elem;
         }}
         enableEvents={enableEvents}
+        strategy={strategy}
       >
         <RootCloseWrapper onRootClose={hidePopover} disabled={disableRootClose}>
           <div role="dialog" ref={contentRef}>
@@ -233,7 +235,9 @@ Popover.propTypes = {
   /** Disables popovers ability to change position to stay in viewport */
   disableFlipping: PropTypes.bool,
   /** Enable event handlers provided by Popper.js */
-  enableEvents: PropTypes.bool
+  enableEvents: PropTypes.bool,
+  /** Sets the strategy for positioning the popover in Popper.js */
+  strategy: PropTypes.oneOf(['absolute', 'fixed'])
 };
 
 Popover.defaultProps = {
@@ -244,7 +248,8 @@ Popover.defaultProps = {
   hasAltCloseButton: false,
   disableFlipping: false,
   title: undefined,
-  enableEvents: true
+  enableEvents: true,
+  strategy: 'absolute'
 };
 
 export default Popover;

--- a/packages/es-components/src/components/containers/popover/Popover.js
+++ b/packages/es-components/src/components/containers/popover/Popover.js
@@ -79,7 +79,8 @@ function Popover(props) {
     hasCloseButton,
     hasAltCloseButton,
     disableRootClose,
-    disableFlipping
+    disableFlipping,
+    enableEvents
   } = props;
 
   const hasTitle = title !== undefined;
@@ -183,6 +184,7 @@ function Popover(props) {
         popperRef={elem => {
           popperRef.current = elem;
         }}
+        enableEvents={enableEvents}
       >
         <RootCloseWrapper onRootClose={hidePopover} disabled={disableRootClose}>
           <div role="dialog" ref={contentRef}>
@@ -229,7 +231,9 @@ Popover.propTypes = {
   /** Function returning a button component to be used as the popover trigger */
   renderTrigger: PropTypes.func.isRequired,
   /** Disables popovers ability to change position to stay in viewport */
-  disableFlipping: PropTypes.bool
+  disableFlipping: PropTypes.bool,
+  /** Enable event handlers provided by Popper.js */
+  enableEvents: PropTypes.bool
 };
 
 Popover.defaultProps = {
@@ -239,7 +243,8 @@ Popover.defaultProps = {
   hasCloseButton: false,
   hasAltCloseButton: false,
   disableFlipping: false,
-  title: undefined
+  title: undefined,
+  enableEvents: true
 };
 
 export default Popover;

--- a/packages/es-components/src/components/containers/popover/Popup.js
+++ b/packages/es-components/src/components/containers/popover/Popup.js
@@ -154,7 +154,8 @@ function Popup(props) {
     transitionTimeout,
     disableFlipping,
     popperRef,
-    enableEvents
+    enableEvents,
+    strategy
   } = props;
   const arrowValues = getArrowValues(arrowSize);
   const [rootNode, rootNodeRef] = useRootNode(document.body);
@@ -188,6 +189,7 @@ function Popup(props) {
           }}
           innerRef={popperRef}
           eventsEnabled={enableEvents}
+          positionFixed={strategy === 'fixed'}
         >
           {({ ref, style, placement, arrowProps }) => (
             <Fade
@@ -226,7 +228,8 @@ Popup.propTypes = {
   hasTitle: PropTypes.bool,
   disableFlipping: PropTypes.bool,
   popperRef: PropTypes.func,
-  enableEvents: PropTypes.bool
+  enableEvents: PropTypes.bool,
+  strategy: PropTypes.oneOf(['absolute', 'fixed'])
 };
 
 Popup.defaultProps = {
@@ -240,7 +243,8 @@ Popup.defaultProps = {
   hasTitle: false,
   disableFlipping: false,
   popperRef: undefined,
-  enableEvents: true
+  enableEvents: true,
+  strategy: 'absolute'
 };
 
 export default Popup;

--- a/packages/es-components/src/components/containers/popover/Popup.js
+++ b/packages/es-components/src/components/containers/popover/Popup.js
@@ -153,7 +153,8 @@ function Popup(props) {
     transitionIn,
     transitionTimeout,
     disableFlipping,
-    popperRef
+    popperRef,
+    enableEvents
   } = props;
   const arrowValues = getArrowValues(arrowSize);
   const [rootNode, rootNodeRef] = useRootNode(document.body);
@@ -186,6 +187,7 @@ function Popup(props) {
             }
           }}
           innerRef={popperRef}
+          eventsEnabled={enableEvents}
         >
           {({ ref, style, placement, arrowProps }) => (
             <Fade
@@ -223,7 +225,8 @@ Popup.propTypes = {
   transitionTimeout: PropTypes.number,
   hasTitle: PropTypes.bool,
   disableFlipping: PropTypes.bool,
-  popperRef: PropTypes.func
+  popperRef: PropTypes.func,
+  enableEvents: PropTypes.bool
 };
 
 Popup.defaultProps = {
@@ -236,7 +239,8 @@ Popup.defaultProps = {
   transitionTimeout: 150,
   hasTitle: false,
   disableFlipping: false,
-  popperRef: undefined
+  popperRef: undefined,
+  enableEvents: true
 };
 
 export default Popup;


### PR DESCRIPTION
This will allow downstream projects to enable and disable events. It would be nice to update react-popper so we could have more control over disabling just the scroll or resize events. 

