### PR TITLE
New: using :focus-visible instead of :focus for global focus styles

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -22,16 +22,18 @@ jobs:
       - id: lint_results_msg
         name: Generate Lint Results Message
         if: always()
+        env:
+          COMMIT_RESPONSE: ${{ steps.commitlint.outputs.results }}
         run: |
           npm i commander
           npm i @actions/core
-          node ./workflow-helpers/generate-commitlint-response.js --results '${{ steps.commitlint.outputs.results }}'
+          node ./workflow-helpers/generate-commitlint-response.js --results "$COMMIT_RESPONSE"
       - name: Post comment
         if: ${{ always() }}
         uses: mshick/add-pr-comment@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          repo-token-user-login: "github-actions[bot]"
+          repo-token-user-login: 'github-actions[bot]'
           message: |
             ## Commitlint
 

--- a/packages/es-components/src/components/util/StyleReset.js
+++ b/packages/es-components/src/components/util/StyleReset.js
@@ -18,7 +18,7 @@ const StyleReset = createGlobalStyle`
     vertical-align: baseline;
   }
 
-  *:focus, input:focus, select:focus, button:focus {
+  *:focus-visible, input:focus-visible, select:focus-visible, button:focus-visible {
     outline: 3px solid #3dbbdb;
   }
 


### PR DESCRIPTION
`:focus-visible` matches the browser's logic around when a focus style should be shown instead of overriding that logic as regular `:focus` does.

See: [this article about the differences between :focus-visible and :focus](https://pawelgrzybek.com/the-difference-between-css-focus-and-focus-visible-pseudo-class/#:~:text=Adding%20the%20%3Afocus%20pseudo%2Dclass,research%20in%20one%20CSS%20property.)