### PR TITLE
Button/DropdownButton flatEdge props

### DIFF
--- a/packages/es-components/src/components/controls/buttons/Button.js
+++ b/packages/es-components/src/components/controls/buttons/Button.js
@@ -10,7 +10,10 @@ const StyledButton = styled.button`
   background-color: ${props => props.colors.bgColor};
   border: 2px solid transparent;
   border-color: ${props => props.colors.bgColor};
-  border-radius: ${props => props.buttonSize.borderRadius};
+  border-bottom-left-radius: ${props => props.borderRadii.bottomLeft};
+  border-bottom-right-radius: ${props => props.borderRadii.bottomRight};
+  border-top-left-radius: ${props => props.borderRadii.topLeft};
+  border-top-right-radius: ${props => props.borderRadii.topRight};
   box-sizing: border-box;
   color: ${props => props.colors.textColor};
   cursor: pointer;
@@ -94,12 +97,22 @@ const StyledButton = styled.button`
   }
 `;
 
-const Button = React.forwardRef(function Button(props, ref) {
-  const { children, styleType, size, block, ...other } = props;
+const Button = React.forwardRef(function Button(
+  { children, styleType, size, block, flatLeftEdge, flatRightEdge, ...other },
+  ref
+) {
   const theme = useTheme();
   const buttonSize = theme.buttonStyles.button.size[size];
   const variant = theme.buttonStyles.button.variant[styleType];
   const isInheritedStyle = styleType === 'inherited';
+
+  const defaultRadius = buttonSize.borderRadius;
+  const borderRadii = {
+    topLeft: flatLeftEdge ? 0 : defaultRadius,
+    topRight: flatRightEdge ? 0 : defaultRadius,
+    bottomRight: flatRightEdge ? 0 : defaultRadius,
+    bottomLeft: flatLeftEdge ? 0 : defaultRadius
+  };
 
   function getButtonColors() {
     if (isInheritedStyle) {
@@ -158,6 +171,7 @@ const Button = React.forwardRef(function Button(props, ref) {
       buttonSize={buttonSize}
       colors={buttonColors}
       ref={ref}
+      borderRadii={borderRadii}
       {...other}
     >
       {children}
@@ -171,13 +185,19 @@ Button.propTypes = {
   styleType: PropTypes.string,
   size: PropTypes.oneOf(['lg', 'default', 'sm', 'xs']),
   /** Make the button's width the size of it's parent container */
-  block: PropTypes.bool
+  block: PropTypes.bool,
+  /** Styles the Button with a flat left edge */
+  flatLeftEdge: PropTypes.bool,
+  /** Styles the Button with a flat right edge */
+  flatRightEdge: PropTypes.bool
 };
 
 Button.defaultProps = {
   styleType: 'default',
   block: false,
-  size: 'default'
+  size: 'default',
+  flatLeftEdge: false,
+  flatRightEdge: false
 };
 
 export default Button;

--- a/packages/es-components/src/components/controls/buttons/Button.md
+++ b/packages/es-components/src/components/controls/buttons/Button.md
@@ -105,3 +105,49 @@ const buttonStyle = {
   <Button styleType="primary" isLinkButton disabled style={buttonStyle}>Link</Button>
 </div>
 ```
+
+### SplitButtonDropdown
+
+You can achieve a split button dropdown style by supplying the `flatLeftEdge` and
+`flatRightEdge` props to `Button` and `DropdownButton`.
+
+```
+import DropdownButton from './DropdownButton';
+
+<>
+  <div>
+    <Button styleType="primary" flatRightEdge>Split Button Dropdown</Button>
+    <DropdownButton
+      shouldCloseOnButtonClick
+      inline
+      rootClose
+      flatLeftEdge
+      styleType="primary"
+    >
+      <DropdownButton.Button
+        name="first" style={{whiteSpace: 'nowrap'}}>First Button</DropdownButton.Button>
+      <DropdownButton.Button
+        name="second" style={{whiteSpace: 'nowrap'}}>Second Button</DropdownButton.Button>
+      <DropdownButton.Button
+        name="third" style={{whiteSpace: 'nowrap'}}>Third Button</DropdownButton.Button>
+    </DropdownButton>
+  </div>
+  <br />
+  <div>
+    <DropdownButton
+      shouldCloseOnButtonClick
+      inline
+      rootClose
+      flatRightEdge
+      styleType="primary"
+    >
+      <DropdownButton.Button
+        name="first" style={{whiteSpace: 'nowrap'}}>First Button</DropdownButton.Button>
+      <DropdownButton.Button
+        name="second" style={{whiteSpace: 'nowrap'}}>Second Button</DropdownButton.Button>
+      <DropdownButton.Button
+        name="third" style={{whiteSpace: 'nowrap'}}>Third Button</DropdownButton.Button>
+    </DropdownButton>
+    <Button styleType="primary" flatLeftEdge>Left Split Button Dropdown</Button>
+  </div>
+</>

--- a/packages/es-components/src/components/controls/buttons/DropdownButton.js
+++ b/packages/es-components/src/components/controls/buttons/DropdownButton.js
@@ -8,6 +8,28 @@ import LinkButton from './LinkButton';
 import useUniqueId from '../../util/useUniqueId';
 import RootCloseWrapper from '../../util/RootCloseWrapper';
 
+const SplitButton = styled(Button)`
+  ${props =>
+    props.flatLeftEdge &&
+    `
+    border-left: solid 1px ${props.theme.colors.gray9};
+  `}
+
+  ${props =>
+    props.flatRightEdge &&
+    `
+    border-right: solid 1px ${props.theme.colors.gray9};
+  `}
+
+  min-width: 10px;
+  padding-left: 8px;
+  padding-right: 6px;
+
+  span {
+    margin-left: 0;
+  }
+`;
+
 const Caret = styled.span`
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
@@ -39,10 +61,10 @@ const ButtonPanelChildrenContainer = styled.div`
 
 const StyledButtonLink = styled(LinkButton)`
   color: black;
-  margin-bottom: 0px;
+  margin-bottom: 0;
+  padding: 10px 20px;
   text-align: left;
   text-decoration: none;
-  padding: 10px 20px;
 
   &:active,
   &:focus,
@@ -134,14 +156,29 @@ function arrowMovement(node) {
   };
 }
 
-function DropdownButton(props) {
-  const [buttonValue, setButtonValue] = useState(props.buttonValue);
+function DropdownButton({
+  id,
+  rootClose,
+  children,
+  buttonValue,
+  manualButtonValue,
+  shouldCloseOnButtonClick,
+  shouldUpdateButtonValue,
+  styleType,
+  inline,
+  flatLeftEdge,
+  flatRightEdge,
+  ...otherProps
+}) {
+  const ActivationButton = flatLeftEdge || flatRightEdge ? SplitButton : Button;
+
+  const [buttonStateValue, setButtonStateValue] = useState(buttonValue);
   const [isOpen, setIsOpen] = useState(false);
 
   const initialRender = useRef(true);
   const buttonDropdown = useRef();
   const triggerButton = useRef();
-  const panelId = useUniqueId(props.id);
+  const panelId = useUniqueId(id);
 
   useEffect(() => {
     const removeFocusTrapListener = focusTrap(buttonDropdown.current);
@@ -169,11 +206,9 @@ function DropdownButton(props) {
   }
 
   function handleDropdownItemClick(buttonProps) {
-    const { shouldCloseOnButtonClick, shouldUpdateButtonValue } = props;
-
     return event => {
       if (shouldUpdateButtonValue) {
-        setButtonValue(buttonProps.children);
+        setButtonStateValue(buttonProps.children);
       }
       if (shouldCloseOnButtonClick) {
         closeDropdown();
@@ -182,15 +217,6 @@ function DropdownButton(props) {
       buttonProps.onClick(event, buttonProps.name);
     };
   }
-
-  const {
-    rootClose,
-    children,
-    manualButtonValue,
-    styleType,
-    inline,
-    ...otherProps
-  } = props;
 
   return (
     <RootCloseWrapper
@@ -209,8 +235,10 @@ function DropdownButton(props) {
         aria-expanded={isOpen}
         aria-haspopup="listbox"
       >
-        <Button
+        <ActivationButton
           {...otherProps}
+          flatLeftEdge={flatLeftEdge}
+          flatRightEdge={flatRightEdge}
           onClick={toggleDropdown}
           aria-haspopup="true"
           aria-pressed={isOpen}
@@ -222,9 +250,9 @@ function DropdownButton(props) {
           ref={triggerButton}
           styleType={styleType}
         >
-          {manualButtonValue || buttonValue}
+          {manualButtonValue || buttonStateValue}
           <Caret />
-        </Button>
+        </ActivationButton>
         <div css="position: relative;">
           <ButtonPanel isOpen={isOpen} id={panelId}>
             <ButtonPanelChildrenContainer>
@@ -272,7 +300,11 @@ DropdownButton.propTypes = {
   styleType: PropTypes.string,
   /** Display the dropdown button inline */
   inline: PropTypes.bool,
-  id: PropTypes.string
+  id: PropTypes.string,
+  /** Styles the Button with a flat left edge */
+  flatLeftEdge: PropTypes.bool,
+  /** Styles the Button with a flat right edge */
+  flatRightEdge: PropTypes.bool
 };
 
 DropdownButton.defaultProps = {
@@ -283,7 +315,9 @@ DropdownButton.defaultProps = {
   styleType: 'default',
   rootClose: false,
   inline: false,
-  id: undefined
+  id: undefined,
+  flatLeftEdge: false,
+  flatRightEdge: false
 };
 
 export default DropdownButton;

--- a/packages/es-components/src/components/controls/buttons/DropdownButton.md
+++ b/packages/es-components/src/components/controls/buttons/DropdownButton.md
@@ -19,7 +19,7 @@ const alertButtonValues = (event, key) => {
 </DropdownButton>
 ```
 
-In some cases you may want to update the the text on the drop down with the last clicked button in the panel if this is the case pass the `shouldUpdateButtonValue` prop.
+In some cases you may want to update the text on the drop down with the last clicked button in the panel if this is the case pass the `shouldUpdateButtonValue` prop.
 
 ```
 const alertButtonValues = (event, name) => {


### PR DESCRIPTION
Added `flatLeftEdge` and `flatRightEdge` props to `Button` and `DropdownButton` which enables a `SplitButton` style combination, among other possibilities. The content of the dropdown items will probably need some manual styling (shown in the example added to the .md file) so they are wide enough.

![image](https://user-images.githubusercontent.com/797074/81234971-202f9d80-8fb7-11ea-821c-37c9c11c59f2.png)
