### PR TITLE
Update: removing PropTypes as global dependency

### DIFF
--- a/packages/es-components/babel.config.js
+++ b/packages/es-components/babel.config.js
@@ -22,6 +22,16 @@ module.exports = function(api) {
     ignore: [/[\/\\]core-js/, /@babel[\/\\]runtime/],
     sourceType: 'unambiguous',
     presets,
-    plugins
+    plugins,
+    env: {
+      production: {
+        plugins: [
+          [
+            'babel-plugin-transform-react-remove-prop-types',
+            { removeImport: true }
+          ]
+        ]
+      }
+    }
   };
 };

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -53,6 +53,7 @@
     "babel-eslint": "^9.0.0",
     "babel-jest": "^24.8.0",
     "babel-loader": "^8.0.6",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "babel-preset-wtw-im": "^2.4.1",
     "es-components-via-theme": "file:../es-components-via-theme",
     "eslint": "^5.16.0",

--- a/packages/es-components/rollup.config.js
+++ b/packages/es-components/rollup.config.js
@@ -54,16 +54,16 @@ export default [
       globals: {
         react: 'React',
         'react-dom': 'ReactDOM',
-        'prop-types': 'PropTypes',
         'styled-components': 'styled'
       }
     },
-    external: ['react', 'react-dom', 'prop-types', 'styled-components'],
+    external: ['react', 'react-dom', 'styled-components'],
     plugins: [
       resolve(),
       commonjs({ include: /node_modules/ }),
       babel({
         exclude: /node_modules/,
+        envName: 'production',
         runtimeHelpers: true
       }),
       replace({


### PR DESCRIPTION
This only takes effect in the UMD build.