### PR TITLE
UPDATE: Adding icon definition for reply-arrow.

### DIFF
--- a/packages/es-components/src/components/base/icons/icon-definitions.js
+++ b/packages/es-components/src/components/base/icons/icon-definitions.js
@@ -234,7 +234,8 @@ const regular = {
   'im-icon-spouse': '6e8',
   'im-icon-play': '6e9',
   'im-icon-pause': '6ea',
-  'im-icon-skip-to-start': '6eb'
+  'im-icon-skip-to-start': '6eb',
+  'im-icon-reply-arrow': '6ec'
 };
 
 export { regular };


### PR DESCRIPTION
This update adds the `.reply-arrow` icon definition to match the update to `es-assets`, per request from BO-UX.