### PR TITLE
New: add heading level to Drawer

### DIFF
--- a/packages/es-components/src/components/containers/drawer/Drawer.md
+++ b/packages/es-components/src/components/containers/drawer/Drawer.md
@@ -89,6 +89,7 @@ class DrawerExample extends React.Component {
 
 Use the `noPadding` property to remove default padding within a panel (useful for lists and tables).
 Use the `titleAside` property to display text or other content on the right side of the panel header.
+Use the `headingLevel` property to change default level of heading.
 You can customize the `key` property of each Panel; if not specified a default key value will be assigned matching the Panel's numeric position.
 
 ```
@@ -116,7 +117,7 @@ class DrawerExample extends React.Component {
             <li>Another Item</li>
           </ul>
         </Drawer.Panel>
-        <Drawer.Panel title="Panel Three" className="alt-color">
+        <Drawer.Panel title="Panel Three" className="alt-color" headingLevel={3}>
           <div>
             More content. Anim pariatur cliche reprehenderit, enim eiusmod
             high life accusamus terry richardson ad squid.

--- a/packages/es-components/src/components/containers/drawer/DrawerPanel.js
+++ b/packages/es-components/src/components/containers/drawer/DrawerPanel.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import AnimateHeight from 'react-animate-height';
 import { noop } from 'lodash';
 
+import Heading from '../heading/Heading';
 import { DrawerContext } from './DrawerContext';
 import Icon from '../../base/icons/Icon';
 import useUniqueId from '../../util/useUniqueId';
@@ -57,6 +58,7 @@ function DrawerPanel(props) {
     onItemClick,
     title,
     titleAside,
+    headingLevel,
     ...other
   } = props;
 
@@ -66,7 +68,7 @@ function DrawerPanel(props) {
 
   return (
     <PanelWrapper {...other}>
-      <div id={headingAriaId} role="heading">
+      <div id={headingAriaId} role="heading" aria-level={headingLevel}>
         <PanelButton
           aria-expanded={isOpen}
           aria-controls={regionAriaId}
@@ -107,6 +109,8 @@ DrawerPanel.propTypes = {
   isOpen: PropTypes.bool,
   /** Removes the default padding from the panel body */
   noPadding: PropTypes.bool,
+  /** Set desired aria-level for heading */
+  headingLevel: Heading.propTypes.level,
   /** @ignore */
   onItemClick: PropTypes.func
 };
@@ -115,6 +119,7 @@ DrawerPanel.defaultProps = {
   isOpen: false,
   noPadding: false,
   titleAside: undefined,
+  headingLevel: 2,
   onItemClick: noop
 };
 


### PR DESCRIPTION
from https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA12.html
> If there is more than one heading on the page and the heading hierarchy is defined through the visual presentation, the aria-level attribute should be used to indicate the hierarchical level of the heading.