### PR TITLE
Fix: classNames properly applied to ToggleButton

### DIFF
--- a/packages/es-components/src/components/controls/buttons/ToggleButton.js
+++ b/packages/es-components/src/components/controls/buttons/ToggleButton.js
@@ -34,7 +34,11 @@ function ToggleButton(props) {
       size={size}
       block={block}
       isOutline={isOutline}
-      className={isPressed ? 'pressed' : undefined}
+      className={
+        isPressed
+          ? `${buttonProps.className || ''} pressed`
+          : buttonProps.className
+      }
       variant={styles.variant[styleType]}
       aria-pressed={isPressed}
     >


### PR DESCRIPTION
ToggleButton now properly applies custom `className` prop values, includes those passed by styled-components.