### PR TITLE
Fix: use text-decoration for PopoverLink

### DIFF
--- a/packages/es-components/src/components/controls/buttons/PopoverLink.js
+++ b/packages/es-components/src/components/controls/buttons/PopoverLink.js
@@ -5,17 +5,17 @@ import LinkButton from './LinkButton';
 import { useTheme } from '../../util/useTheme';
 
 const StyledButton = styled(LinkButton)`
-  border-bottom: ${props => !props.suppressUnderline && `1px dashed`};
-  border-bottom-color: ${props =>
-    !props.suppressUnderline && props.variant.textColor};
-  line-height: 1;
-  text-decoration: none;
+  text-decoration: ${props =>
+    props.suppressUnderline
+      ? 'none'
+      : `${props.variant.textColor} dashed underline`};
 
   &:hover,
   :focus {
-    border-bottom: ${props => !props.suppressUnderline && `1px solid`};
-    border-bottom-color: ${props =>
-      !props.suppressUnderline && props.variant.textColor};
+    text-decoration: ${props =>
+      props.suppressUnderline
+        ? 'none'
+        : `${props.variant.textColor} solid underline`};
   }
 `;
 


### PR DESCRIPTION
`border-bottom` doesn't work with wrapped text
![image](https://user-images.githubusercontent.com/6783495/91204246-07abd600-e6c1-11ea-8d0c-c0f2346d3bd5.png)
Updated to use `text-decoration`
![image](https://user-images.githubusercontent.com/6783495/91204282-14302e80-e6c1-11ea-9d61-75037de5522c.png)
