### PR TITLE
Fix popover

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "lint-staged": {
     "packages/es-components/src/**/*.js": [
       "prettier --single-quote --write",
-      "cd packages/es-components && npx eslint --fix"
+      "eslint --fix --config packages/es-components/.eslintrc.js"
     ]
   },
   "devDependencies": {

--- a/packages/es-components-wtw-theme/package-lock.json
+++ b/packages/es-components-wtw-theme/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "es-components-wtw-theme",
-      "version": "21.6.83-pre-prod.0",
+      "version": "21.7.0-pre-prod.0",
       "license": "MIT"
     }
   }

--- a/packages/es-components/.eslintrc.js
+++ b/packages/es-components/.eslintrc.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const plugins = ['import', '@babel'];
 const exts = [
   'eslint:recommended',
@@ -14,7 +15,10 @@ module.exports = {
       jsx: true,
       destructuring: true,
       experimentalObjectRestSpread: true,
-      ecmaVersion: 'latest'
+      ecmaVersion: 'latest',
+    },
+    babelOptions: {
+    configFile: path.join(__dirname, 'babel.config.js')
     }
   },
   rules: {

--- a/packages/es-components/package-lock.json
+++ b/packages/es-components/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "es-components",
-      "version": "21.7.0-pre-prod.0",
+      "version": "21.7.0-pre-prod.1",
       "license": "MIT",
       "dependencies": {
         "@babel/helpers": "^7.13.16",

--- a/packages/es-components/package-lock.json
+++ b/packages/es-components/package-lock.json
@@ -57,6 +57,7 @@
         "bl": "^1.2.3",
         "braces": "^3.0.2",
         "concurrently": "^6.0.2",
+        "cross-env": "^7.0.3",
         "cypress": "^9.6.0",
         "es-components-via-theme": "file:../es-components-via-theme",
         "eslint": "^8.23.0",
@@ -7668,6 +7669,24 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -29792,6 +29811,15 @@
       "resolved": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz",
       "integrity": "sha512-PFZEGbDUeoNbL2GHIEpJRQGheXReDody/9axKTxhXtQqIL443wnNigtVZO9iuCIMPApKZRv7k2xr8euXHqNxQQ==",
       "dev": true
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -9,7 +9,7 @@
   "main": "cjs/index.js",
   "sideEffects": false,
   "scripts": {
-    "build": "MAIN_BUILD=\"$( (git merge-base --is-ancestor HEAD origin/main && echo 'true') || echo 'false' )\" npm run rollup",
+    "build": "cross-env MAIN_BUILD=\"$( (git merge-base --is-ancestor HEAD origin/main && echo 'true') || echo 'false' )\" npm run rollup",
     "lint": "eslint src",
     "mkdocsdir": "node -e \"let mdkirp = require('mkdirp'); let path = require('path'); mdkirp(path.join(__dirname, 'docs'));\" && touch docs/temp ",
     "prepublishOnly": "npm run build",
@@ -73,6 +73,7 @@
     "bl": "^1.2.3",
     "braces": "^3.0.2",
     "concurrently": "^6.0.2",
+    "cross-env": "^7.0.3",
     "cypress": "^9.6.0",
     "es-components-via-theme": "file:../es-components-via-theme",
     "eslint": "^8.23.0",

--- a/packages/es-components/src/components/containers/popover/Popover.js
+++ b/packages/es-components/src/components/containers/popover/Popover.js
@@ -8,15 +8,15 @@ import Button from '../../controls/buttons/Button';
 import Popup from './Popup';
 import RootCloseWrapper from '../../util/RootCloseWrapper';
 
-const reactVersionString = React.version.match(/\d+/)?.[0] || '0';
-const REACT_MAJOR_VERSION = parseInt(reactVersionString, 10);
-
 const Container = styled.div`
   display: inline-block;
 `;
 
 const PopoverHeader = styled.div`
-  background-color: ${props => props.hasTitle ? props.theme.colors[props.styleType] : props.theme.colors.white};
+  background-color: ${props =>
+    props.hasTitle
+      ? props.theme.colors[props.styleType]
+      : props.theme.colors.white};
   color: ${props => props.theme.colors.white};
   display: flex;
   justify-content: space-between;
@@ -109,9 +109,7 @@ function Popover(props) {
 
   function toggleShow(event) {
     event.preventDefault();
-    if (REACT_MAJOR_VERSION <= 16) {
-      event.stopPropagation();
-    }
+    event.stopPropagation();
     setIsOpen(!isOpen);
   }
 
@@ -205,12 +203,20 @@ function Popover(props) {
         keepTogether={keepTogether}
         {...otherProps}
       >
-        <RootCloseWrapper onRootClose={hidePopover} disabled={disableRootClose} className={popoverWrapperClassName}>
+        <RootCloseWrapper
+          onRootClose={hidePopover}
+          disabled={disableRootClose}
+          className={popoverWrapperClassName}
+        >
           <div role="dialog" ref={contentRef}>
             <PopoverHeader hasTitle={hasTitle} styleType={styleType}>
               {hasTitle && <TitleBar>{title}</TitleBar>}
               {hasAltCloseButton && altCloseButton}
-              <CloseHelpText tabIndex={-1} ref={escMsgRef} aria-label="Press escape to close the Popover" />
+              <CloseHelpText
+                tabIndex={-1}
+                ref={escMsgRef}
+                aria-label="Press escape to close the Popover"
+              />
             </PopoverHeader>
             <PopoverBody hasAltCloseWithNoTitle={hasAltCloseWithNoTitle}>
               <PopoverContent showCloseButton={showCloseButton}>
@@ -276,7 +282,13 @@ Popover.propTypes = {
   /** Pass a className to the wrapper of the popover content */
   popoverWrapperClassName: PropTypes.string,
   /** Specify the background color of the popover header (similar to Button style types) */
-  styleType: PropTypes.oneOf(['primary', 'info', 'success', 'warning', 'danger'])
+  styleType: PropTypes.oneOf([
+    'primary',
+    'info',
+    'success',
+    'warning',
+    'danger'
+  ])
 };
 
 Popover.defaultProps = {


### PR DESCRIPTION
a. Remove conditional based on react version that determines whether e.stopPropagation is called in toggleShow of popover.
b. add cross-env for build command so we can run prepublishOnly on Windows.
c. Update precommit hook so we can make a commit on Windows.