### PR TITLE
EM vs REM

### DIFF
--- a/packages/es-components/src/components/general-styling-guidelines/GeneralStylingGuidelines.md
+++ b/packages/es-components/src/components/general-styling-guidelines/GeneralStylingGuidelines.md
@@ -3,7 +3,7 @@
 A general rule of thumb for setting measurements is as follows:
 
 - If the measurement is focused on text or positioning within or around a
-  container (like padding and margin), use `em` so that if your container's
+  container (like padding and margin), use `rem` so that if your container's
   text size changes, your spacing stays proportional.
 - If the measurement is part of an overall layout, use `px`. Our layouts are
   largely based on pixel measurements. (In the `es-components-via-theme`, the


### PR DESCRIPTION
Should `rem` be the suggested usage instead of `em`?
https://blog.logrocket.com/using-em-vs-rem-css/

> rem is favored for its simplicity, consistency, and predictability