### PR TITLE
Update: allow Modals to be used in Web Components without an extra ref

### DIFF
--- a/packages/es-components/src/components/containers/sliding-pane/SlidingPane.js
+++ b/packages/es-components/src/components/containers/sliding-pane/SlidingPane.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import Modal from 'react-modal';
 import _noop from 'lodash/noop';
@@ -7,6 +7,7 @@ import Heading from '../heading/Heading';
 import LinkButton from '../../controls/buttons/LinkButton';
 import screenReaderOnly from '../../patterns/screenReaderOnly/screenReaderOnly';
 import Icon from '../../base/icons/Icon';
+import { useRootNodeLocator } from '../../util/useRootNode';
 
 const PaneBase = styled(Modal)`
   background: ${props => props.theme.colors.white};
@@ -172,6 +173,9 @@ export default function SlidingPane({
   parentSelector,
   ...rest
 }) {
+  const [rootNode, RootNodeLocator] = useRootNodeLocator(document.body);
+  const modalParentSelector =
+    parentSelector || useCallback(() => rootNode, [rootNode]);
   const Pane = getPane(from);
   const styles = {
     overlay: { ...defaultStyles.overlay, ...overlayStyles },
@@ -187,6 +191,7 @@ export default function SlidingPane({
   return (
     <>
       <GlobalPaneStyles />
+      <RootNodeLocator />
       <Pane
         style={styles}
         closeTimeoutMS={closeTimeout}
@@ -195,7 +200,7 @@ export default function SlidingPane({
         onRequestClose={onRequestClose}
         shouldCloseOnEsc={shouldCloseOnEsc}
         contentLabel={`Modal "${title}"`}
-        parentSelector={parentSelector}
+        parentSelector={modalParentSelector}
         {...rest}
       >
         <Header>
@@ -254,5 +259,5 @@ SlidingPane.defaultProps = {
   overlayStyles: {},
   contentStyles: {},
   appElement: undefined,
-  parentSelector: () => document.body
+  parentSelector: null
 };

--- a/packages/es-components/src/components/util/useRootNode.js
+++ b/packages/es-components/src/components/util/useRootNode.js
@@ -8,7 +8,7 @@ export default function useRootNode(initialRoot) {
     const foundRoot = node.getRootNode();
     const targetNode = foundRoot.body || foundRoot;
     if (initialRoot !== targetNode) setRootNode(targetNode);
-  });
+  }, []);
   return [rootNode, nodeRef];
 }
 

--- a/packages/es-components/src/components/util/useRootNode.js
+++ b/packages/es-components/src/components/util/useRootNode.js
@@ -1,5 +1,5 @@
 import 'get-root-node-polyfill/implement';
-import { useState, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 
 export default function useRootNode(initialRoot) {
   const [rootNode, setRootNode] = useState(initialRoot);
@@ -10,4 +10,13 @@ export default function useRootNode(initialRoot) {
     if (initialRoot !== targetNode) setRootNode(targetNode);
   });
   return [rootNode, nodeRef];
+}
+
+export function useRootNodeLocator(initialRoot) {
+  const [rootNode, rootNodeRef] = useRootNode(initialRoot);
+  const RootNodeInput = useCallback(
+    () => <input type="hidden" ref={rootNodeRef} />,
+    []
+  );
+  return [rootNode, RootNodeInput];
 }


### PR DESCRIPTION
I've checked within a regular `document.body` and also within a Web Component, and it seems that this solution does work.