### PR TITLE
Lock the styled-components v6 version at 6.3.11 for compatibility issues

### DIFF
--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -38,7 +38,7 @@
   "peerDependencies": {
     "react": ">=17",
     "react-dom": ">=17",
-    "styled-components": "^5 || ^6.0.0 < 6.0.12"
+    "styled-components": "^5 || 6.0.0 < 6.0.12"
   },
   "devDependencies": {
     "@babel/cli": "^7.20.7",

--- a/packages/es-components/package.json
+++ b/packages/es-components/package.json
@@ -38,7 +38,7 @@
   "peerDependencies": {
     "react": ">=17",
     "react-dom": ">=17",
-    "styled-components": "^5 || ^6"
+    "styled-components": "^5 || 6.3.11"
   },
   "devDependencies": {
     "@babel/cli": "^7.20.7",


### PR DESCRIPTION
Fix: lock v6 at 6.3.11