### PR TITLE
Fix: use correct date-fns isValid import

### DIFF
--- a/packages/es-components/src/components/util/isParseableDate.js
+++ b/packages/es-components/src/components/util/isParseableDate.js
@@ -1,5 +1,5 @@
 import parse from 'date-fns/parse';
-import isValid from 'date-fns/is_valid';
+import isValid from 'date-fns/isValid';
 
 export default function isParseableDate(date) {
   const parsedDate = parse(date);


### PR DESCRIPTION
The error stems from how require works. If a module is not found at the current directory it'll keep going up until it either finds one that matches or throws if we finally hit global and it does not exist. `date-fns/is_valid` does not exist in `date-fns@2.4.1` that is referenced in `es-components`, but the module does exist in `date-fns@1.30.1` that is used by out of our indirect dependencies in the project root.