### PR TITLE
WE-18942 Bumped z-index in order to fix an overlap bug

### DIFF
--- a/packages/es-components/src/components/containers/menu/MenuPanel.js
+++ b/packages/es-components/src/components/containers/menu/MenuPanel.js
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import DismissButton from '../../controls/DismissButton';
 import { InlineContext } from './InlineContext';
+import useTopZIndex from '../../../hooks/useTopZIndex';
 
 const StyledPanel = styled.div`
   background-color: ${props => props.theme.colors.gray2};
   display: ${props => (props.isOpen ? 'block' : 'none')};
   position: absolute;
-  z-index: 999;
+  z-index: ${({ topIndex }) => topIndex};
 `;
 
 const StyledDismissButton = styled(DismissButton)`
@@ -35,6 +36,7 @@ const StyledChildrenContainer = styled.div`
 
 function MenuPanel(props) {
   const { children, headerContent, isOpen, onClose, ...other } = props;
+  const getTopIndex = useTopZIndex();
 
   useEffect(() => {
     if (!isOpen) {
@@ -58,7 +60,7 @@ function MenuPanel(props) {
   const inline = useContext(InlineContext);
 
   return (
-    <StyledPanel isOpen={isOpen} {...other}>
+    <StyledPanel isOpen={isOpen} topIndex={getTopIndex()} {...other}>
       <Header hasHeaderContent={hasHeaderContent}>
         {hasHeaderContent && <span>{headerContent}</span>}
         <StyledDismissButton onClick={onClose} />

--- a/packages/es-components/src/components/containers/modal/Modal.js
+++ b/packages/es-components/src/components/containers/modal/Modal.js
@@ -13,6 +13,7 @@ import { ModalContext } from './ModalContext';
 import Header from './ModalHeader';
 import Body from './ModalBody';
 import Footer from './ModalFooter';
+import useTopZIndex from '../../../hooks/useTopZIndex';
 
 const modalSize = {
   small: '300px',
@@ -45,7 +46,7 @@ const ModalStyles = createGlobalStyle`
       right: 0;
       top: 0;
       transition: background-color ${() => animationTimeMs / 2}ms linear;
-      z-index: 1030;
+      z-index: ${({ topIndex }) => topIndex};
       -webkit-overflow-scrolling: touch;
 
       &.ReactModal__Overlay--after-open {
@@ -166,6 +167,7 @@ function Modal({
   const [windowHeight, setWindowHeight] = useState(window.innerHeight);
   const modalRef = useRef(null);
   const innerContentRef = useRef(null);
+  const getTopIndex = useTopZIndex();
 
   const setContentRef = useCallback(
     contentElement => {
@@ -234,8 +236,14 @@ function Modal({
     <ThemeProvider theme={{ modalHeight, windowHeight, portalClassName }}>
       <RootNodeLocator />
       {shouldShow ? (
-        <ModalStyles showAnimation={animation} showBackdrop={backdrop} />
-      ) : null}
+        <ModalStyles
+          showAnimation={animation}
+          showBackdrop={backdrop}
+          topIndex={getTopIndex()}
+        />
+      ) : (
+        <></>
+      )}
       <ModalContext.Provider value={{ onHide, ariaId }}>
         <ReactModal
           portalClassName={portalClassName}

--- a/packages/es-components/src/components/containers/popover/Popup.js
+++ b/packages/es-components/src/components/containers/popover/Popup.js
@@ -6,6 +6,7 @@ import { Manager, Reference, Popper } from 'react-popper';
 
 import Fade from '../../util/Fade';
 import useRootNode from '../../util/useRootNode';
+import useTopZIndex from '../../../hooks/useTopZIndex';
 
 const PopperBox = styled.div`
   border: 1px solid rgba(0, 0, 0, 0.3);
@@ -15,7 +16,7 @@ const PopperBox = styled.div`
   min-width: 270px;
   position: absolute;
   text-align: center;
-  z-index: 99999;
+  z-index: ${({ topIndex }) => topIndex};
 `;
 
 const Arrow = styled.div`
@@ -160,6 +161,7 @@ export default function Popup(props) {
   } = props;
   const arrowValues = getArrowValues(arrowSize);
   const [rootNode, rootNodeRef] = useRootNode(document.body);
+  const getTopIndex = useTopZIndex();
 
   return (
     <Manager>
@@ -218,6 +220,7 @@ export default function Popup(props) {
                 ref={ref}
                 style={style}
                 arrowSize={arrowValues}
+                topIndex={getTopIndex()}
                 {...otherProps}
               >
                 {children}

--- a/packages/es-components/src/components/containers/tooltip/Tooltip.js
+++ b/packages/es-components/src/components/containers/tooltip/Tooltip.js
@@ -9,10 +9,11 @@ import PopoverLink from '../../controls/buttons/PopoverLink';
 import screenReaderOnly from '../../patterns/screenReaderOnly/screenReaderOnly';
 import useUniqueId from '../../util/useUniqueId';
 import useRootNode from '../../util/useRootNode';
+import useTopZIndex from '../../../hooks/useTopZIndex';
 
 const TooltipBase = styled.div`
   position: absolute;
-  z-index: 999;
+  z-index: ${({ topIndex }) => topIndex};
 `;
 
 const TooltipInner = styled.div`
@@ -95,6 +96,7 @@ function Tooltip(props) {
   let TooltipArrow;
   const tooltipId = name ? `es-tooltip__${name}` : undefined;
   const [rootNode, rootNodeRef] = useRootNode(document.body);
+  const getTopIndex = useTopZIndex();
 
   switch (position) {
     case 'right':
@@ -173,6 +175,7 @@ function Tooltip(props) {
                 id={tooltipId}
                 style={style}
                 aria-live="polite"
+                topIndex={getTopIndex()}
                 {...other}
               >
                 <TooltipArrow ref={arrowProps.ref} style={arrowProps.style} />

--- a/packages/es-components/src/components/controls/buttons/DropdownButton.js
+++ b/packages/es-components/src/components/controls/buttons/DropdownButton.js
@@ -7,6 +7,7 @@ import Button from './Button';
 import LinkButton from './LinkButton';
 import useUniqueId from '../../util/useUniqueId';
 import RootCloseWrapper from '../../util/RootCloseWrapper';
+import useTopZIndex from '../../../hooks/useTopZIndex';
 
 const SplitButton = styled(Button)`
   ${props =>
@@ -47,7 +48,7 @@ const ButtonPanel = styled.div`
   display: ${props => (props.isOpen ? 'block' : 'none')};
   margin-top: 3px;
   position: relative;
-  z-index: 1000;
+  z-index: ${({ topIndex }) => topIndex};
 
   @media (min-width: ${props => props.theme.screenSize.tablet}) {
     position: absolute;
@@ -120,9 +121,8 @@ function focusTrap(node) {
 }
 
 function arrowMovement(node) {
-  const { focusableElements, firstFocusable, lastFocusable } = getFocusables(
-    node
-  );
+  const { focusableElements, firstFocusable, lastFocusable } =
+    getFocusables(node);
   const focusables = [...focusableElements];
   const rootNode = node.getRootNode();
 
@@ -179,6 +179,7 @@ function DropdownButton({
   const buttonDropdown = useRef();
   const triggerButton = useRef();
   const panelId = useUniqueId(id);
+  const getTopIndex = useTopZIndex();
 
   useEffect(() => {
     const removeFocusTrapListener = focusTrap(buttonDropdown.current);
@@ -254,7 +255,11 @@ function DropdownButton({
           <Caret />
         </ActivationButton>
         <div css="position: relative;">
-          <ButtonPanel isOpen={isOpen} id={panelId}>
+          <ButtonPanel
+            isOpen={isOpen}
+            id={panelId}
+            topIndex={isOpen ? getTopIndex() : -1}
+          >
             <ButtonPanelChildrenContainer>
               {Children.map(children, child => {
                 const onClickHandler = handleDropdownItemClick(child.props);

--- a/packages/es-components/src/components/controls/buttons/DropdownButton.js
+++ b/packages/es-components/src/components/controls/buttons/DropdownButton.js
@@ -47,7 +47,7 @@ const ButtonPanel = styled.div`
   display: ${props => (props.isOpen ? 'block' : 'none')};
   margin-top: 3px;
   position: relative;
-  z-index: 999;
+  z-index: 1000;
 
   @media (min-width: ${props => props.theme.screenSize.tablet}) {
     position: absolute;

--- a/packages/es-components/src/components/patterns/datepicker/DatePicker.js
+++ b/packages/es-components/src/components/patterns/datepicker/DatePicker.js
@@ -13,6 +13,7 @@ import { DatepickerStyles } from './datePickerStyles';
 import ReactDatePickerPropTypes from './ReactDatePickerPropTypes';
 
 import { calendarArrowStyles } from './datepickerAssets';
+import useTopZIndex from '../../../hooks/useTopZIndex';
 
 const STRING_FORMAT = 'yyyy-MM-dd';
 
@@ -64,6 +65,7 @@ const DateTextbox = React.forwardRef(function DateTextbox(props, ref) {
       inputRef.current.focus();
     }
   }));
+  const getTopIndex = useTopZIndex();
 
   /* eslint-disable react/forbid-foreign-prop-types */
   const datepickerProps = pick(props, Object.keys(ReactDatePickerPropTypes));
@@ -82,7 +84,7 @@ const DateTextbox = React.forwardRef(function DateTextbox(props, ref) {
 
   return (
     <>
-      <DatepickerStyles />
+      <DatepickerStyles topIndex={getTopIndex()} />
       {props.suppressDatepicker ? (
         textbox
       ) : (

--- a/packages/es-components/src/components/patterns/datepicker/datePickerStyles.js
+++ b/packages/es-components/src/components/patterns/datepicker/datePickerStyles.js
@@ -226,7 +226,7 @@ const timeStyles = css`
 
 const popperStyles = css`
   .react-datepicker-popper {
-    z-index: 1060;
+    z-index: ${({ topIndex }) => topIndex || 1060};
   }
 
   .react-datepicker-popper[data-placement^='bottom'] {

--- a/packages/es-components/src/hooks/useTopZIndex.js
+++ b/packages/es-components/src/hooks/useTopZIndex.js
@@ -1,0 +1,45 @@
+import { useCallback } from 'react';
+
+let topIndex = 0;
+let lastComputeTime = 0;
+
+function getCurrentTopIndex() {
+  const allDocumentElements = [...document.getElementsByTagName('*')];
+  let shadowElements = allDocumentElements.filter(el => el.shadowRoot);
+  let allElements = [...allDocumentElements];
+
+  while (shadowElements.length) {
+    const targetShadowEl = shadowElements.pop();
+    const newElements = [...targetShadowEl.shadowRoot.querySelectorAll('*')];
+    allElements = [...allElements, ...newElements];
+    shadowElements = [
+      ...shadowElements,
+      ...newElements.filter(el => el.shadowRoot)
+    ];
+  }
+
+  const allIndexes = allElements.map(
+    el => parseInt(window.getComputedStyle(el).zIndex, 10) || 0
+  );
+
+  const topIndex = allIndexes.reduce(
+    (topInd, ind) => (ind > topInd ? ind : topInd),
+    allIndexes[0]
+  );
+
+  return topIndex + 1;
+}
+
+export default function useTopZIndex() {
+  const getTopIndex = useCallback(() => {
+    // only compute at most every 1 second
+    if (new Date().getTime() - lastComputeTime < 1000) return topIndex;
+
+    const newIndex = getCurrentTopIndex();
+    lastComputeTime = new Date().getTime();
+    topIndex = newIndex;
+    return topIndex;
+  }, []);
+
+  return getTopIndex;
+}


### PR DESCRIPTION
[WE-18942](https://jira.extendhealth.com/browse/WE-18942) - Shopping - The dropdown in Plan Rec sits behind the Shopping Plan Compare Component.

On this bug, the household dropdown is displaying behind the Shopping Plan Compare web component. So, I adjusted the z-index a bit, in hopes to fix this issue.

Area's I've tested
- Toast notifications. I've tested toast notifications which appears that the z-index is set to 1001. 

![2023-05-15_14h32_37](https://github.com/WTW-IM/es-components/assets/47194690/244d4e6a-6d06-4139-89da-e39ba148ca8c)

- Via Benefits banner. I've tested Via Benefits banner which appears that the z-index is set to 1005. 

![2023-05-15_14h33_10](https://github.com/WTW-IM/es-components/assets/47194690/e89e4723-0e44-4d81-a58e-0f6b605f03dd)

- Shopping Plan Compare web component. I've tested the Shopping Plan Compare web component header which appears that the z-index is set to 999. 

![2023-05-15_14h31_35](https://github.com/WTW-IM/es-components/assets/47194690/08920dfd-d2a6-49d3-bc33-41290c8fe012)

I also tested other area's such as modals and sliding panes within plan recommendation. 
- Health Information sliding pane appears to have a z-index of 1100.

![2023-05-15_16h32_40](https://github.com/WTW-IM/es-components/assets/47194690/774a1584-7542-4e42-806b-3e4d278192e4)

- No Recommendation Available modal within the 'DropdownButton' component. Which has a z-index of 1030.

![2023-05-15_16h33_33](https://github.com/WTW-IM/es-components/assets/47194690/c53a8e7f-f6ba-437e-bd3d-d65b925ffd17)

Please review these and let me know if there's any other area's that I should test. @stevematney 