### PR TITLE
Update: only render modal if it should show

### DIFF
--- a/packages/es-components/src/components/containers/modal/Modal.js
+++ b/packages/es-components/src/components/containers/modal/Modal.js
@@ -120,7 +120,7 @@ function Modal(props) {
 
   const shouldCloseOnOverlayClick = backdrop !== 'static' && backdrop;
 
-  return (
+  return show ? (
     <>
       <ModalStyles showAnimation={animation} showBackdrop={backdrop} />
       <ModalContext.Provider value={{ onHide, ariaId }}>
@@ -151,7 +151,7 @@ function Modal(props) {
         </ReactModal>
       </ModalContext.Provider>
     </>
-  );
+  ) : null;
 }
 
 Modal.propTypes = {


### PR DESCRIPTION
When there are multiple modals on a page, it renders each one on the page. After a certain point, performance degrades and pages become less responsive.

Only rendering if the show prop is true will prevent every modal from being rendered and only render one modal on the page at any given time.