### PR TITLE
Update: extract and reuse useDisableBodyScroll

### DIFF
--- a/packages/es-components/src/components/containers/modal/Modal.js
+++ b/packages/es-components/src/components/containers/modal/Modal.js
@@ -6,6 +6,7 @@ import ReactModal from 'react-modal';
 import tinycolor from 'tinycolor2';
 
 import useUniqueId from '../../util/useUniqueId';
+import { useDisableBodyScroll } from '../../util/useDisableBodyScroll';
 import { useRootNodeLocator } from '../../util/useRootNode';
 import { ModalContext } from './ModalContext';
 import Header from './ModalHeader';
@@ -226,25 +227,7 @@ function Modal({
     }
   }, [modalRef.current]);
 
-  useEffect(() => {
-    const newStyle = 'overflow: hidden;';
-    const getCurrentStyle = () => document.body.getAttribute('style') || '';
-    const disableScroll = () =>
-      document.body.setAttribute('style', `${getCurrentStyle()} ${newStyle}`);
-    const enableScroll = () =>
-      document.body.setAttribute(
-        'style',
-        getCurrentStyle().replace(newStyle, '')
-      );
-
-    if (show) {
-      disableScroll();
-    } else {
-      enableScroll();
-    }
-
-    return enableScroll;
-  }, [show]);
+  useDisableBodyScroll(show);
 
   const shouldCloseOnOverlayClick = backdrop !== 'static' && backdrop;
 

--- a/packages/es-components/src/components/containers/sliding-pane/SlidingPane.js
+++ b/packages/es-components/src/components/containers/sliding-pane/SlidingPane.js
@@ -7,6 +7,7 @@ import Heading from '../heading/Heading';
 import LinkButton from '../../controls/buttons/LinkButton';
 import screenReaderOnly from '../../patterns/screenReaderOnly/screenReaderOnly';
 import Icon from '../../base/icons/Icon';
+import { useDisableBodyScroll } from '../../util/useDisableBodyScroll';
 import { useRootNodeLocator } from '../../util/useRootNode';
 
 const PaneBase = styled(Modal)`
@@ -129,10 +130,6 @@ const defaultStyles = {
 };
 
 const GlobalPaneStyles = createGlobalStyle`
-  .ReactModal__Body--open {
-    overflow-y: hidden;
-  }
-
   .ReactModal__Overlay--after-open {
     background-color: rgba(0,0,0,0.5) !important;
   }
@@ -174,6 +171,7 @@ export default function SlidingPane({
   ...rest
 }) {
   const [rootNode, RootNodeLocator] = useRootNodeLocator(document.body);
+  useDisableBodyScroll(isOpen);
   const modalParentSelector =
     parentSelector || useCallback(() => rootNode, [rootNode]);
   const Pane = getPane(from);

--- a/packages/es-components/src/components/util/useDisableBodyScroll.js
+++ b/packages/es-components/src/components/util/useDisableBodyScroll.js
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+
+export const useDisableBodyScroll = shouldDisableScroll => {
+  useEffect(() => {
+    const newStyle = 'overflow: hidden;';
+    const getCurrentStyle = () => document.body.getAttribute('style') || '';
+    const disableScroll = () =>
+      document.body.setAttribute('style', `${getCurrentStyle()} ${newStyle}`);
+    const enableScroll = () =>
+      document.body.setAttribute(
+        'style',
+        getCurrentStyle().replace(newStyle, '')
+      );
+
+    if (shouldDisableScroll) {
+      disableScroll();
+    } else {
+      enableScroll();
+    }
+
+    return enableScroll;
+  }, [shouldDisableScroll]);
+};

--- a/packages/es-components/src/components/util/useDisableBodyScroll.js
+++ b/packages/es-components/src/components/util/useDisableBodyScroll.js
@@ -4,13 +4,20 @@ export const useDisableBodyScroll = shouldDisableScroll => {
   useEffect(() => {
     const newStyle = 'overflow: hidden;';
     const getCurrentStyle = () => document.body.getAttribute('style') || '';
-    const disableScroll = () =>
+    let scrollDisabled = false;
+    const disableScroll = () => {
+      scrollDisabled = true;
       document.body.setAttribute('style', `${getCurrentStyle()} ${newStyle}`);
-    const enableScroll = () =>
+    };
+    const enableScroll = () => {
+      if (!scrollDisabled) return;
+      scrollDisabled = false;
       document.body.setAttribute(
         'style',
+        // this will only replace one instance of newStyle, which is what we want.
         getCurrentStyle().replace(newStyle, '')
       );
+    };
 
     if (shouldDisableScroll) {
       disableScroll();


### PR DESCRIPTION
@stevematney I've noticed that this effect is running initially when `Modal`/`SlidingPane` is rendered with `isOpen`/`show` set to false. In that case it just tries to remove that style when it's not there anyway. Not a big problem on one hand but still it bugs me that it's doing what it really shouldn't do. Should I prevent such behavior?