### PR TITLE
Fix: suppress uncaught error if element is not loaded

### DIFF
--- a/packages/es-components/src/components/containers/horizontalScrollWrapper/HorizontalScrollWrapper.js
+++ b/packages/es-components/src/components/containers/horizontalScrollWrapper/HorizontalScrollWrapper.js
@@ -191,6 +191,8 @@ function HorizontalScrollWrapper({
     if (code !== 'tab') return;
 
     const element = document.activeElement.parentElement;
+    if (!element) return;
+
     const style = window.getComputedStyle
       ? getComputedStyle(element, null)
       : element.currentStyle;


### PR DESCRIPTION
Related bug: https://jira.extendhealth.com/browse/WE-14049