### PR TITLE
New: provide render function for popover content body

### DIFF
--- a/packages/es-components/src/components/containers/popover/Popover.js
+++ b/packages/es-components/src/components/containers/popover/Popover.js
@@ -73,6 +73,7 @@ function Popover(props) {
     name,
     title,
     content,
+    renderContent,
     placement,
     arrowSize,
     renderTrigger,
@@ -204,7 +205,7 @@ function Popover(props) {
 
             <PopoverBody hasAltCloseWithNoTitle={hasAltCloseWithNoTitle}>
               <PopoverContent showCloseButton={showCloseButton}>
-                {content}
+                {renderContent ? renderContent({ toggleShow }) : content}
               </PopoverContent>
               {showCloseButton && closeButton}
             </PopoverBody>
@@ -215,13 +216,26 @@ function Popover(props) {
   );
 }
 
+function contentRequired(expectedType) {
+  return (props, propName, componentName) => {
+    const isContentProvided = props.content || props.renderContent;
+    return isContentProvided
+      ? expectedType(props, propName, componentName)
+      : new Error('Neither content nor renderContent were provided to Popover');
+  };
+}
+
 Popover.propTypes = {
   /** The name of the popover. Used for differentiating popovers */
   name: PropTypes.string.isRequired,
   /** The text displayed in the popover title section */
   title: PropTypes.string,
-  /** The content displayed in the popover body */
-  content: PropTypes.node.isRequired,
+  /** The content displayed in the popover body. This is required if renderContent is not used */
+  // eslint-disable-next-line react/require-default-props
+  content: contentRequired(PropTypes.node),
+  /** Function returning the content to be displayed in the popover body. This is required if content is not used */
+  // eslint-disable-next-line react/require-default-props
+  renderContent: contentRequired(PropTypes.func),
   /** The placement of the popover in relation to the link */
   placement: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
   /** The size of the arrow on the popover box */

--- a/packages/es-components/src/components/containers/popover/Popover.md
+++ b/packages/es-components/src/components/containers/popover/Popover.md
@@ -260,3 +260,34 @@ const StyledPopover = styled(Popover)`
   )}
 />
 ```
+
+A render prop is also available for the content body in the form of `renderContent`. The render function provides access to the `toggleShow` function. This allows
+popover content to control the visibility, such as with a custom close button;
+
+```
+import Button from '../../controls/buttons/Button';
+
+<Popover
+  name="customStylingExample"
+  title="Custom Styling"
+  renderContent={({ toggleShow }) => {
+    return (
+      <>
+        <p>This is the popover's content. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch.</p>
+        <Button onClick={toggleShow}>Close</Button>
+      </>
+    )
+  }}
+  placement="bottom"
+  renderTrigger={({ ref, toggleShow, isOpen }) => (
+    <Button
+      onClick={toggleShow}
+      aria-expanded={isOpen}
+      ref={ref}
+      styleType="primary"
+    >
+      Popover with Closable Content
+    </Button>
+  )}
+/>
+```


### PR DESCRIPTION
* A custom proptype is used to ensure either `content` or `renderContent` is used