### PR TITLE
Fix Modal Scrolling

### DIFF
--- a/packages/es-components/config/styleguidist-page-scripts.js
+++ b/packages/es-components/config/styleguidist-page-scripts.js
@@ -1,0 +1,2 @@
+const Modal = require('react-modal');
+Modal.setAppElement('#rsg-root');

--- a/packages/es-components/src/components/containers/modal/Modal.js
+++ b/packages/es-components/src/components/containers/modal/Modal.js
@@ -1,7 +1,7 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { createGlobalStyle } from 'styled-components';
-import { noop } from 'lodash';
+import { createGlobalStyle, ThemeProvider } from 'styled-components';
+import { noop, debounce } from 'lodash';
 import ReactModal from 'react-modal';
 import tinycolor from 'tinycolor2';
 
@@ -18,87 +18,116 @@ const modalSize = {
   large: '900px'
 };
 
-const ModalStyles = createGlobalStyle`
-  .background-overlay {
-    bottom: 0;
-    left: 0;
-    position: fixed;
-    right: 0;
-    top: 0;
-    z-index: 1030;
-    transition: background-color 150ms linear;
-  }
+const animationTimeMs = 300;
 
-  .background-overlay--after-open {
+const getModalMargin = (windowHeight, modalHeight) => {
+  const fullMargin = windowHeight - modalHeight;
+  const thirdTopMargin = fullMargin / 3;
+  return Math.max(thirdTopMargin, 0);
+};
+
+const ModalStyles = createGlobalStyle`
+  body.modal-open {
+    overflow: hidden;
+    .background-overlay {
+      bottom: 0;
+      left: 0;
+      position: fixed;
+      right: 0;
+      top: 0;
       background-color: ${props => {
-        if (props.showBackdrop) {
+        const color = tinycolor(props.theme.colors.black);
+        color.setAlpha(0);
+        return color.toRgbString();
+      }};
+      transition: background-color ${() => animationTimeMs}ms linear;
+      z-index: 1030;
+      &.ReactModal__Overlay--after-open {
+        ${props => {
+          if (!props.showBackdrop) return '';
+
           const color = tinycolor(props.theme.colors.black);
           color.setAlpha(0.5);
-          return color.toRgbString();
+          return `background-color: ${color.toRgbString()};`;
+        }}
+
+        &.ReactModal__Overlay--before-close {
+          background-color: ${props => {
+            const color = tinycolor(props.theme.colors.black);
+            color.setAlpha(0);
+            return color.toRgbString();
+          }};
         }
-        return 'transparent';
-      }} !important;
-  }
-
-  .modal-content {
-    background-clip: padding-box;
-    background-color: ${props => props.theme.colors.white};
-    border-radius: 3px;
-    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
-    font-family: 'Source Sans Pro', 'Segoe UI', Segoe, Calibri, Tahoma, sans-serif;
-    font-size: ${props => props.theme.font.baseFontSize};
-    outline: 0;
-    position: relative;
-    width: 100%;
-    ${props =>
-      props.showAnimation
-        ? `
-    opacity: 0;
-    transform: translateY(-100%);
-    transition: transform 300ms ease-out, opacity 300ms linear;
-    -webkit-overflow-scrolling: touch;
-    `
-        : ''};
-  }
-
-  .modal-content--after-open {
-    ${props =>
-      props.showAnimation
-        ? `
-      opacity: 1;
-      transform: translateY(0);
-    `
-        : ''};
-  }
-
-  .modal-content--before-close {
-    ${props =>
-      props.showAnimation
-        ? `
-        opacity: 0;
-      transform: translateY(-100%);
-    `
-        : ''};
-  }
-
-  .small {
-    @media (min-width: ${props => props.theme.screenSize.phone}) {
-      margin: 20vh auto;
-      width: ${modalSize.small};
+      }
     }
-  }
 
-  .medium {
-    @media (min-width: ${props => props.theme.screenSize.tablet}) {
-      margin: 20vh auto;
-      width: ${modalSize.medium};
-    }
-  }
 
-  .large {
-    @media (min-width: ${props => props.theme.screenSize.desktop}) {
-      margin: 20vh auto;
-      width: ${modalSize.large};
+    .modal-content {
+      background-clip: padding-box;
+      background-color: ${props => props.theme.colors.white};
+      border-radius: 3px;
+      box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
+      font-family: 'Source Sans Pro', 'Segoe UI', Segoe, Calibri, Tahoma, sans-serif;
+      font-size: ${props => props.theme.font.baseFontSize};
+      outline: 0;
+      opacity: 0;
+      overflow: scroll;
+      position: relative;
+      transition:
+        top ${() => animationTimeMs}ms ease-out,
+        opacity ${() => animationTimeMs}ms linear;
+      -webkit-overflow-scrolling: touch;
+      width: 100%;
+      max-height: 100%;
+      ${props =>
+        props.showAnimation
+          ? `
+            top: -100%;
+          `
+          : ''};
+      &.ReactModal__Content--after-open {
+        ${props =>
+          props.showAnimation
+            ? `
+              opacity: 1;
+              top: 0;
+            `
+            : ''};
+
+        &.ReactModal__Content--before-close {
+          ${props =>
+            props.showAnimation
+              ? `
+                opacity: 0;
+                top: -100%
+              `
+              : ''};
+        }
+      }
+
+      &.small {
+        @media (min-width: ${props => props.theme.screenSize.phone}) {
+          margin: ${({ theme }) =>
+            getModalMargin(theme.windowHeight, theme.modalHeight)}px auto;
+          width: ${modalSize.small};
+        }
+      }
+
+      &.medium {
+        @media (min-width: ${props => props.theme.screenSize.tablet}) {
+          margin: ${({ theme }) =>
+            getModalMargin(theme.windowHeight, theme.modalHeight)}px auto;
+          width: ${modalSize.medium};
+        }
+      }
+
+      &.large {
+        @media (min-width: ${props => props.theme.screenSize.desktop}) {
+          margin: ${({ theme }) =>
+            getModalMargin(theme.windowHeight, theme.modalHeight)}px auto;
+          width: ${modalSize.large};
+        }
+      }
     }
   }
 `;
@@ -115,52 +144,88 @@ function Modal({
   size,
   parentSelector,
   className,
+  contentRef,
   ...other
 }) {
   const ariaId = useUniqueId(other.id);
   const [rootNode, RootNodeLocator] = useRootNodeLocator(document.body);
+  const [headerHeight, setHeaderHeight] = useState(60);
+  const [modalHeight, setModalHeight] = useState(300);
+  const [shouldShow, setShouldShow] = useState(show);
+  const [windowHeight, setWindowHeight] = useState(window.innerHeight);
+
+  const modalHeightRef = useCallback(modalElement => {
+    if (contentRef) {
+      if (typeof contentRef === 'function') {
+        contentRef(modalElement);
+      } else {
+        // eslint-disable-next-line no-param-reassign
+        contentRef.current = modalElement;
+      }
+    }
+
+    setModalHeight(modalElement?.offsetHeight || 0);
+  });
   const modalParentSelector =
     parentSelector || useCallback(() => rootNode, [rootNode]);
+
+  useEffect(() => {
+    if (!animation || show) {
+      setShouldShow(show);
+      return noop;
+    }
+
+    let mounted = true;
+    setTimeout(() => {
+      if (!mounted) return;
+
+      setShouldShow(false);
+    }, animationTimeMs);
+
+    return () => {
+      mounted = false;
+    };
+  }, [show, animation]);
+
+  useEffect(() => {
+    const setHeight = debounce(() => setWindowHeight(window.innerHeight), 100);
+    window.addEventListener('resize', setHeight);
+    return () => window.removeEventListener('resize', setHeight);
+  }, []);
 
   const shouldCloseOnOverlayClick = backdrop !== 'static' && backdrop;
 
   return (
-    <>
+    <ThemeProvider
+      theme={{ headerHeight, setHeaderHeight, modalHeight, windowHeight }}
+    >
       <RootNodeLocator />
-      {show ? (
-        <>
-          <ModalStyles showAnimation={animation} showBackdrop={backdrop} />
-          <ModalContext.Provider value={{ onHide, ariaId }}>
-            <ReactModal
-              className={{
-                base: `modal-content ${size} ${className || ''}`,
-                afterOpen: `modal-content--after-open ${className || ''}`,
-                beforeClose: `modal-content--before-close ${className || ''}`
-              }}
-              overlayClassName={{
-                base: 'background-overlay',
-                afterOpen: 'background-overlay--after-open',
-                beforeClose: 'background-overlay--before-close'
-              }}
-              closeTimeoutMS={animation ? 150 : null}
-              isOpen={show}
-              aria={{
-                labelledby: ariaId
-              }}
-              shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
-              onRequestClose={onHide}
-              onAfterOpen={onEnter}
-              onAfterClose={onExit}
-              shouldCloseOnEsc={escapeExits}
-              parentSelector={modalParentSelector}
-              {...other}
-            >
-              {children}
-            </ReactModal>
-          </ModalContext.Provider>
-        </>
+      {shouldShow ? (
+        <ModalStyles showAnimation={animation} showBackdrop={backdrop} />
       ) : null}
-    </>
+      <ModalContext.Provider value={{ onHide, ariaId }}>
+        <ReactModal
+          bodyOpenClassName="modal-open"
+          className={`${className} ${size} modal-content`}
+          overlayClassName="background-overlay"
+          closeTimeoutMS={animation ? animationTimeMs : null}
+          isOpen={show}
+          aria={{
+            labelledby: ariaId
+          }}
+          shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
+          onRequestClose={onHide}
+          onAfterOpen={onEnter}
+          onAfterClose={onExit}
+          shouldCloseOnEsc={escapeExits}
+          parentSelector={modalParentSelector}
+          contentRef={modalHeightRef}
+          {...other}
+        >
+          {children}
+        </ReactModal>
+      </ModalContext.Provider>
+    </ThemeProvider>
   );
 }
 
@@ -194,7 +259,11 @@ Modal.propTypes = {
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   /** Selects the parent */
   parentSelector: PropTypes.func,
-  className: PropTypes.string
+  className: PropTypes.string,
+  contentRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.any })
+  ])
 };
 
 Modal.defaultProps = {
@@ -208,7 +277,8 @@ Modal.defaultProps = {
   size: 'medium',
   children: undefined,
   parentSelector: null,
-  className: null
+  className: null,
+  contentRef: null
 };
 
 Modal.Header = Header;

--- a/packages/es-components/src/components/containers/modal/Modal.js
+++ b/packages/es-components/src/components/containers/modal/Modal.js
@@ -72,7 +72,7 @@ const ModalStyles = createGlobalStyle`
       font-size: ${props => props.theme.font.baseFontSize};
       outline: 0;
       opacity: 0;
-      overflow: scroll;
+      overflow-y: auto;
       position: relative;
       transition:
         top ${() => animationTimeMs}ms ease-out,

--- a/packages/es-components/src/components/containers/modal/Modal.js
+++ b/packages/es-components/src/components/containers/modal/Modal.js
@@ -33,7 +33,7 @@ const ModalStyles = createGlobalStyle`
     .background-overlay {
       bottom: 0;
       background-color: ${props => {
-        const color = tinycolor(props.theme.colors.black);
+        const color = tinycolor(props.theme.colors.gray9);
         color.setAlpha(0);
         return color.toRgbString();
       }};
@@ -51,14 +51,14 @@ const ModalStyles = createGlobalStyle`
         ${props => {
           if (!props.showBackdrop) return '';
 
-          const color = tinycolor(props.theme.colors.black);
+          const color = tinycolor(props.theme.colors.gray9);
           color.setAlpha(0.5);
           return `background-color: ${color.toRgbString()};`;
         }}
 
         &.ReactModal__Overlay--before-close {
           background-color: ${props => {
-            const color = tinycolor(props.theme.colors.black);
+            const color = tinycolor(props.theme.colors.gray9);
             color.setAlpha(0);
             return color.toRgbString();
           }};
@@ -76,40 +76,18 @@ const ModalStyles = createGlobalStyle`
       outline: 0;
       opacity: 0;
       position: absolute;
-      top: 0;
+      transform: none;
       left: 0;
       transition:
-        top ${() => animationTimeMs}ms ease-in,
-        opacity ${() => animationTimeMs}ms ease-in;
+        transform ${() => animationTimeMs}ms ease-out,
+        opacity ${() => animationTimeMs}ms ease-out;
       -webkit-overflow-scrolling: touch;
       width: 100%;
-      ${props =>
-        props.showAnimation
-          ? `
-            top: -50px;
-          `
-          : ''};
 
       &.ReactModal__Content--after-open {
-        ${props =>
-          props.showAnimation
-            ? `
-              opacity: 1;
-              top: 0;
-            `
-            : ''};
-
+        opacity: 1;
         &.ReactModal__Content--before-close {
-          ${props =>
-            props.showAnimation
-              ? `
-              transition:
-                top ${animationTimeMs}ms ease-out,
-                opacity ${animationTimeMs}ms ease-out;
-                opacity: 0;
-                top: -50px;
-              `
-              : ''};
+          opacity: 0;
         }
       }
 
@@ -119,6 +97,30 @@ const ModalStyles = createGlobalStyle`
           margin: ${({ theme }) =>
             getModalMargin(theme.windowHeight, theme.modalHeight)}px auto;
           width: ${modalSize.small};
+          ${props =>
+            props.showAnimation
+              ? `
+                transform: translateY(-50px);
+              `
+              : ''};
+
+          &.ReactModal__Content--after-open {
+            ${props =>
+              props.showAnimation
+                ? `
+                  transform: translateY(0);
+                `
+                : ''};
+
+            &.ReactModal__Content--before-close {
+              ${props =>
+                props.showAnimation
+                  ? `
+                    transform: translateY(-50px);
+                  `
+                  : ''};
+            }
+          }
         }
       }
 
@@ -128,6 +130,30 @@ const ModalStyles = createGlobalStyle`
           margin: ${({ theme }) =>
             getModalMargin(theme.windowHeight, theme.modalHeight)}px auto;
           width: ${modalSize.medium};
+          ${props =>
+            props.showAnimation
+              ? `
+                transform: translateY(-50px);
+              `
+              : ''};
+
+          &.ReactModal__Content--after-open {
+            ${props =>
+              props.showAnimation
+                ? `
+                  transform: translateY(0);
+                `
+                : ''};
+
+            &.ReactModal__Content--before-close {
+              ${props =>
+                props.showAnimation
+                  ? `
+                    transform: translateY(-50px);
+                  `
+                  : ''};
+            }
+          }
         }
       }
 
@@ -137,6 +163,33 @@ const ModalStyles = createGlobalStyle`
           margin: ${({ theme }) =>
             getModalMargin(theme.windowHeight, theme.modalHeight)}px auto;
           width: ${modalSize.large};
+          ${props =>
+            props.showAnimation
+              ? `
+                transform: translateY(-50px);
+              `
+              : ''};
+
+          &.ReactModal__Content--after-open {
+            ${props =>
+              props.showAnimation
+                ? `
+                  transform: translateY(0);
+                `
+                : ''};
+
+            &.ReactModal__Content--before-close {
+              ${props =>
+                props.showAnimation
+                  ? `
+                    transition:
+                      top ${animationTimeMs}ms ease-out,
+                      opacity ${animationTimeMs}ms ease-out;
+                    transform: translateY(-50px);
+                  `
+                  : ''};
+            }
+          }
         }
       }
     }

--- a/packages/es-components/src/components/containers/modal/Modal.js
+++ b/packages/es-components/src/components/containers/modal/Modal.js
@@ -23,7 +23,7 @@ const animationTimeMs = 300;
 const getModalMargin = (windowHeight, modalHeight) => {
   const fullMargin = windowHeight - modalHeight;
   const thirdTopMargin = fullMargin / 3;
-  return Math.max(thirdTopMargin, 0);
+  return Math.max(thirdTopMargin, 50);
 };
 
 const ModalStyles = createGlobalStyle`
@@ -44,7 +44,7 @@ const ModalStyles = createGlobalStyle`
       position: fixed;
       right: 0;
       top: 0;
-      transition: background-color ${() => animationTimeMs}ms linear;
+      transition: background-color ${() => animationTimeMs / 2}ms linear;
       z-index: 1030;
 
       &.ReactModal__Overlay--after-open {
@@ -75,16 +75,18 @@ const ModalStyles = createGlobalStyle`
       font-size: ${props => props.theme.font.baseFontSize};
       outline: 0;
       opacity: 0;
-      position: relative;
+      position: absolute;
+      top: 0;
+      left: 0;
       transition:
-        top ${() => animationTimeMs}ms ease-out,
-        opacity ${() => animationTimeMs}ms linear;
+        top ${() => animationTimeMs}ms ease-in,
+        opacity ${() => animationTimeMs}ms ease-in;
       -webkit-overflow-scrolling: touch;
       width: 100%;
       ${props =>
         props.showAnimation
           ? `
-            top: -100%;
+            top: -50px;
           `
           : ''};
 
@@ -101,8 +103,11 @@ const ModalStyles = createGlobalStyle`
           ${props =>
             props.showAnimation
               ? `
+              transition:
+                top ${animationTimeMs}ms ease-out,
+                opacity ${animationTimeMs}ms ease-out;
                 opacity: 0;
-                top: -100%
+                top: -50px;
               `
               : ''};
         }
@@ -110,6 +115,7 @@ const ModalStyles = createGlobalStyle`
 
       &.small {
         @media (min-width: ${props => props.theme.screenSize.phone}) {
+          position: relative;
           margin: ${({ theme }) =>
             getModalMargin(theme.windowHeight, theme.modalHeight)}px auto;
           width: ${modalSize.small};
@@ -118,6 +124,7 @@ const ModalStyles = createGlobalStyle`
 
       &.medium {
         @media (min-width: ${props => props.theme.screenSize.tablet}) {
+          position: relative;
           margin: ${({ theme }) =>
             getModalMargin(theme.windowHeight, theme.modalHeight)}px auto;
           width: ${modalSize.medium};
@@ -126,6 +133,7 @@ const ModalStyles = createGlobalStyle`
 
       &.large {
         @media (min-width: ${props => props.theme.screenSize.desktop}) {
+          position: relative;
           margin: ${({ theme }) =>
             getModalMargin(theme.windowHeight, theme.modalHeight)}px auto;
           width: ${modalSize.large};
@@ -157,6 +165,7 @@ function Modal({
   const [modalHeight, setModalHeight] = useState(300);
   const [shouldShow, setShouldShow] = useState(show);
   const [windowHeight, setWindowHeight] = useState(window.innerHeight);
+  const modalRef = useRef(null);
   const innerContentRef = useRef(null);
   const callRef = (ref, element) => {
     if (ref) {
@@ -175,13 +184,18 @@ function Modal({
 
   const modalHeightRef = useCallback(modalElement => {
     callRef(overlayRef, modalElement);
-    let newHeight = modalElement?.offsetHeight || 0;
+    let newHeight = 0;
+    if (modalElement) {
+      modalRef.current = modalElement;
+      newHeight = modalElement.offsetHeight;
+    }
     if (innerContentRef.current) {
       const contRefHeight = innerContentRef.current.offsetHeight;
       if (contRefHeight < newHeight) newHeight = contRefHeight;
     }
     setModalHeight(newHeight);
   });
+
   const modalParentSelector =
     parentSelector || useCallback(() => rootNode, [rootNode]);
 
@@ -208,6 +222,12 @@ function Modal({
     window.addEventListener('resize', setHeight);
     return () => window.removeEventListener('resize', setHeight);
   }, []);
+
+  useEffect(() => {
+    if (modalRef.current && modalRef.current.scroll) {
+      modalRef.current.scroll(0, 0);
+    }
+  }, [modalRef.current]);
 
   const shouldCloseOnOverlayClick = backdrop !== 'static' && backdrop;
 

--- a/packages/es-components/src/components/containers/modal/Modal.js
+++ b/packages/es-components/src/components/containers/modal/Modal.js
@@ -29,6 +29,7 @@ const getModalMargin = (windowHeight, modalHeight) => {
 const ModalStyles = createGlobalStyle`
   body.modal-open {
     overflow: hidden;
+
     .background-overlay {
       bottom: 0;
       left: 0;
@@ -42,6 +43,7 @@ const ModalStyles = createGlobalStyle`
       }};
       transition: background-color ${() => animationTimeMs}ms linear;
       z-index: 1030;
+
       &.ReactModal__Overlay--after-open {
         ${props => {
           if (!props.showBackdrop) return '';
@@ -60,7 +62,6 @@ const ModalStyles = createGlobalStyle`
         }
       }
     }
-
 
     .modal-content {
       background-clip: padding-box;
@@ -85,6 +86,7 @@ const ModalStyles = createGlobalStyle`
             top: -100%;
           `
           : ''};
+
       &.ReactModal__Content--after-open {
         ${props =>
           props.showAnimation

--- a/packages/es-components/src/components/containers/modal/Modal.md
+++ b/packages/es-components/src/components/containers/modal/Modal.md
@@ -10,7 +10,7 @@ import Button from '../../controls/buttons/Button';
 
 const [show, setShow] = React.useState(false);
 const [size, setSize] = React.useState('medium');
-const [hideCloseButton, setHideCloseButton] = React.useState('medium');
+const [hideCloseButton, setHideCloseButton] = React.useState(false);
 const setInitialState = ({show: newShow, size: newSize, hideCloseButton: newHideClose}) => {
   setShow(newShow);
   setSize(newSize);

--- a/packages/es-components/src/components/containers/modal/Modal.md
+++ b/packages/es-components/src/components/containers/modal/Modal.md
@@ -8,27 +8,34 @@ the level passed in.
 ```
 import Button from '../../controls/buttons/Button';
 
-const [state, setState] = React.useState({show: false});
+const [show, setShow] = React.useState(false);
+const [size, setSize] = React.useState('medium');
+const [hideCloseButton, setHideCloseButton] = React.useState('medium');
+const setInitialState = ({show: newShow, size: newSize, hideCloseButton: newHideClose}) => {
+  setShow(newShow);
+  setSize(newSize);
+  setHideCloseButton(newHideClose);
+}
 
 <div>
-  <Button aria-haspopup='dialog' onClick={() => setState({show: true, size: 'small', hideCloseButton: true})} style={{marginRight:'15px'}}>Open Small Modal</Button>
+  <Button aria-haspopup='dialog' onClick={() => setInitialState({show: true, size: 'small', hideCloseButton: true})} style={{marginRight:'15px'}}>Open Small Modal</Button>
 
-  <Button aria-haspopup='dialog' onClick={() => setState({show: true, size: 'medium', hideCloseButton: false})} style={{marginRight:'15px'}}>Open Medium Modal</Button>
+  <Button aria-haspopup='dialog' onClick={() => setInitialState({show: true, size: 'medium', hideCloseButton: false})} style={{marginRight:'15px'}}>Open Medium Modal</Button>
 
-  <Button aria-haspopup='dialog' onClick={() => setState({show: true, size: 'large', hideCloseButton: false})}>Open Large Modal</Button>
+  <Button aria-haspopup='dialog' onClick={() => setInitialState({show: true, size: 'large', hideCloseButton: false})}>Open Large Modal</Button>
 
   <Modal
-    size={state.size}
-    show={state.show}
-    onHide={() => setState({show: false})}
+    size={size}
+    show={show}
+    onHide={() => setShow(false)}
   >
-    <Modal.Header level={4} hideCloseButton={state.hideCloseButton}>This is the header.</Modal.Header>
+    <Modal.Header level={4} hideCloseButton={hideCloseButton}>This is the header.</Modal.Header>
     <Modal.Body>Body Content. Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch.This is the popover's content. Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid.</Modal.Body>
     <Modal.Footer>
       <span style={{ flexGrow: 1, marginRight: '10px' }}>
         This is the footer.
       </span>
-      <Button onClick={()=> setState({show: false})} style={{margin:0}}>Ok</Button>
+      <Button onClick={() => setShow(false)} style={{margin:0}}>Ok</Button>
     </Modal.Footer>
   </Modal>
 </div>
@@ -40,22 +47,22 @@ const [state, setState] = React.useState({show: false});
 import ModalButtonContainer from './ModalButtonContainer';
 import Button from '../../controls/buttons/Button';
 
-const [state, setState] = React.useState({show: false});
+const [show, setShow] = React.useState(false);
 
 <div>
-  <Button aria-haspopup='dialog' onClick={() => setState({show: true, size: 'medium', hideCloseButton: false})} style={{marginRight:'15px'}}>Open Modal</Button>
+  <Button aria-haspopup='dialog' onClick={() => setShow(true)} style={{marginRight:'15px'}}>Open Modal</Button>
 
   <Modal
     size="medium"
-    show={state.show}
-    onHide={() => setState({show: false})}
+    show={show}
+    onHide={() => setShow(false)}
   >
-    <Modal.Header level={4} hideCloseButton={state.hideCloseButton}>This is the header.</Modal.Header>
+    <Modal.Header level={4} hideCloseButton={false}>This is the header.</Modal.Header>
     <Modal.Body>Body Content. Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch.This is the popover's content. Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid.</Modal.Body>
     <Modal.Footer>
       <ModalButtonContainer>
-        <Button onClick={()=> setState({show: false})} style={{margin: '15px 0 0 15px'}}>Cancel</Button>
-        <Button onClick={()=> setState({show: false})} styleType="primary" style={{margin: '15px 0 0 15px'}}>Ok</Button>
+        <Button onClick={() => setShow(false)} style={{margin: '15px 0 0 15px'}}>Cancel</Button>
+        <Button onClick={() => setShow(false)} styleType="primary" style={{margin: '15px 0 0 15px'}}>Ok</Button>
       </ModalButtonContainer>
     </Modal.Footer>
   </Modal>

--- a/packages/es-components/src/components/containers/modal/ModalBody.js
+++ b/packages/es-components/src/components/containers/modal/ModalBody.js
@@ -3,7 +3,26 @@ import styled from 'styled-components';
 // Note: ModalBody relies on a parent (Modal) with ThemeProvider wrapping it
 const ModalBody = styled.div`
   color: ${props => props.theme.colors.gray9};
+  margin-top: ${props => props.theme.headerHeight}px;
   padding: 15px;
+
+  .small & {
+    @media (min-width: ${props => props.theme.screenSize.phone}) {
+      margin-top: unset;
+    }
+  }
+
+  .medium & {
+    @media (min-width: ${props => props.theme.screenSize.tablet}) {
+      margin-top: unset;
+    }
+  }
+
+  .large & {
+    @media (min-width: ${props => props.theme.screenSize.desktop}) {
+      margin-top: unset;
+    }
+  }
 `;
 
 export default ModalBody;

--- a/packages/es-components/src/components/containers/modal/__snapshots__/Modal.specs.js.snap
+++ b/packages/es-components/src/components/containers/modal/__snapshots__/Modal.specs.js.snap
@@ -11,7 +11,7 @@ exports[`renders different modal sections 1`] = `
 
 exports[`renders different modal sections 2`] = `
 <div
-  class="sc-Axmtr hLfbbQ"
+  class="sc-Axmtr lgUceX"
 >
   Body
 </div>

--- a/packages/es-components/src/components/controls/textbox/TextAddons.js
+++ b/packages/es-components/src/components/controls/textbox/TextAddons.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 const defaultBorderRadius = '2px';
 
-const AddOn = styled.button`
+const AddOn = styled.div`
   background-color: ${props => props.addOnBgColor};
   border: 1px solid
     ${props =>

--- a/packages/es-components/src/components/controls/textbox/Textbox.js
+++ b/packages/es-components/src/components/controls/textbox/Textbox.js
@@ -59,7 +59,6 @@ const Textbox = React.forwardRef(function Textbox(props, ref) {
           addOnBgColor={addOnBgColor}
           aria-hidden="true"
           onClick={focusInput}
-          type="button"
         >
           <Icon aria-hidden="true" name={prependIconName} size={18} />
         </Prepend>
@@ -78,7 +77,6 @@ const Textbox = React.forwardRef(function Textbox(props, ref) {
           addOnBgColor={addOnBgColor}
           aria-hidden="true"
           onClick={focusInput}
-          type="button"
         >
           <Icon aria-hidden="true" name={appendIconName} size={18} />
         </Append>

--- a/packages/es-components/styleguide.config.js
+++ b/packages/es-components/styleguide.config.js
@@ -84,6 +84,7 @@ module.exports = {
   context: {
     dateFormat: 'date-fns/format'
   },
+  require: [path.join(__dirname, 'config', 'styleguidist-page-scripts')],
   assetsDir: path.join(__dirname, 'docs'),
   webpackConfig: {
     optimization: {


### PR DESCRIPTION
This is a large rework of Modals that resolves #471.

Modals now:
* Scroll within themselves in full-width (mobile) view with a fixed header
* Position themselves with their center at about 1/3 down the page.
* Animate correctly
* Scroll within themselves when they are at 100% of the window height (without a fixed header when not in full-width view)