### PR TITLE
Allow popovers to have custom styling

### DIFF
--- a/packages/es-components/src/components/containers/popover/Popover.js
+++ b/packages/es-components/src/components/containers/popover/Popover.js
@@ -81,7 +81,8 @@ function Popover(props) {
     disableRootClose,
     disableFlipping,
     enableEvents,
-    strategy
+    strategy,
+    ...otherProps
   } = props;
 
   const hasTitle = title !== undefined;
@@ -187,6 +188,7 @@ function Popover(props) {
         }}
         enableEvents={enableEvents}
         strategy={strategy}
+        {...otherProps}
       >
         <RootCloseWrapper onRootClose={hidePopover} disabled={disableRootClose}>
           <div role="dialog" ref={contentRef}>

--- a/packages/es-components/src/components/containers/popover/Popover.md
+++ b/packages/es-components/src/components/containers/popover/Popover.md
@@ -231,3 +231,32 @@ const styles = {
     </div>
 </div>
 ```
+
+Extra props will be passed through to the popup container, allowing you to override default styling.
+
+```
+import Button from '../../controls/buttons/Button';
+import styled from 'styled-components';
+
+const StyledPopover = styled(Popover)`
+  min-width: 100px;
+  max-width: 200px;
+`;
+
+<StyledPopover
+  name="customStylingExample"
+  title="Custom Styling"
+  content="This is the popover's content. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch."
+  placement="bottom"
+  renderTrigger={({ ref, toggleShow, isOpen }) => (
+    <Button
+      onClick={toggleShow}
+      aria-expanded={isOpen}
+      ref={ref}
+      styleType="primary"
+    >
+      Popover with custom styling
+    </Button>
+  )}
+/>
+```

--- a/packages/es-components/src/components/containers/popover/Popup.js
+++ b/packages/es-components/src/components/containers/popover/Popup.js
@@ -155,7 +155,8 @@ function Popup(props) {
     disableFlipping,
     popperRef,
     enableEvents,
-    strategy
+    strategy,
+    ...otherProps
   } = props;
   const arrowValues = getArrowValues(arrowSize);
   const [rootNode, rootNodeRef] = useRootNode(document.body);
@@ -198,7 +199,12 @@ function Popup(props) {
               mountOnEnter
               unmountOnExit
             >
-              <PopperBox ref={ref} style={style} arrowSize={arrowValues}>
+              <PopperBox
+                ref={ref}
+                style={style}
+                arrowSize={arrowValues}
+                {...otherProps}
+              >
                 {children}
                 <Arrow
                   ref={arrowProps.ref}


### PR DESCRIPTION
This is a pretty simple update. We're just passing through extra props. The need for this stemmed from a problem I ran into where I needed to be able to lower the `min-width` of the popup container.