### PR TITLE
Fix: setting default month on dateInput if none provided

### DIFF
--- a/packages/es-components/src/components/patterns/dateInput/DateInput.js
+++ b/packages/es-components/src/components/patterns/dateInput/DateInput.js
@@ -55,7 +55,7 @@ function DateInput({
 }) {
   const [state, dispatch] = useReducer(reducer, {
     day: defaultValue ? defaultValue.getDate() : defaultDay,
-    month: defaultValue ? defaultValue.getMonth() + 1 : '',
+    month: defaultValue ? defaultValue.getMonth() + 1 : 1,
     year: defaultValue ? defaultValue.getFullYear().toString() : ''
   });
 


### PR DESCRIPTION
@jerhemy - you set this to an empty string a while back, do you remember why this was done? This should default to 1 unless I'm missing a use case.

If the month is set to an empty string, it still displays the first month in the list but doesn't set the value. Say I wanted to enter a date in January: it's already displaying that month, so I enter day and year but it's invalid because January has not been set (unless I select another month and then select January again). 

Try the "Min and Max dates" demo to see what I mean.

If the value shouldn't be set to begin with the way to do that is to provide a `selectedOptionText` prop to the `Month` component. The component won't return a date until other fields are filled out, so defaulting to the first item in the list shouldn't cause an unwanted initial date that I'm aware of. 
