### PR TITLE
Fix: ensuring we don't spread over potentially undefined propTypes

### DIFF
--- a/packages/es-components/src/components/controls/buttons/Button.js
+++ b/packages/es-components/src/components/controls/buttons/Button.js
@@ -200,7 +200,7 @@ const Button = React.forwardRef(function Button(
 });
 
 Button.propTypes = {
-  ...ButtonBase.propTypes,
+  ...(ButtonBase.propTypes || {}),
   waiting: PropTypes.bool,
   children: PropTypes.node.isRequired,
   /** Select the color style of the button, types come from theme buttonStyles.button */
@@ -217,7 +217,7 @@ Button.propTypes = {
 };
 
 Button.defaultProps = {
-  ...ButtonBase.defaultProps,
+  ...(ButtonBase.defaultProps || {}),
   waiting: false,
   styleType: 'default',
   block: false,

--- a/packages/es-components/src/components/controls/buttons/ButtonBase.js
+++ b/packages/es-components/src/components/controls/buttons/ButtonBase.js
@@ -26,7 +26,7 @@ const ButtonBase = React.forwardRef(function ButtonBaseInner(
 });
 
 ButtonBase.propTypes = {
-  ...styled.button.propTypes,
+  ...(styled.button.propTypes || {}),
   /** Styles the Button with the "disabled" state and prevents click action */
   waiting: PropTypes.bool
 };

--- a/packages/es-components/src/components/controls/buttons/features/withLoadingStateWhileRunning.js
+++ b/packages/es-components/src/components/controls/buttons/features/withLoadingStateWhileRunning.js
@@ -34,14 +34,14 @@ export const withLoadingStateWhileRunning = ButtonComponent => {
   );
 
   ButtonWithLoadingState.propTypes = {
-    ...ButtonComponent.propTypes,
+    ...(ButtonComponent.propTypes || {}),
     showWhileRunning: PropTypes.any,
     children: PropTypes.node.isRequired,
     onClick: PropTypes.func
   };
 
   ButtonWithLoadingState.defaultProps = {
-    ...ButtonComponent.defaultProps,
+    ...(ButtonComponent.defaultProps || {}),
     showWhileRunning: undefined,
     onClick: undefined
   };


### PR DESCRIPTION
We've started seeing an error pop up in the console:
```console
Cannot read property 'apply' of undefined
```

I think this should fix it, since @sviridovdy narrowed it down to #518, but it's difficult to test without being able to load the UMD module directly. I did pack this up in production mode and I tested it locally. However, the local instance uses the es6 module build and not the UMD build. Even so, I didn't see any errors.

I can at least say that this change does not break anything.