### PR TITLE
Fix: marginally improve radio button when zooming

### DIFF
--- a/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
+++ b/packages/es-components/src/components/controls/radio-buttons/RadioButton.js
@@ -15,10 +15,7 @@ function radioFill(color) {
     content: '';
     display: block;
     height: 13px;
-    left: 3px;
-    position: relative;
     width: 13px;
-    top: 3px;
     transition: background 0.25s linear;
   `;
 }
@@ -57,10 +54,13 @@ const RadioInput = styled.input`
 `;
 
 const RadioDisplay = styled.span`
+  align-items: center;
   border: 3px solid ${props => props.borderColor};
   border-radius: 50%;
   box-sizing: border-box;
+  display: flex;
   height: 25px;
+  justify-content: center;
   margin-right: 8px;
   min-width: 25px;
 


### PR DESCRIPTION
Slightly improves the radio button "googly eye" effect at certain zoom levels. 

It's not perfect, so I've done some experimenting with SVG circles with some success. There are wrinkles to iron out with those, so this is a incremental improvement.