### PR TITLE
Breaking: making modals reliant on an internal ID

### DIFF
--- a/migrations/v21_to_v22.md
+++ b/migrations/v21_to_v22.md
@@ -1,0 +1,78 @@
+# Migration Guide: v21 to v22:
+
+## Component Changes
+
+Modals no longer have the static `.background-overlay` and `.modal-content`
+classes. If you were previously using those classes to style your modals, we
+recommend passing classes from your local implementation into the components you
+wish to style. You can also pass `className` or `backdropClassName`, which will
+get added to the modal itself.
+
+By default, the backdrop and modal content receive these classes:
+
+- Backdrop
+  - `ReactModal__Overlay`
+  - `ReactModal__Overlay--after-open`
+  - `ReactModal__Overlay--before-close`
+- Modal
+  - `ReactModal__Content`
+  - `ReactModal__Content--after-open`
+  - `ReactModal__Content--before-close`
+
+Here's an example of what all the styling might look like in practice, using
+`styled-components`.
+
+```jsx
+const MyModalStyles = createGlobalStyle`
+  .my-modal, .my-modal.ReactModal__Content {
+    // custom styles for modal content
+  }
+
+  .my-modal.ReactModal__Content--after-open {
+    // custom styles for opening transition of modal content
+  }
+
+  .my-modal.ReactModal__Content--before-close {
+    // custom styles for closing transition of modal content
+  }
+
+  .my-modal-backdrop, .my-modal.ReactModal__Overlay {
+    // custom styles for modal overlay
+  }
+
+  .my-modal-backdrop.ReactModal__Overlay--after-open {
+    // custom styles for opening transition of modal overlay
+  }
+
+  .my-modal-backdrop.ReactModal__Overlay--before-close {
+    // custom styles for closing transition of modal overlay
+  }
+
+  .my-modal-header {
+    // custom styles for modal header
+  }
+
+  .my-modal-body {
+    // custom styles for modal body
+  }
+
+  .my-modal-footer {
+    // custom styles for modal footer
+  }
+`;
+
+const MyModal = () => (
+  <>
+    <MyModalStyles />
+    <Modal className="my-modal" backdropClassName="my-modal-backdrop">
+      <Modal.Header className="my-modal-header">This is my modal!</Modal.Header>
+      <Modal.Body className="my-modal-body">
+        This is the modal body. It has some really great content!
+      </Modal.Body>
+      <Modal.Footer className="my-modal-footer">
+        This is my modal's footer.
+      </Modal.Footer>
+    </Modal>
+  </>
+);
+```

--- a/packages/es-components/src/components/containers/modal/Modal.js
+++ b/packages/es-components/src/components/containers/modal/Modal.js
@@ -269,8 +269,9 @@ function Modal({
       <ModalContext.Provider value={{ onHide, ariaId }}>
         <ReactModal
           portalClassName={portalClassName}
-          className={`${className} ${size} ${contentClassName}`}
-          overlayClassName={backdropClassName}
+          className={`${className || ''} ${size} ${contentClassName}`}
+          overlayClassName={`${other.backdropClassName ||
+            ''} ${backdropClassName}`}
           closeTimeoutMS={animation ? animationTimeMs : null}
           isOpen={show}
           aria={{
@@ -323,11 +324,16 @@ Modal.propTypes = {
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   /** Selects the parent */
   parentSelector: PropTypes.func,
+  /** Classes for the Modal content */
   className: PropTypes.string,
+  /** Classes for the Modal backdrop */
+  backdropClassName: PropTypes.string,
+  /** A ref to the overlay */
   overlayRef: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.any })
   ]),
+  /** A ref to the content */
   contentRef: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.any })
@@ -347,7 +353,8 @@ Modal.defaultProps = {
   parentSelector: null,
   className: null,
   overlayRef: null,
-  contentRef: null
+  contentRef: null,
+  backdropClassName: undefined
 };
 
 Modal.Header = Header;

--- a/packages/es-components/src/components/containers/modal/Modal.js
+++ b/packages/es-components/src/components/containers/modal/Modal.js
@@ -28,7 +28,7 @@ const getModalMargin = (windowHeight, modalHeight) => {
 
 const ModalStyles = createGlobalStyle`
   .${({ theme }) => theme.portalClassName} {
-    .background-overlay {
+    .${({ theme }) => theme.backdropClassName} {
       bottom: 0;
       background-color: ${props => {
         const color = tinycolor(props.theme.colors.gray9);
@@ -65,7 +65,7 @@ const ModalStyles = createGlobalStyle`
       }
     }
 
-    .modal-content {
+    .${({ theme }) => theme.contentClassName} {
       background-clip: padding-box;
       background-color: ${props => props.theme.colors.white};
       border-radius: 3px;
@@ -157,7 +157,7 @@ function Modal({
   ...other
 }) {
   const ariaId = useUniqueId(other.id);
-  const portalClassName = `ReactModalPortal-${useUniqueId()}`;
+  const modalId = useUniqueId();
   const [rootNode, RootNodeLocator] = useRootNodeLocator(document.body);
   const [modalHeight, setModalHeight] = useState(300);
   const [shouldShow, setShouldShow] = useState(show);
@@ -195,6 +195,10 @@ function Modal({
 
   const modalParentSelector =
     parentSelector || useCallback(() => rootNode, [rootNode]);
+
+  const portalClassName = `ReactModalPortal-${modalId}`;
+  const backdropClassName = `background-overlay-${modalId}`;
+  const contentClassName = `modal-content-${modalId}`;
 
   useEffect(() => {
     if (!animation || show) {
@@ -249,7 +253,15 @@ function Modal({
   const shouldCloseOnOverlayClick = backdrop !== 'static' && backdrop;
 
   return (
-    <ThemeProvider theme={{ modalHeight, windowHeight, portalClassName }}>
+    <ThemeProvider
+      theme={{
+        modalHeight,
+        windowHeight,
+        portalClassName,
+        backdropClassName,
+        contentClassName
+      }}
+    >
       <RootNodeLocator />
       {shouldShow ? (
         <ModalStyles showAnimation={animation} showBackdrop={backdrop} />
@@ -257,8 +269,8 @@ function Modal({
       <ModalContext.Provider value={{ onHide, ariaId }}>
         <ReactModal
           portalClassName={portalClassName}
-          className={`${className} ${size} modal-content`}
-          overlayClassName="background-overlay"
+          className={`${className} ${size} ${contentClassName}`}
+          overlayClassName={backdropClassName}
           closeTimeoutMS={animation ? animationTimeMs : null}
           isOpen={show}
           aria={{

--- a/packages/es-components/src/components/containers/modal/Modal.md
+++ b/packages/es-components/src/components/containers/modal/Modal.md
@@ -1,9 +1,85 @@
-Use the `closeButton` attribute on the Modal.Header to show or hide the "X" button.
+Use the `closeButton` attribute on the Modal.Header to show or hide the "X"
+button.
 
-For accessbility, make sure to include the attribute `aria-haspopup='dialog'` on whatever link you create to activate the modal. If you need
-an informational dialog that contains no focusable elements, use a popover or something else more appropriate. Additionally, you can supply
-a level prop to the `Modal.Header` to prevent skipping heading levels. The style of the `Modal.Header` will remain the same regardless of
-the level passed in.
+For accessbility, make sure to include the attribute `aria-haspopup='dialog'` on
+whatever link you create to activate the modal. If you need an informational
+dialog that contains no focusable elements, use a popover or something else more
+appropriate. Additionally, you can supply a level prop to the `Modal.Header` to
+prevent skipping heading levels. The style of the `Modal.Header` will remain the
+same regardless of the level passed in.
+
+If you need to custom style the Modal, we recommend passing classes from your
+local implementation into the components you wish to style. You can also pass
+`className` or `backdropClassName`, which will get added to the modal itself.
+
+By default, the backdrop and modal content receive these classes:
+
+- Backdrop
+  - `ReactModal__Overlay`
+  - `ReactModal__Overlay--after-open`
+  - `ReactModal__Overlay--before-close`
+- Modal
+  - `ReactModal__Content`
+  - `ReactModal__Content--after-open`
+  - `ReactModal__Content--before-close`
+
+Here's an example of what all the styling might look like in practice,
+using `styled-components`.
+
+```jsx static
+const MyModalStyles = createGlobalStyle`
+  .my-modal, .my-modal.ReactModal__Content {
+    // custom styles for modal content
+  }
+
+  .my-modal.ReactModal__Content--after-open {
+    // custom styles for opening transition of modal content
+  }
+
+  .my-modal.ReactModal__Content--before-close {
+    // custom styles for closing transition of modal content
+  }
+
+  .my-modal-backdrop, .my-modal.ReactModal__Overlay {
+    // custom styles for modal overlay
+  }
+
+  .my-modal-backdrop.ReactModal__Overlay--after-open {
+    // custom styles for opening transition of modal overlay
+  }
+
+  .my-modal-backdrop.ReactModal__Overlay--before-close {
+    // custom styles for closing transition of modal overlay
+  }
+
+  .my-modal-header {
+    // custom styles for modal header
+  }
+
+  .my-modal-body {
+    // custom styles for modal body
+  }
+
+  .my-modal-footer {
+    // custom styles for modal footer
+  }
+`;
+
+const MyModal = () => (
+  <>
+    <MyModalStyles />
+    <Modal className="my-modal" backdropClassName="my-modal-backdrop">
+      <Modal.Header className="my-modal-header">This is my modal!</Modal.Header>
+      <Modal.Body className="my-modal-body">
+        This is the modal body. It has some really great content!
+      </Modal.Body>
+      <Modal.Footer className="my-modal-footer">
+        This is my modal's footer.
+      </Modal.Footer>
+    </Modal>
+  </>
+);
+```
 
 ```
 import Button from '../../controls/buttons/Button';
@@ -79,8 +155,9 @@ const [show, setShow] = React.useState(false);
     <Modal.Body>Body Content. Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch.This is the popover's content. Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid.</Modal.Body>
     <Modal.Footer>
       <ModalButtonContainer>
-        <Button onClick={() => setShow(false)} style={{marginTope: 15}}>Cancel</Button>
-        <Button onClick={() => setShow(false)} styleType="primary" style={{marginTop: 15}}>Ok</Button>
+        <Button onClick={() => setShow(false)}>Cancel</Button>
+        {'\u00A0'}
+        <Button onClick={() => setShow(false)} styleType="primary">Ok</Button>
       </ModalButtonContainer>
     </Modal.Footer>
   </Modal>

--- a/packages/es-components/src/components/containers/modal/Modal.md
+++ b/packages/es-components/src/components/containers/modal/Modal.md
@@ -18,11 +18,29 @@ const setInitialState = ({show: newShow, size: newSize, hideCloseButton: newHide
 }
 
 <div>
-  <Button aria-haspopup='dialog' onClick={() => setInitialState({show: true, size: 'small', hideCloseButton: true})} style={{marginRight:'15px'}}>Open Small Modal</Button>
+  <Button
+    aria-haspopup='dialog'
+    onClick={() => setInitialState({show: true, size: 'small', hideCloseButton: true})}
+    style={{margin: '0 15px 15px 0'}}
+  >
+    Open Small Modal
+  </Button>
 
-  <Button aria-haspopup='dialog' onClick={() => setInitialState({show: true, size: 'medium', hideCloseButton: false})} style={{marginRight:'15px'}}>Open Medium Modal</Button>
+  <Button
+    aria-haspopup='dialog'
+    onClick={() => setInitialState({show: true, size: 'medium', hideCloseButton: false})}
+    style={{margin: '0 15px 15px 0'}}
+  >
+    Open Medium Modal
+  </Button>
 
-  <Button aria-haspopup='dialog' onClick={() => setInitialState({show: true, size: 'large', hideCloseButton: false})}>Open Large Modal</Button>
+  <Button
+    aria-haspopup='dialog'
+    onClick={() => setInitialState({show: true, size: 'large', hideCloseButton: false})}
+    style={{margin: '0 15px 15px 0'}}
+  >
+    Open Large Modal
+  </Button>
 
   <Modal
     size={size}
@@ -61,8 +79,8 @@ const [show, setShow] = React.useState(false);
     <Modal.Body>Body Content. Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch.This is the popover's content. Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid.</Modal.Body>
     <Modal.Footer>
       <ModalButtonContainer>
-        <Button onClick={() => setShow(false)} style={{margin: '15px 0 0 15px'}}>Cancel</Button>
-        <Button onClick={() => setShow(false)} styleType="primary" style={{margin: '15px 0 0 15px'}}>Ok</Button>
+        <Button onClick={() => setShow(false)} style={{marginTope: 15}}>Cancel</Button>
+        <Button onClick={() => setShow(false)} styleType="primary" style={{marginTop: 15}}>Ok</Button>
       </ModalButtonContainer>
     </Modal.Footer>
   </Modal>


### PR DESCRIPTION
This will ensure that outside styles never affect modal styles by mistake.

⚠️ I marked this as a _**breaking**_ change because it removes static styles that used to be available ⚠️ 