### PR TITLE
CPED-1875 Small Popver Addition

### DIFF
--- a/packages/es-components/src/components/containers/popover/Popover.js
+++ b/packages/es-components/src/components/containers/popover/Popover.js
@@ -15,8 +15,7 @@ const Container = styled.div`
 `;
 
 const PopoverHeader = styled.div`
-  background-color: ${props =>
-    props.hasTitle ? props.theme.colors.primary : props.theme.colors.white};
+  background-color: ${props => props.hasTitle ? props.theme.colors[props.styleType] : props.theme.colors.white};
   color: ${props => props.theme.colors.white};
   display: flex;
   justify-content: space-between;
@@ -87,6 +86,8 @@ function Popover(props) {
     enableEvents,
     keepTogether,
     strategy,
+    popoverWrapperClassName,
+    styleType,
     ...otherProps
   } = props;
 
@@ -198,18 +199,13 @@ function Popover(props) {
         keepTogether={keepTogether}
         {...otherProps}
       >
-        <RootCloseWrapper onRootClose={hidePopover} disabled={disableRootClose}>
+        <RootCloseWrapper onRootClose={hidePopover} disabled={disableRootClose} className={popoverWrapperClassName}>
           <div role="dialog" ref={contentRef}>
-            <PopoverHeader hasTitle={hasTitle}>
+            <PopoverHeader hasTitle={hasTitle} styleType={styleType}>
               {hasTitle && <TitleBar>{title}</TitleBar>}
               {hasAltCloseButton && altCloseButton}
-              <CloseHelpText
-                tabIndex={-1}
-                ref={escMsgRef}
-                aria-label="Press escape to close the Popover"
-              />
+              <CloseHelpText tabIndex={-1} ref={escMsgRef} aria-label="Press escape to close the Popover" />
             </PopoverHeader>
-
             <PopoverBody hasAltCloseWithNoTitle={hasAltCloseWithNoTitle}>
               <PopoverContent showCloseButton={showCloseButton}>
                 {renderContent ? renderContent({ toggleShow }) : content}
@@ -268,7 +264,11 @@ Popover.propTypes = {
   /** Sets the strategy for positioning the popover in Popper.js */
   strategy: PropTypes.oneOf(['absolute', 'fixed']),
   /** When using a React portal, such as sliding pane, this helps the arrow to stay aligned with the trigger */
-  keepTogether: PropTypes.bool
+  keepTogether: PropTypes.bool,
+  /** Pass a className to the wrapper of the popover content */
+  popoverWrapperClassName: PropTypes.string,
+  /** Specify the background color of the popover header (similar to Button style types) */
+  styleType: PropTypes.oneOf(['primary', 'info', 'success', 'warning', 'danger'])
 };
 
 Popover.defaultProps = {
@@ -281,7 +281,9 @@ Popover.defaultProps = {
   title: undefined,
   enableEvents: true,
   strategy: 'absolute',
-  keepTogether: true
+  keepTogether: true,
+  styleType: 'primary',
+  popoverWrapperClassName: 'popover--active'
 };
 
 export default Popover;

--- a/packages/es-components/src/components/containers/popover/Popover.md
+++ b/packages/es-components/src/components/containers/popover/Popover.md
@@ -261,6 +261,30 @@ const StyledPopover = styled(Popover)`
 />
 ```
 
+Alternatively, you can pass a styleType prop to the Popover just like you can with Button
+
+```
+import Button from '../../controls/buttons/Button';
+
+<Popover
+  name="styleTypeExample"
+  title="style typing"
+  styleType="primary" // match button style
+  content="This is the popover's content. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch."
+  placement="bottom"
+  renderTrigger={({ ref, toggleShow, isOpen }) => (
+    <Button
+      onClick={toggleShow}
+      aria-expanded={isOpen}
+      ref={ref}
+      styleType="primary"
+    >
+      Popover with custom styling
+    </Button>
+  )}
+/>
+```
+
 A render prop is also available for the content body in the form of `renderContent`. The render function provides access to the `toggleShow` function. This allows
 popover content to control the visibility, such as with a custom close button;
 
@@ -290,4 +314,30 @@ import Button from '../../controls/buttons/Button';
     </Button>
   )}
 />
+```
+If the popover elements ever need to be detected or queried as part of the DOM you can pass a popoverWrapperClassName to check for in your javascript
+
+```
+import Button from '../../controls/buttons/Button';
+
+<Popover
+  name="wrapperClassName"
+  popoverWrapperClassName="classForAncestorOfPopoverContentAndHeader"
+  title="Class One"
+  content="This is the popover's content. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch."
+  placement="bottom"
+  renderTrigger={({ ref, toggleShow, isOpen }) => (
+    <Button
+      onClick={toggleShow}
+      aria-expanded={isOpen}
+      ref={ref}
+      styleType="primary"
+    >
+      Pop Me
+    </Button>
+  )}
+/>
+
+// Get currently active (Popovers that have been inserted into the DOM via the render trigger) Popover nodes
+const popoverNodes = document.getElementsByClassName("classForAncestorOfPopoverContentAndHeader");
 ```


### PR DESCRIPTION
This PR adds two things:

1. A `styleType` prop to the Popover component so that it can easily match the `styleType` of its triggering Button
2. A `popoverWrapperClassName` prop to Popover so active popovers can be queried on the DOM

In hindsight, item 1 could have been easily solved downstream with styled components. I'm a bit new to the React component world and didn't realize that until I'd made these changes. Hopefully this still makes the Popover more convenient to work with.