### PR TITLE
Fix: removed overflow clip from global focus style

### DIFF
--- a/packages/es-components/src/components/util/StyleReset.js
+++ b/packages/es-components/src/components/util/StyleReset.js
@@ -20,7 +20,6 @@ const StyleReset = createGlobalStyle`
 
   *:focus, input:focus, select:focus, button:focus {
     outline: 3px solid #3dbbdb;
-    overflow: clip;
   }
 
   ul, ol {

--- a/packages/es-components/styleguide.config.js
+++ b/packages/es-components/styleguide.config.js
@@ -33,7 +33,6 @@ module.exports = {
 
         *:focus, input:focus, select:focus, button:focus {
           outline: 3px solid #3dbbdb;
-          overflow: clip;
         }
       </style>
       <link rel="preload" href="https://bdaim-webexcdn-p.azureedge.net/es-assets/icons.css" as="style">


### PR DESCRIPTION
The overflow style was causing some unintended side-effects in the Datepicker component. I'm not sure why it was part of it to begin with, and the rest of the components behave the same without it, so I'm just removing it.