### PR TITLE
Update: (WE-11421) add border to button in focus

### DIFF
--- a/packages/es-components/src/components/controls/buttons/Button.js
+++ b/packages/es-components/src/components/controls/buttons/Button.js
@@ -59,6 +59,7 @@ const StyledButton = styled.button`
   &:focus {
     color: ${props => props.colors.hoverTextColor};
     background-color: ${props => props.colors.hoverBgColor};
+    border: 1px solid;
     border-color: ${props => props.colors.hoverBorderColor};
     box-shadow: 0 1px 1px rgba(0, 0, 0, 0.075),
       0 0 0 0.2rem ${props => props.colors.focusBoxShadowColor};


### PR DESCRIPTION
Taking out the role of the combobox ended up breaking it, so I'm going to leave the accessibility fixes for another PR.  This change just adds a border to buttons when they are in focus.