### PR TITLE
ENIFP-2072: removing warning message of popover in console

### DIFF
--- a/packages/es-components/src/components/containers/popover/Popover.md
+++ b/packages/es-components/src/components/containers/popover/Popover.md
@@ -2,6 +2,7 @@ Popover utilizes a [render prop](https://reactjs.org/docs/render-props.html) to 
 This function will require `ref`, `toggleShow`, and `isOpen` parameters to function properly.
 
 ```
+import React from 'react';
 import Button from '../../controls/buttons/Button';
 
 const styles = {
@@ -9,7 +10,7 @@ const styles = {
     margin: '10px'
 };
 
-<>
+<React.StrictMode>
     <div style={styles}>
     <Popover
       name="topEx"
@@ -85,7 +86,7 @@ const styles = {
       />
     </div>
 
-</>
+</React.StrictMode>
 ```
 
 ```

--- a/packages/es-components/src/components/util/Fade.tsx
+++ b/packages/es-components/src/components/util/Fade.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import Transition, {
   TransitionStatus,
@@ -50,6 +50,7 @@ const Fade: React.FC<FadeProps> = ({
   opacity,
   ...otherProps
 }) => {
+  const nodeRef = useRef(null);
   const transitionStyles = {
     transition: `opacity ${duration || 150}ms linear`,
     opacity
@@ -65,7 +66,7 @@ const Fade: React.FC<FadeProps> = ({
   return !hasValidChildren ? (
     <>{children}</>
   ) : (
-    <Transition {...transitionProps}>
+    <Transition nodeRef={nodeRef} {...transitionProps}>
       {transitionStatus => {
         try {
           return (


### PR DESCRIPTION
removing following warning error in console.
![image](https://github.com/WTW-IM/es-components/assets/104922269/77cc9618-0d70-434e-8cc8-cecde6223e58)

now the warning error didn't showup after click button:
![image](https://github.com/WTW-IM/es-components/assets/104922269/cb602178-93b0-41db-b3fa-ec70aae0361c)

searched a lot of answers,  finally following answers fix the problem. 
https://www.youtube.com/watch?v=ifuylPrUnFc
https://stackoverflow.com/questions/68693826/react-transition-group-finddomnode-is-deprecated-in-strictmode

