### PR TITLE
Fix: set Dropdown focus values if validation context not available

### DIFF
--- a/packages/es-components/src/components/controls/dropdown/Dropdown.js
+++ b/packages/es-components/src/components/controls/dropdown/Dropdown.js
@@ -16,8 +16,12 @@ const Dropdown = styled.select`
   transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
 
   &:focus {
-    border-color: ${props => props.focusBorderColor};
-    box-shadow: ${props => props.focusBoxShadow};
+    border-color: ${props =>
+      props.focusBorderColor ||
+      props.theme.validationInputColor.default.focusBorderColor};
+    box-shadow: ${props =>
+      props.focusBoxShadow ||
+      props.theme.validationInputColor.default.focusBoxShadow};
     outline: 0;
   }
 


### PR DESCRIPTION
Previously if a `Dropdown` wasn't wrapped in a `Control` it would not set the focus styles correctly. This applies the default focus styles from the theme if the values aren't supplied via other methods.