### PR TITLE
Update: focusing popover content when opened, rather than esc links

### DIFF
--- a/packages/es-components/src/components/containers/popover/Popover.js
+++ b/packages/es-components/src/components/containers/popover/Popover.js
@@ -1,7 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { noop } from 'lodash';
 
 import DismissButton from '../../controls/DismissButton';
 import Button from '../../controls/buttons/Button';
@@ -71,28 +70,26 @@ const CloseHelpText = styled.span`
   width: 1px;
 `;
 
-function Popover(props) {
-  const {
-    name,
-    title,
-    content,
-    renderContent,
-    placement,
-    arrowSize,
-    renderTrigger,
-    hasCloseButton,
-    hasAltCloseButton,
-    disableCloseOnScroll,
-    disableRootClose,
-    disableFlipping,
-    enableEvents,
-    keepTogether,
-    strategy,
-    popoverWrapperClassName,
-    styleType,
-    ...otherProps
-  } = props;
-
+function Popover({
+  name,
+  title,
+  content,
+  renderContent,
+  placement,
+  arrowSize,
+  renderTrigger,
+  hasCloseButton,
+  hasAltCloseButton,
+  disableCloseOnScroll,
+  disableRootClose,
+  disableFlipping,
+  enableEvents,
+  keepTogether,
+  strategy,
+  popoverWrapperClassName,
+  styleType,
+  ...otherProps
+}) {
   const hasTitle = title !== undefined;
   const hasAltCloseWithNoTitle = !hasTitle && hasAltCloseButton;
   const showCloseButton = hasCloseButton && !hasAltCloseButton;
@@ -101,9 +98,6 @@ function Popover(props) {
   const triggerBtnRef = useRef(null);
   const popperRef = useRef(null);
   const contentRef = useRef(null);
-  const escMsgRef = useRef(null);
-  const closeBtnRef = useRef(null);
-  const timeoutRef = useRef(null);
 
   const [isOpen, setIsOpen] = useState(false);
 
@@ -122,46 +116,44 @@ function Popover(props) {
     }
   }
 
-  function hidePopOnScroll() {
-    setInterval(() => {
-      if (popperRef.current) {
-        const bounds = popperRef.current.getBoundingClientRect();
-        const inViewport =
-          bounds.top >= 0 && bounds.bottom <= window.innerHeight;
-
-        if (!inViewport && isOpen) {
-          setIsOpen(false);
-        }
-      }
-    }, 100);
-  }
-
   useEffect(() => {
     if (isFirstRun.current) {
       isFirstRun.current = false;
       return;
     }
 
-    if (timeoutRef.current !== null) {
-      clearTimeout(timeoutRef.current);
-    }
+    let timeoutId;
 
     if (isOpen) {
-      timeoutRef.current = setTimeout(() => {
-        if (closeBtnRef.current) {
-          closeBtnRef.current.focus();
-        } else if (escMsgRef.current) {
-          escMsgRef.current.focus();
+      timeoutId = setTimeout(() => {
+        if (contentRef.current) {
+          contentRef.current.focus();
         }
       }, 100);
     } else {
       triggerBtnRef.current.focus();
     }
+
+    return () => clearTimeout(timeoutId);
   }, [isOpen]);
 
   useEffect(() => {
     if (disableCloseOnScroll) {
-      return noop;
+      return;
+    }
+
+    function hidePopOnScroll() {
+      setInterval(() => {
+        if (popperRef.current) {
+          const bounds = popperRef.current.getBoundingClientRect();
+          const inViewport =
+            bounds.top >= 0 && bounds.bottom <= window.innerHeight;
+
+          if (!inViewport && isOpen) {
+            setIsOpen(false);
+          }
+        }
+      }, 100);
     }
 
     if (isOpen) {
@@ -171,9 +163,7 @@ function Popover(props) {
   }, [isOpen, disableCloseOnScroll]);
 
   const closeButton = (
-    <PopoverCloseButton onClick={toggleShow} ref={closeBtnRef}>
-      Close
-    </PopoverCloseButton>
+    <PopoverCloseButton onClick={toggleShow}>Close</PopoverCloseButton>
   );
 
   const altCloseButton = (
@@ -181,7 +171,6 @@ function Popover(props) {
       aria-label="Close"
       hasTitle={hasTitle}
       onClick={toggleShow}
-      ref={closeBtnRef}
     />
   );
 
@@ -210,13 +199,12 @@ function Popover(props) {
           disabled={disableRootClose}
           className={popoverWrapperClassName}
         >
-          <div role="dialog" ref={contentRef}>
+          <div role="dialog" ref={contentRef} tabIndex={-1}>
             <PopoverHeader hasTitle={hasTitle} styleType={styleType}>
               {hasTitle && <TitleBar>{title}</TitleBar>}
               {hasAltCloseButton && altCloseButton}
               <CloseHelpText
                 tabIndex={-1}
-                ref={escMsgRef}
                 aria-label="Press escape to close the Popover"
               />
             </PopoverHeader>

--- a/packages/es-components/src/components/containers/popover/Popover.specs.js
+++ b/packages/es-components/src/components/containers/popover/Popover.specs.js
@@ -86,9 +86,7 @@ it('sets focus on a focusable element within the content', async () => {
   renderWithTheme(buildPopover({ content: popoverContent }));
   await user.click(screen.getByText('Popover Trigger Button'));
 
-  await waitFor(() =>
-    expect(
-      screen.getByLabelText('Press escape to close the Popover')
-    ).toHaveFocus()
+  await waitFor(async () =>
+    expect(await screen.findByRole('dialog')).toHaveFocus()
   );
 });


### PR DESCRIPTION
Previously, the focus would land on the closing instruction span and would look like this:
![MicrosoftTeams-image (21)](https://github.com/WTW-IM/es-components/assets/1235376/b269e9a5-9a9d-4f27-9144-f3bca9d7c8e9)

Now, focus will land on the Popover content and look like this
![Screenshot 2023-05-19 at 4 49 12 PM](https://github.com/WTW-IM/es-components/assets/1235376/41002ed5-fb95-43fc-b726-1df7adad1300)