### PR TITLE
Fix: pass class names through to modal

### DIFF
--- a/packages/es-components/src/components/containers/modal/Modal.js
+++ b/packages/es-components/src/components/containers/modal/Modal.js
@@ -114,6 +114,7 @@ function Modal({
   show,
   size,
   parentSelector,
+  className,
   ...other
 }) {
   const ariaId = useUniqueId(other.id);
@@ -132,9 +133,9 @@ function Modal({
           <ModalContext.Provider value={{ onHide, ariaId }}>
             <ReactModal
               className={{
-                base: `modal-content  ${size}`,
-                afterOpen: 'modal-content--after-open',
-                beforeClose: 'modal-content--before-close'
+                base: `modal-content ${size} ${className || ''}`,
+                afterOpen: `modal-content--after-open ${className || ''}`,
+                beforeClose: `modal-content--before-close ${className || ''}`
               }}
               overlayClassName={{
                 base: 'background-overlay',
@@ -192,7 +193,8 @@ Modal.propTypes = {
   /** Sets the size of the modal */
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   /** Selects the parent */
-  parentSelector: PropTypes.func
+  parentSelector: PropTypes.func,
+  className: PropTypes.string
 };
 
 Modal.defaultProps = {
@@ -205,7 +207,8 @@ Modal.defaultProps = {
   show: false,
   size: 'medium',
   children: undefined,
-  parentSelector: null
+  parentSelector: null,
+  className: null
 };
 
 Modal.Header = Header;

--- a/packages/es-components/src/components/containers/modal/Modal.specs.js
+++ b/packages/es-components/src/components/containers/modal/Modal.specs.js
@@ -61,6 +61,12 @@ it('hides dismiss button when hideCloseButton is true', () => {
   expect(getByText('Header').parentElement.querySelector('button')).toBeNull();
 });
 
+it('passes through class names', () => {
+  const { container } = renderModal({ className: 'myclass' });
+  const element = container.parentElement.querySelector('.myclass');
+  expect(element).not.toBeNull();
+});
+
 describe('when ESC is pressed', () => {
   it('invokes onHide by default', () => {
     const onHide = jest.fn();


### PR DESCRIPTION
styled-components adds classnames for e.g. `const MyModal = styled(Modal)`.  This fix passes class names through to the modal.  