### PR TITLE
EN-26814 New: include new summarized star rating version and fix contrast accessibility issues

### DIFF
--- a/packages/es-components/src/components/containers/sliding-pane/SlidingPane.tsx
+++ b/packages/es-components/src/components/containers/sliding-pane/SlidingPane.tsx
@@ -119,7 +119,7 @@ const Header = styled.div`
 const CloseLink = styled(LinkButton)<CloseLinkProps>`
   padding: 16px;
   cursor: pointer;
-  opacity: 0.7;
+  opacity: 1;
 `;
 
 const TitleWrapper = styled.div`
@@ -176,14 +176,17 @@ const GlobalPaneStyles = createGlobalStyle`
   }
 `;
 
-function getPane(direction: string) {
+function PaneDirectional({
+  direction,
+  ...rest
+}: { direction: string } & PaneBaseProps & ReactModal.Props) {
   switch (direction) {
     case 'bottom':
-      return PaneBottom;
+      return <PaneBottom {...rest} />;
     case 'left':
-      return PaneLeft;
+      return <PaneLeft {...rest} />;
     default:
-      return PaneRight;
+      return <PaneRight {...rest} />;
   }
 }
 
@@ -216,7 +219,6 @@ export default function SlidingPane({
     [rootNode]
   );
   const modalParentSelector = parentSelector || handle;
-  const Pane = getPane(from);
   const styles = {
     overlay: { ...defaultStyles.overlay, ...overlayStyles },
     content: { ...defaultStyles.content, ...contentStyles }
@@ -234,7 +236,8 @@ export default function SlidingPane({
     <>
       <GlobalPaneStyles />
       <RootNodeLocator />
-      <Pane
+      <PaneDirectional
+        direction={from}
         style={styles}
         closeTimeoutMS={closeTimeout}
         isOpen={isOpen}
@@ -263,7 +266,7 @@ export default function SlidingPane({
           </Header>
         )}
         <Content>{children}</Content>
-      </Pane>
+      </PaneDirectional>
     </>
   );
 }

--- a/packages/es-components/src/components/patterns/progress-tracker/__snapshots__/ProgressTracker.specs.tsx.snap
+++ b/packages/es-components/src/components/patterns/progress-tracker/__snapshots__/ProgressTracker.specs.tsx.snap
@@ -9,7 +9,7 @@ exports[`ProgressTracker renders as expected 1`] = `
   justify-content: space-between;
   padding-left: 0;
   margin-left: 0;
-  background-image: linear-gradient(     to right,     #444 0%,     #444       0%,     #c5c5c5       0%,     #c5c5c5 100%   );
+  background-image: linear-gradient(     to right,     #444 0%,     #444       0%,     #919191       0%,     #919191 100%   );
   background-position: 0 21px;
   background-repeat: no-repeat;
   background-size: 100% 3px;
@@ -48,7 +48,7 @@ exports[`ProgressTracker renders as expected 1`] = `
   width: 20px;
   height: 20px;
   box-sizing: border-box;
-  border: 1px solid #c5c5c5;
+  border: 1px solid #919191;
   border-radius: 20px;
   margin-bottom: 5px;
   background-color: white;
@@ -228,7 +228,7 @@ exports[`ProgressTracker renders as expected 2`] = `
   justify-content: space-between;
   padding-left: 0;
   margin-left: 0;
-  background-image: linear-gradient(     to right,     #444 0%,     #444       50%,     #c5c5c5       50%,     #c5c5c5 100%   );
+  background-image: linear-gradient(     to right,     #444 0%,     #444       50%,     #919191       50%,     #919191 100%   );
   background-position: 0 21px;
   background-repeat: no-repeat;
   background-size: 100% 3px;
@@ -267,7 +267,7 @@ exports[`ProgressTracker renders as expected 2`] = `
   width: 20px;
   height: 20px;
   box-sizing: border-box;
-  border: 1px solid #c5c5c5;
+  border: 1px solid #919191;
   border-radius: 20px;
   margin-bottom: 5px;
   background-color: white;
@@ -486,7 +486,7 @@ exports[`ProgressTracker renders as expected 3`] = `
   justify-content: space-between;
   padding-left: 0;
   margin-left: 0;
-  background-image: linear-gradient(     to right,     #444 0%,     #444       100%,     #c5c5c5       100%,     #c5c5c5 100%   );
+  background-image: linear-gradient(     to right,     #444 0%,     #444       100%,     #919191       100%,     #919191 100%   );
   background-position: 0 21px;
   background-repeat: no-repeat;
   background-size: 100% 3px;
@@ -525,7 +525,7 @@ exports[`ProgressTracker renders as expected 3`] = `
   width: 20px;
   height: 20px;
   box-sizing: border-box;
-  border: 1px solid #c5c5c5;
+  border: 1px solid #919191;
   border-radius: 20px;
   margin-bottom: 5px;
   background-color: white;
@@ -743,7 +743,7 @@ exports[`ProgressTracker renders as expected 4`] = `
   justify-content: space-between;
   padding-left: 0;
   margin-left: 0;
-  background-image: linear-gradient(     to right,     #444 0%,     #444       100%,     #c5c5c5       100%,     #c5c5c5 100%   );
+  background-image: linear-gradient(     to right,     #444 0%,     #444       100%,     #919191       100%,     #919191 100%   );
   background-position: 0 21px;
   background-repeat: no-repeat;
   background-size: 100% 3px;
@@ -782,7 +782,7 @@ exports[`ProgressTracker renders as expected 4`] = `
   width: 20px;
   height: 20px;
   box-sizing: border-box;
-  border: 1px solid #c5c5c5;
+  border: 1px solid #919191;
   border-radius: 20px;
   margin-bottom: 5px;
   background-color: white;

--- a/packages/es-components/src/components/patterns/progress-tracker/__snapshots__/progress-tracker-subcomponents.specs.tsx.snap
+++ b/packages/es-components/src/components/patterns/progress-tracker/__snapshots__/progress-tracker-subcomponents.specs.tsx.snap
@@ -33,7 +33,7 @@ exports[`sets the appropriate styles for isPastStep 1`] = `
   width: 20px;
   height: 20px;
   box-sizing: border-box;
-  border: 1px solid #c5c5c5;
+  border: 1px solid #919191;
   border-radius: 20px;
   margin-bottom: 5px;
   background-color: white;

--- a/packages/es-components/src/components/patterns/progress-tracker/progress-tracker-subcomponents.tsx
+++ b/packages/es-components/src/components/patterns/progress-tracker/progress-tracker-subcomponents.tsx
@@ -47,13 +47,13 @@ export const ProgressContainer = styled.ol<ProgressContainerProps>`
           props.$activeStepIndex,
           props.$numberOfSteps
         )}%,
-    ${props => props.theme.colors.gray5}
+    ${props => props.theme.colors.gray6}
       ${props =>
         getProgressLineBreakPercentage(
           props.$activeStepIndex,
           props.$numberOfSteps
         )}%,
-    ${props => props.theme.colors.gray5} 100%
+    ${props => props.theme.colors.gray6} 100%
   );
   background-position: 0
     ${() => getCenterTopPosition(ACTIVE, TRACKING_LINE_HEIGHT)}px;
@@ -112,7 +112,7 @@ export const BasicProgressButton = styled.button`
     width: ${() => INACTIVE}px;
     height: ${() => INACTIVE}px;
     box-sizing: border-box;
-    border: ${props => `1px solid ${props.theme.colors.gray5}`};
+    border: ${props => `1px solid ${props.theme.colors.gray6}`};
     border-radius: ${() => INACTIVE}px;
     margin-bottom: 5px;
     background-color: white;
@@ -289,19 +289,31 @@ const ProgressLi = styled.li<ProgressLiProps>`
   }
 `;
 
-function getProgressItemType(
-  itemType: Maybe<StepState>,
-  showNav: Maybe<boolean>
-) {
+function ProgressItemRenderer({
+  itemType,
+  showNav,
+  ...rest
+}: {
+  itemType: Maybe<StepState>;
+  showNav: Maybe<boolean>;
+} & React.ComponentPropsWithoutRef<'button'>) {
   switch (itemType) {
     case stepStates.active:
-      return ActiveProgressButton;
+      return <ActiveProgressButton {...rest} />;
     case stepStates.pastStep:
-      return showNav ? PastProgressButton : NonNavigablePastProgressButton;
+      return showNav ? (
+        <PastProgressButton {...rest} />
+      ) : (
+        <NonNavigablePastProgressButton {...rest} />
+      );
     case stepStates.clickableFutureStep:
-      return showNav ? FutureProgressButton : BasicProgressButton;
+      return showNav ? (
+        <FutureProgressButton {...rest} />
+      ) : (
+        <BasicProgressButton {...rest} />
+      );
     default:
-      return BasicProgressButton;
+      return <BasicProgressButton {...rest} />;
   }
 }
 
@@ -350,11 +362,10 @@ export const ProgressItem = React.forwardRef<HTMLLIElement, ProgressItemProps>(
     },
     ref
   ) {
-    let itemType;
-    if (isPastStep || active || canClickFutureStep) {
-      itemType = getStepState(active, isPastStep, canClickFutureStep);
-    }
-    const ProgressItemType = getProgressItemType(itemType, showNav);
+    const itemType =
+      isPastStep || active || canClickFutureStep
+        ? getStepState(active, isPastStep, canClickFutureStep)
+        : undefined;
     const itemId = useUniqueId();
 
     const listItemProps = {
@@ -364,13 +375,15 @@ export const ProgressItem = React.forwardRef<HTMLLIElement, ProgressItemProps>(
 
     return (
       <ProgressLi $numberOfSteps={numberOfSteps} ref={ref}>
-        <ProgressItemType
+        <ProgressItemRenderer
+          itemType={itemType}
+          showNav={showNav}
           {...listItemProps}
           id={itemId}
           aria-labelledby={`${itemId}-span`}
         >
           <span id={`${itemId}-span`}>{label}</span>
-        </ProgressItemType>
+        </ProgressItemRenderer>
       </ProgressLi>
     );
   }

--- a/packages/es-components/src/components/patterns/starRating/StarRating.md
+++ b/packages/es-components/src/components/patterns/starRating/StarRating.md
@@ -1,4 +1,4 @@
-Simple star rating
+Simple star rating:
 
 ```
 <StarRating rating={3.5} />
@@ -12,6 +12,19 @@ Simple star rating
 ```
 <StarRating rating={5} />
 ```
+Poor performer:
 ```
 <StarRating rating={4} isPoorPerformer />
+```
+Summarized star rating:
+```
+<StarRating rating={4.5} isSummarized />
+```
+Overwriting summarized star rating with text:
+```
+<StarRating rating={4} isSummarized overwriteSummaryText='Plan Too New To Be Measured' />
+```
+No rating available:
+```
+<StarRating rating={null}/>
 ```

--- a/packages/es-components/src/components/patterns/starRating/StarRating.tsx
+++ b/packages/es-components/src/components/patterns/starRating/StarRating.tsx
@@ -19,8 +19,24 @@ export type StarRatingProps = Override<
     ratingExplanation?: string;
     onExplanationOpen?: () => void;
     noRatingText?: string;
+    isSummarized?: boolean;
+    overwriteSummaryText?: string;
   }
 >;
+
+const SummaryContainer = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 4px;
+
+  strong {
+    font-size: 1.1em;
+    margin-top: -1px;
+    text-align: left;
+    line-height: 1.2;
+  }
+`;
 
 const StarContainer = styled.div<{ isPoorPerformer?: boolean }>`
   display: flex;
@@ -36,8 +52,10 @@ const StarContainer = styled.div<{ isPoorPerformer?: boolean }>`
   }
 `;
 
-const StarRatingLink = styled(LinkButton)`
-  border-bottom: 1px dashed;
+const StarRatingLink = styled(LinkButton)<{
+  showBorder?: boolean;
+}>`
+  border-bottom: ${props => (props.showBorder ? '1px dashed' : 'none')};
   color: ${props => props.theme.colors.gray8};
   text-decoration: none;
 
@@ -67,6 +85,13 @@ const PoorPerformerOverlay = styled.div`
   margin-top: -5px;
   background-image: url(${ASSETS_PATH}images/poor-performer-mask.svg);
   background-size: 100% 100%;
+`;
+
+const SummarizedOverlay = styled.div`
+  height: 25px;
+  width: 25px;
+  margin-top: -23px;
+  background-image: url(${ASSETS_PATH}images/summarized-star-rating-mask.svg);
 `;
 
 function getStarRatingBackgroundWidth(rating: number) {
@@ -104,6 +129,8 @@ const StarRating = React.forwardRef<HTMLButtonElement, StarRatingProps>(
       noRatingText = NOT_AVAILABLE_MESSAGE,
       onClick: onClickProp,
       onExplanationOpen,
+      isSummarized = false,
+      overwriteSummaryText,
       ...props
     },
     ref
@@ -132,26 +159,42 @@ const StarRating = React.forwardRef<HTMLButtonElement, StarRatingProps>(
       <>
         <StarRatingLink
           ref={el => callRefs(el, rootNodeRef, ref)}
+          showBorder={!isSummarized}
           {...props}
           onClick={onClick}
         >
-          {rating === null && <span>{noRatingText}</span>}
-          {rating !== null && (
-            <StarContainer
-              aria-label={ariaText}
-              isPoorPerformer={isPoorPerformer}
-            >
-              {!isPoorPerformer ? (
-                <div>
-                  <StarFill fillWidth={getStarRatingBackgroundWidth(rating)} />
-                  <StarOverlay />
-                </div>
+          {rating === null ? (
+            <span>{noRatingText}</span>
+          ) : (
+            <>
+              {isSummarized ? (
+                <SummaryContainer aria-label={ariaText}>
+                  <div>
+                    <StarFill fillWidth={getStarRatingBackgroundWidth(1)} />
+                    <SummarizedOverlay />
+                  </div>
+                  <strong>{overwriteSummaryText || `${rating}/5`}</strong>
+                </SummaryContainer>
               ) : (
-                <div>
-                  <PoorPerformerOverlay />
-                </div>
+                <StarContainer
+                  aria-label={ariaText}
+                  isPoorPerformer={isPoorPerformer}
+                >
+                  {!isPoorPerformer ? (
+                    <div>
+                      <StarFill
+                        fillWidth={getStarRatingBackgroundWidth(rating)}
+                      />
+                      <StarOverlay />
+                    </div>
+                  ) : (
+                    <div>
+                      <PoorPerformerOverlay />
+                    </div>
+                  )}
+                </StarContainer>
               )}
-            </StarContainer>
+            </>
           )}
         </StarRatingLink>
         <StarRatingExplanation
@@ -165,10 +208,16 @@ const StarRating = React.forwardRef<HTMLButtonElement, StarRatingProps>(
 );
 
 StarRating.propTypes = {
+  /** The rating to show. */
   rating: PropTypes.number.isRequired,
+  /** Whether to show the poor performer version. It will hide its rating */
   isPoorPerformer: PropTypes.bool,
   onExplanationOpen: PropTypes.func,
-  noRatingText: PropTypes.string
+  noRatingText: PropTypes.string,
+  /** Whether to show the summarized version. */
+  isSummarized: PropTypes.bool,
+  /** Whether to overwrite the summary text. It will hide its rating. It only shows if `isSummarized` is true. */
+  overwriteSummaryText: PropTypes.string
 };
 
 export default StarRating;


### PR DESCRIPTION
### Jira ticket 

[EN-26814](https://im-jira.internal.towerswatson.com/browse/EN-26814)

### Notes

**Star Rating**
- Added two new props for StarRating, `isSummarized` and `overwriteSummaryText`.
- `isSummarized` is a boolean that indicates whether to summarize the star rating component and make it smaller with numeric values.
- `overwriteSummaryText` works in conjunction with `isSummarized` to show a text instead of the numeric rating.
- All previous functionality and styling have been maintained.
- Also added a couple of descriptions, metadata and examples into the component page. 

**Sliding Pane**
- Set the opacity of the close button to 1 to increase contrast and fix accessibility issues.
- Refactored pane direction handler to fix linter issues.

**Progress Tracker**
- Replaced gray5 references to gray6 to increase contrast between white background and lines.
- Refactored item type handler to fix linter issues.

### Screenshots

**Star Rating**
<img width="936" height="497" alt="image" src="https://github.com/user-attachments/assets/5e77d610-7e36-45d8-ab44-3dab35d43060" />

**Sliding Pane**
- Before:
<img width="128" height="139" alt="image" src="https://github.com/user-attachments/assets/b0ca4942-c224-4eb2-a949-58332b901a8c" />

- After:
<img width="119" height="114" alt="image" src="https://github.com/user-attachments/assets/a1967ad3-40f2-4c23-8c48-e388c12ae3b7" />

**Progress Tracker**
- Before:
<img width="1043" height="683" alt="image" src="https://github.com/user-attachments/assets/b75e5cf9-d182-4e6f-9e4e-e571e2376e98" />

-After:
<img width="996" height="649" alt="image" src="https://github.com/user-attachments/assets/7398aae9-fe57-4684-8a5d-9e90afc64245" />

