### PR TITLE
Update(styling): WE-16644 consistent font for text inputs and areas & consistent spacing

### DIFF
--- a/packages/es-components-via-theme/index.js
+++ b/packages/es-components-via-theme/index.js
@@ -184,6 +184,9 @@ const theme = {
     boxShadowDark: boxShadowDark,
     inputFocus: inputFocus
   },
+  spacing: {
+    defaultMargin: '1.875rem'
+  },
   brandColors: {
     primary1: primary1,
     primary2: primary2,

--- a/packages/es-components-via-theme/index.js
+++ b/packages/es-components-via-theme/index.js
@@ -496,7 +496,7 @@ const theme = {
   font: {
     baseFontSize: '18px',
     baseLineHeight: 1.428,
-    baseFontFace: 'Source Sans Pro',
+    baseFontFace: '"Source Sans Pro", "Segoe UI", Segoe, Calibri, Tahoma, sans-serif',
     headingDesktop: {
       1: '44.78976px',
       2: '37.3248px',

--- a/packages/es-components-via-theme/index.js
+++ b/packages/es-components-via-theme/index.js
@@ -493,6 +493,7 @@ const theme = {
   font: {
     baseFontSize: '18px',
     baseLineHeight: 1.428,
+    baseFontFace: 'Source Sans Pro',
     headingDesktop: {
       1: '44.78976px',
       2: '37.3248px',

--- a/packages/es-components/src/components/controls/textbox/InputBase.js
+++ b/packages/es-components/src/components/controls/textbox/InputBase.js
@@ -7,6 +7,7 @@ export default styled.input`
   box-sizing: border-box;
   color: ${props => props.theme.colors.black};
   font-size: ${props => props.theme.font.baseFontSize};
+  font-face: ${props => props.theme.font.baseFontFace};
   font-weight: normal;
   height: 39px;
   line-height: ${props => props.theme.font.baseLineHeight};

--- a/packages/es-components/src/components/controls/textbox/Textarea.js
+++ b/packages/es-components/src/components/controls/textbox/Textarea.js
@@ -11,6 +11,7 @@ const TextareaBase = styled.textarea`
   box-sizing: border-box;
   color: ${props => props.theme.colors.black};
   font-size: ${props => props.theme.font.baseFontSize};
+  font-face: ${props => props.theme.font.baseFontFace};
   font-weight: normal;
   line-height: ${props => props.theme.font.baseLineHeight};
   min-width: 0;

--- a/packages/es-components/src/components/patterns/dateInput/__snapshots__/DateInput.specs.js.snap
+++ b/packages/es-components/src/components/patterns/dateInput/__snapshots__/DateInput.specs.js.snap
@@ -52,6 +52,7 @@ exports[`displays monthNames provided by the monthNames prop 1`] = `
   box-sizing: border-box;
   color: #000;
   font-size: 18px;
+  font-face: Source Sans Pro;
   font-weight: normal;
   height: 39px;
   line-height: 1.428;
@@ -290,6 +291,7 @@ exports[`hides the Day input when Day is excluded 1`] = `
   box-sizing: border-box;
   color: #000;
   font-size: 18px;
+  font-face: Source Sans Pro;
   font-weight: normal;
   height: 39px;
   line-height: 1.428;

--- a/packages/es-components/src/components/patterns/dateInput/__snapshots__/DateInput.specs.js.snap
+++ b/packages/es-components/src/components/patterns/dateInput/__snapshots__/DateInput.specs.js.snap
@@ -52,7 +52,7 @@ exports[`displays monthNames provided by the monthNames prop 1`] = `
   box-sizing: border-box;
   color: #000;
   font-size: 18px;
-  font-face: Source Sans Pro;
+  font-face: "Source Sans Pro","Segoe UI",Segoe,Calibri,Tahoma,sans-serif;
   font-weight: normal;
   height: 39px;
   line-height: 1.428;
@@ -291,7 +291,7 @@ exports[`hides the Day input when Day is excluded 1`] = `
   box-sizing: border-box;
   color: #000;
   font-size: 18px;
-  font-face: Source Sans Pro;
+  font-face: "Source Sans Pro","Segoe UI",Segoe,Calibri,Tahoma,sans-serif;
   font-weight: normal;
   height: 39px;
   line-height: 1.428;


### PR DESCRIPTION
- [X] Consistent text input & text area font face

- [x] Add a standard sized spacing key/value to via-theme to be used to space elements apart